### PR TITLE
.map() does not behave like jQuery.map()

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -338,6 +338,14 @@ $('li').map(function(i, el) {
 //=> apple, orange, pear
 ```
 
+For compatibility, cheerio (as of 0.13.0) mirrors jQuery's questionable
+handling of return values:
+
+> The function can return an individual data item or an array of data items
+> to be inserted into the resulting set. If an array is returned, the elements
+> inside the array are inserted into the set. If the function returns null or
+> undefined, no element will be inserted.
+
 #### .filter( selector ) <br /> .filter( function(index) )
 
 Iterates over a cheerio object, reducing the set of selector elements to those that match the selector or pass the function's test. If using the function method, the function is executed in the context of the selected element, so `this` refers to the current element.

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -84,9 +84,10 @@ var each = exports.each = function(fn) {
 };
 
 var map = exports.map = function(fn) {
-  return _.map(this, function(el, i) {
-    return fn.call(this.make(el), i, el);
-  }, this);
+  return _.reduce(this, function(memo, el, i) {
+    var val = fn.call(this.make(el), i, el);
+    return val == null ? memo : memo.concat(val);
+  }, [], this);
 };
 
 var filter = exports.filter = function(match) {

--- a/test/api.traversing.js
+++ b/test/api.traversing.js
@@ -231,6 +231,20 @@ describe('$(...)', function() {
 
       expect(classes).to.be('apple, orange, pear');
     });
+
+    it('(fn) : should unpack items from any array returned', function() {
+      var result = $('li', food).map(function(idx) {
+        return [[1, 2, 3], [4, 5], [6], 7, [[8]]][idx];
+      });
+      expect(result).to.eql([1, 2, 3, 4, 5, 6, 7, [8]]);
+    });
+
+    it('(fn) : should omit null/undefined return values', function() {
+      var result = $('li', food).map(function(idx) {
+        return [null, 2, 3, undefined, 5][idx];
+      });
+      expect(result).to.eql([2, 3, 5]);
+    });
   });
 
   describe('.filter', function() {


### PR DESCRIPTION
jQuery's map implementation allows for the removal of an item from the resulting array by returning either null or undefined.

Cheerio's implementation leaves an empty placeholder.

From jQuery's documentation:

> The function can return:
> 
> the translated value, which will be mapped to the resulting array
> null or undefined, to remove the item
> an array of values, which will be flattened into the full array
