### PR TITLE
Remove global `render`

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -64,7 +64,7 @@ var tagType = {
   template : 1
 };
 
-render = module.exports = function(dom, opts) {
+var render = module.exports = function(dom, opts) {
   dom = (isArray(dom) || dom.cheerio) ? dom : [dom];
   opts = opts || {};
 


### PR DESCRIPTION
Smallest change ever, but this was being flagged in our tests.
