### PR TITLE
Boolean attributes

### DIFF
--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -1,10 +1,25 @@
+booleanAttributes = 
+  checked  : true
+  selected : true
+  disabled : true
+  readonly : true
+  multiple : true
+  ismap    : true
+  defer    : true
+  declare  : true
+  noresize : true
+  nowrap   : true
+  noshade  : true
+  compact  : true
+
+
 formatAttributes = exports.formatAttributes = (attributes) ->
   if !attributes
     return ""
 
   output = []
   for key, value of attributes
-    if key is value
+    if key is value and (booleanAttributes[key] or key is '/') # TODO: '/' should not be an attribute, but the current implementation let's it slip in
       output.push key
     else
       output.push key + ' = "' + value + '"';

--- a/test/render.coffee
+++ b/test/render.coffee
@@ -40,10 +40,14 @@ describe 'render', ->
       str = "<br />"
       html(str).should.equal '<br />'
       done()
+  
+    it 'should shorten the \'checked\' attribute when it contains the value \'checked\'', (done) ->
+      str = '<input checked = "checked"/>'
+      html(str).should.equal '<input checked/>'
+      done()
       
-    it 'should display empty strings for undefined attribs', ->
-      # str = '<link rel="stylesheet" media = "" href="" />'
-      # html(str).should.equal str
-      # 
-      # done()
-      
+    it 'should not shorten the \'name\' attribute when it contains the value \'name\'', (done) ->
+      str = '<input name = "name"/>'
+      html(str).should.equal '<input name = "name"/>'
+      done()
+


### PR DESCRIPTION
Hi there,

I had an `input` with `name="name"` as an attribute. Cheerio was squashing this to just `name`. It should only do this with a set of Boolean attributes - I've put in a test for this and put in a whitelist of the attributes.

Thanks,
Jos
