### PR TITLE
Fix bug in `filter`

### DIFF
--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -91,7 +91,7 @@ var map = exports.map = function(fn) {
 var filter = exports.filter = function(match) {
   var make = _.bind(this.make, this);
   return make(_.filter(this, _.isString(match) ?
-    function(el) { return select(match, el).length; }
+    function(el) { return select(match, el)[0] === el; }
   : function(el, i) { return match.call(make(el), i, el); }
   ));
 };

--- a/test/api.traversing.js
+++ b/test/api.traversing.js
@@ -137,6 +137,11 @@ describe('$(...)', function() {
       var pear = $('li', fruits).filter('.pear').text();
       expect(pear).to.be('Pear');
     });
+
+    it('(selector) : should not consider nested elements', function() {
+      var lis = $(fruits).filter('li');
+      expect(lis).to.have.length(0);
+    });
     
     it('(fn) : should reduce the set of matched elements to those that pass the function\'s test', function() {
       var orange = $('li', fruits).filter(function(i, el) {


### PR DESCRIPTION
Selectors passed to the `filter` method should only be applied to the
top-level elements in the selection. In other words, descendent elements
should _not_ be considered when filtering by a selector string.

From [the jQuery documentation on `$.fn.filter`](http://api.jquery.com/filter/):

> **Description**: Reduce the set of matched elements to those that
> match the selector or pass the function's test.

This should resolve issue #158.
