### PR TITLE
use a bound function rather than passing context to `_.filter`

### DIFF
--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -82,11 +82,11 @@ var map = exports.map = function(fn) {
   }, this);
 };
 
-var filter = exports.filter = function(match) {  
-  return this.make(_.filter(this, _.isString(match) ?
+var filter = exports.filter = function(match) {
+  var make = _.bind(this.make, this);
+  return make(_.filter(this, _.isString(match) ?
     function(el) { return select(match, el).length; }
-  : function(el, i) { return match.call(this.make(el), i, el); }
-  , this
+  : function(el, i) { return match.call(make(el), i, el); }
   ));
 };
 


### PR DESCRIPTION
This seems slightly clearer, and also appeases whichever linter I have hooked up to Vim.
