### PR TITLE
Correct bug in jQuery.fn.closest

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -234,7 +234,7 @@ $('.orange').parents('#fruits').length
 ```
 
 #### .closest(selector)
-Get the closest element that matches the selector by searching through the element and the elements parents.
+For each element in the set, get the first element that matches the selector by testing the element itself and traversing up through its ancestors in the DOM tree.
 
 ```js
 $('.orange').closest()

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -22,11 +22,26 @@ var parents = exports.parents = function(selector) {
   return this;
 };
 
+// For each element in the set, get the first element that matches the selector
+// by testing the element itself and traversing up through its ancestors in the
+// DOM tree.
 var closest = exports.closest = function(selector) {
-  if (this[0] && selector) {
-    return traverseParents(this, this[0], selector, 1)
+  var set = [];
+
+  if (!selector) {
+    return this.make(set);
   }
-  return [];
+
+  this.each(function(idx, elem) {
+    var closestElem = traverseParents(this, elem, selector, 1)[0];
+
+    // Do not add duplicate elements to the set
+    if (closestElem && set.indexOf(closestElem) < 0) {
+      set.push(closestElem);
+    }
+  }.bind(this));
+
+  return this.make(set);
 };
 
 var next = exports.next = function() {

--- a/test/api.traversing.js
+++ b/test/api.traversing.js
@@ -174,6 +174,7 @@ describe('$(...)', function() {
     it('() : should return an empty array', function() {
       var result = $('.orange', fruits).closest();
       expect(result).to.have.length(0);
+      expect(result).to.be.a($);
     })
 
     it('(selector) : should find the closest element that matches the selector, searching through its ancestors and itself', function() {
@@ -185,6 +186,11 @@ describe('$(...)', function() {
       result = $('.orange', food).closest('li');
       expect(result[0].attribs['class']).to.be('orange');
     })
+
+    it('(selector) : should find the closest element of each item, removing duplicates', function() {
+      var result = $('li', food).closest('ul');
+      expect(result).to.have.length(2);
+    });
 
     it('() : should not break if the selector does not have any results', function() {
       var result = $('.saladbar', food).closest('ul');


### PR DESCRIPTION
According to the jQuery documentation, the `closest` method should
operate on each element in the collection, and the result should not
contain duplicate elements.

This patch also ensures that the method always returns a valid Cheerio
object.
