### PR TITLE
Parent bug

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -216,8 +216,8 @@ $('#fruits').find('li').length
 //=> 3
 ```
 
-#### .parent()
-Gets the parent of the first selected element.
+#### .parent([selector])
+Get the parent of each element in the current set of matched elements, optionally filtered by a selector.
 
 ```js
 $('.pear').parent().attr('id')

--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -72,8 +72,11 @@ var val = exports.val = function(value) {
           var queryString = 'input[type=radio][name=' + this.attr('name') + ']:checked';
           var parentEl = this;
 
-          //Go up until we hit a form or root
-          while(parentEl[0].name != 'form' && parentEl[0].name != 'root') parentEl = parentEl.parent();
+          // Go up until we hit a form or root
+          parentEl = this.closest('form');
+          if (parentEl.length === 0) {
+            parentEl = this.make(this.parents().last()[0].parent);
+          }
 
           if (querying) {
             return parentEl.find(queryString).attr('value');

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -7,11 +7,26 @@ var find = exports.find = function(selector) {
   return this.make(select(selector, [].slice.call(this.children())));
 };
 
-var parent = exports.parent = function(elem) {
-  if (this[0] && this[0].parent)
-    return this.make(this[0].parent);
-  else
-    return this;
+// Get the parent of each element in the current set of matched elements,
+// optionally filtered by a selector.
+var parent = exports.parent = function(selector) {
+  var set = [];
+  var $set;
+
+  this.each(function(idx, elem) {
+    var parentElem = elem.parent;
+    if (set.indexOf(parentElem) < 0 && parentElem.type !== 'root') {
+      set.push(parentElem);
+    }
+  });
+
+  $set = this.make(set)
+
+  if (arguments.length) {
+    $set = $set.filter(selector);
+  }
+
+  return $set;
 };
 
 var parents = exports.parents = function(selector) {

--- a/test/api.attributes.js
+++ b/test/api.attributes.js
@@ -123,9 +123,9 @@ describe('$(...)', function() {
 
     it('(key) : should remove a single attr', function() {
       var $fruits = $(fruits);
-      expect($('ul', $fruits.parent()).attr('id')).to.not.be(undefined);
-      $('ul', $fruits).removeAttr('id');
-      expect($('ul', $fruits).attr('id')).to.be(undefined);
+      expect($fruits.attr('id')).to.not.be(undefined);
+      $fruits.removeAttr('id');
+      expect($fruits.attr('id')).to.be(undefined);
     });
 
     it('should return cheerio object', function() {

--- a/test/api.traversing.js
+++ b/test/api.traversing.js
@@ -171,7 +171,7 @@ describe('$(...)', function() {
 
   describe('.parent', function() {
 
-    it('() : should return the parent of each matched element', function(){
+    it('() : should return the parent of each matched element', function() {
       var result = $('.orange', fruits).parent();
       expect(result).to.have.length(1);
       expect(result[0].attribs.id).to.be('fruits');
@@ -181,9 +181,23 @@ describe('$(...)', function() {
       expect(result[1].attribs.id).to.be('vegetables');
     });
 
-    it('() : should return an empty object for top-level elements', function(){
+    it('() : should return an empty object for top-level elements', function() {
       var result = $('ul', fruits).parent();
       expect(result).to.have.length(0);
+    });
+
+    it('() : should not contain duplicate elements', function() {
+      var result = $('li', fruits).parent();
+      expect(result).to.have.length(1);
+    });
+
+    it('(selector) : should filter the matched parent elements by the selector', function() {
+      var result = $('.orange', fruits).parent();
+      expect(result).to.have.length(1);
+      expect(result[0].attribs.id).to.be('fruits');
+      result = $('li', food).parent('#fruits');
+      expect(result).to.have.length(1);
+      expect(result[0].attribs.id).to.be('fruits');
     });
 
   });

--- a/test/api.utils.js
+++ b/test/api.utils.js
@@ -72,8 +72,7 @@ describe('$', function() {
       var $src = $('<div><span>foo</span><span>bar</span><span>baz</span></div>').children();
       var $elem = $src.clone();
       expect($elem.length).to.equal(3);
-      expect($elem.parent().length).to.equal(1);
-      expect($elem.parent()[0].type).to.equal('root');
+      expect($elem.parent()).to.have.length(0);
       expect($elem.text()).to.equal($src.text());
       $src.text('rofl');
       expect($elem.text()).to.not.equal($src.text());


### PR DESCRIPTION
This corrects Cheerio's implementation of `$.fn.parent` according to @farhadi's tests in issue #225 and [the jQuery API documentation on the method](http://api.jquery.com/parent/).

This required changing other Cheerio internals and tests:
- `.val` implementation & `.removeAttr` tests: This code was leveraging [incorrect behavior of the previous implementation that would return a reference to the original Cheerio object](https://github.com/MatthewMueller/cheerio/blob/f866996122c23d883a00e389aebf5802974c3377/lib/api/traversing.js#L14)
- `.clone` tests: This code was leveraging [incorrect behavior of the previous implementation that would return a Cheerio object wrapping the "root" element when the selected elements had no parent](https://github.com/MatthewMueller/cheerio/blob/f866996122c23d883a00e389aebf5802974c3377/lib/api/traversing.js#L12)
