### PR TITLE
Travis Configuration Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
   - 0.6
   - 0.8
+  - "0.10"


### PR DESCRIPTION
Updates to the Travis config so cheerio will now build against v0.10.x for node, since it's been released as stable. 
