### PR TITLE
Tests for .parent()

### DIFF
--- a/test/api.traversing.js
+++ b/test/api.traversing.js
@@ -169,6 +169,25 @@ describe('$(...)', function() {
     })
   });
 
+  describe('.parent', function() {
+
+    it('() : should return the parent of each matched element', function(){
+      var result = $('.orange', fruits).parent();
+      expect(result).to.have.length(1);
+      expect(result[0].attribs.id).to.be('fruits');
+      result = $('li', food).parent();
+      expect(result).to.have.length(2);
+      expect(result[0].attribs.id).to.be('fruits');
+      expect(result[1].attribs.id).to.be('vegetables');
+    });
+
+    it('() : should return an empty object for top-level elements', function(){
+      var result = $('ul', fruits).parent();
+      expect(result).to.have.length(0);
+    });
+
+  });
+
   describe('.closest', function() {
 
     it('() : should return an empty array', function() {


### PR DESCRIPTION
There are 2 bugs in .parent() behavior.
1- .parent() should return the parent for each matched element not only the first element.
2- .parent() should return an empty object for top-level elements.

The first bug also exists in most of other traversing methods.

To reduce effort needed to implement the whole jQuery API, I suggest porting codes from Zepto or jQuery itself.
