### PR TITLE
$.find should query descendants only

### DIFF
--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -90,7 +90,7 @@ var remove = exports.remove = function(selector) {
 
   // Filter if we have selector
   if (selector)
-    elems = elems.find(selector);
+    elems = elems.filter(selector);
 
   elems.each(function(i, el) {
     var siblings = el.parent.children,

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -6,7 +6,7 @@ var _ = require('underscore'),
 var find = exports.find = function(selector) {
   if (!selector) return this;
   try {
-    var elem = select(selector, [].slice.call(this));
+    var elem = select(selector, [].slice.call(this.children()));
     return this.make(elem);
   } catch(e) {
     return this.make([]);
@@ -66,7 +66,7 @@ var children = exports.children = function(selector) {
   if (selector === undefined) return this.make(children);
   else if (_.isNumber(selector)) return this.make(children[selector]);
 
-  return this.make(children).find(selector);
+  return this.make(children).filter(selector);
 };
 
 var each = exports.each = function(fn) {

--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -61,7 +61,7 @@ var Cheerio = module.exports = function(selector, context, root) {
   } else if(typeof context === 'string') {
     if(isHtml(context)) {
       // $('li', '<ul>...</ul>')
-      context = parse(context).children;
+      context = parse(context);
       context = this.make(context, this);
     } else {
       // $('li', 'ul')
@@ -74,7 +74,7 @@ var Cheerio = module.exports = function(selector, context, root) {
   if(!context) return this;
 
   // #id, .class, tag
-  return context.find(selector);
+  return context.parent().find(selector);
 };
 
 /**

--- a/test/api.traversing.js
+++ b/test/api.traversing.js
@@ -24,6 +24,10 @@ describe('$(...)', function() {
       expect($('ul', fruits).find('blah')).to.have.length(0);
     });
 
+    it('(invalid single) : should query descendants only', function() {
+      expect($('#fruits', fruits).find('ul')).to.have.length(0);
+    });
+
     it('should return empty if search already empty result', function() {
       expect($('#fruits').find('li')).to.have.length(0);
     });


### PR DESCRIPTION
From [the jQuery docs for `.find()`](http://api.jquery.com/find/):

> **Description**: Get the descendants of each element in the current set
> of matched elements, filtered by a selector, jQuery object, or element.

Given that description, the following behavior is incorrect:

``` javascript
// Should return 1, currently returns 2
$("<div><div></div></div>").find("div").length;
```
