### PR TITLE
$.html now takes a cheerio object in addtion to an element or array

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -40,7 +40,7 @@ var tagType = {
 
 var render = exports = module.exports = function(dom, output) {
   output = output || [];
-  dom = isArray(dom) ? dom : [dom];
+  dom = isArray(dom) || dom.cheerio ? dom : [dom];
   
   var len = dom.length,
       elem;

--- a/test/api.utils.js
+++ b/test/api.utils.js
@@ -10,7 +10,7 @@ describe('$', function() {
   
   describe('.html', function() {
     
-    it('(html) should return innerHTML of element', function() {
+    it('.html() should return innerHTML; $.html(obj) should return outerHTML', function() {
       var html = "<div><span>foo</span><span>bar</span></div>",
           $ = cheerio.load(html),
           span = $('div').children().get(1);
@@ -18,5 +18,15 @@ describe('$', function() {
       $(span).html().should.equal('bar');
       $.html(span).should.equal('<span>bar</span>')
     });
+
+    it('$.html(<obj>) should accept an object, an array, or a cheerio object', function() {
+      var $ = cheerio;
+      var span = $("<span>foo</span>");
+          
+      $.html(span.get(0)).should.equal('<span>foo</span>')
+      $.html(span.get()).should.equal('<span>foo</span>')
+      $.html(span).should.equal('<span>foo</span>')
+    });
+
   });
 });


### PR DESCRIPTION
`$.html($("<span>foo</span>"))` was not returning the expected `"<span>foo</span>"`.

I added a fix to parse.js, and updated the tests to check behavior for an object, an array, and a cheerio object.
