### PR TITLE
.removeClass() should remove all occurrences of class name

### DIFF
--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -70,46 +70,29 @@ var addClass = exports.addClass = function(value) {
 
 var removeClass = exports.removeClass = function(value) {
 
+  var split = function(className) {
+    return className.trim().split(/\s+/);
+  };
+
   // Handle if value is a function
   if (_.isFunction(value)) {
-    this.each(function(j) {
-      var $this = $(this),
-          className = $this.attr('class') || '';
-      $this.removeClass(value.call(this, j, className));
+    return this.each(function(idx) {
+      $this.removeClass(value.call(this, idx, $(this).attr('class') || ''));
     });
   }
 
-  // If value isnt undefined and also not a string
-  if(value !== undefined && !_.isString(value)) return this;
-
-  var classNames = (value || '').split(rspace),
-      numClasses = classNames.length,
-      className,
-      $elem,
-      ret;
-
-  for (var i = 0, iLen = this.length; i < iLen; i++) {
-    $elem = $(this[i]);
-    className = this[i].attribs['class'];
-
-    if(!$.isTag(this[i]) || !className) continue;
-    else if(!value) {
-      this[i].attribs['class'] = '';
-      continue;
+  return this.each(function() {
+    if ($.isTag(this)) {
+      // If `value` is "" or undefined, set the class attribute to "".
+      // Otherwise, split the class name into an array of class names,
+      // discard occurrences of `value`, and join the remaining class
+      // names to produce the updated attribute value.
+      this.attribs['class'] = !value ? '' : _.reject(
+        split(this.attribs['class']),
+        function(name) { return _.contains(split(value), name) }
+      ).join(' ');
     }
-
-    // Separate out the classes
-    ret = (' ' + className + ' ').replace(rclass, ' ');
-
-    for (var j = 0; j < numClasses; j++) {
-      className = classNames[j];
-      ret = ret.replace(' ' + className + ' ', ' ');
-    }
-
-    this[i].attribs['class'] = ret.trim();
-  }
-
-  return this;
+  });
 };
 
 module.exports = $.fn.extend(exports);

--- a/test/api.attributes.js
+++ b/test/api.attributes.js
@@ -166,6 +166,11 @@ describe('$(...)', function() {
       expect($('.fruit', $fruits).hasClass('fruit')).to.be.ok();
     });
 
+    it('(class) : should remove all occurrences of a class name', function() {
+      var $div = $('<div class="x x y x z"></div>');
+      expect($div.removeClass('x').hasClass('x')).to.be(false);
+    });
+
     it('(fn) : should remove classes returned from the function');
 
   });


### PR DESCRIPTION
We're currently in line with jQuery (as of 1.7.2, at least), but in my view this behaviour is erroneous:

```
> $('<b class="x x">').removeClass('x').hasClass('x')
true
```

`.removeClass()` should remove all occurrences of the class name. I'm happy to create a pull request if you agree.
