### PR TITLE
attr(key, val) on empty objects.

### DIFF
--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -46,7 +46,7 @@ var attr = exports.attr = function(name, value) {
     return elem.attribs;
   }
 
-  if (Object.hasOwnProperty.call(elem.attribs, name)) {
+  if (Object.prototype.hasOwnProperty.call(elem.attribs, name)) {
     // Get the (decoded) attribute
     return decode(elem.attribs[name]);
   }

--- a/test/api.attributes.js
+++ b/test/api.attributes.js
@@ -32,7 +32,7 @@ describe('$(...)', function() {
     });
 
     it('(key, value) : should return an empty object for an empty object', function() {
-      var $src = $().attr('test', 'test');
+      var $src = $().attr('key', 'value');
       expect($src.length).to.equal(0);
       expect($src[0]).to.be(undefined);
     });


### PR DESCRIPTION
attr(key, val) on empty objects should return an empty object instead of undefined.
