### PR TITLE
coffee script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "devDependencies": {
     "mocha" : "0.x",
-    "should" : "*"
+    "should" : "*",
+	"coffee-script": "*"
   },
   "scripts": {
     "prepublish": "coffee -o lib/ src/"


### PR DESCRIPTION
Another little tweak. For some reason mocha wouldn't load my global coffee-script module. I thought it would make sense to add as one of the dev dependencies so that test will run out of the box
