### PR TITLE
fix find semantics

### DIFF
--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -4,7 +4,6 @@ var _ = require('underscore'),
     isTag = utils.isTag;
 
 var find = exports.find = function(selector) {
-  if (!selector) return this;
   try {
     var elem = select(selector, [].slice.call(this.children()));
     return this.make(elem);

--- a/test/api.traversing.js
+++ b/test/api.traversing.js
@@ -7,8 +7,8 @@ describe('$(...)', function() {
 
   describe('.find', function() {
 
-    it('() : should return this', function() {
-      expect($('ul', fruits).find()[0].name).to.equal('ul');
+    it('() : should find nothing', function() {
+      expect($('ul', fruits).find()).to.have.length(0);
     });
 
     it('(single) : should find one descendant', function() {


### PR DESCRIPTION
jQuery::find finds nothing if no selector is given. This is the correct behaviour.
