### PR TITLE
Fix spacing between attributes and their values

### DIFF
--- a/lib/api/render.js
+++ b/lib/api/render.js
@@ -40,7 +40,7 @@ var formatAttrs = function(attributes) {
     if (key === value && (booleanAttributes[key] || key === '/')) {
       output.push(key);
     } else {
-      output.push(key + ' = "' + value + '"');
+      output.push(key + '="' + value + '"');
     }
   }
   


### PR DESCRIPTION
Spacing looks weird ;) If this is the way you usually write HTML then ignore this (not trying to impose) but virtually every HTML doc ever omits these spaces.

Makes `.html()` output this

``` html
<img src="foo" alt="bar" />
```

instead of 

``` html
<img src = "foo" alt = "bar" />
```
