### PR TITLE
Cancel iteration when iterator returns false

### DIFF
--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -70,9 +70,16 @@ var children = exports.children = function(selector) {
 };
 
 var each = exports.each = function(fn) {
-  _.each(this, function(el, i) {
-    fn.call(this.make(el), i, el);
-  }, this);
+  var length = this.length,
+      el, i;
+
+  for (i = 0; i < length; ++i) {
+    el = this[i];
+    if (fn.call(this.make(el), i, el) === false) {
+      break;
+    }
+  }
+
   return this;
 };
 

--- a/test/api.traversing.js
+++ b/test/api.traversing.js
@@ -101,6 +101,17 @@ describe('$(...)', function() {
       expect(items[2].attribs['class']).to.equal('pear');
     });
 
+    it('( (i, elem) -> ) : should break iteration when the iterator function returns false', function() {
+
+        var iterationCount = 0;
+        $('li', fruits).each(function(idx, elem) {
+          iterationCount++;
+          return idx < 1;
+        });
+
+        expect(iterationCount).to.equal(2);
+    });
+
   });
 
   describe('.map', function() {


### PR DESCRIPTION
As noted in the [jQuery API docs on
.each()](http://api.jquery.com/each/):

> We can stop the loop from within the callback function by returning
> `false`.

(As requested in issue #132.)
