### PR TITLE
Correct behavior of `Cheerio#parents`

### DIFF
--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -70,12 +70,13 @@ var val = exports.val = function(value) {
       switch (this.attr('type')) {
         case 'radio':
           var queryString = 'input[type=radio][name=' + this.attr('name') + ']:checked';
-          var parentEl = this;
+          var parentEl, root;
 
           // Go up until we hit a form or root
           parentEl = this.closest('form');
           if (parentEl.length === 0) {
-            parentEl = this.make(this.parents().last()[0].parent);
+            root = (this.parents().last()[0] || this[0]).parent;
+            parentEl = this.make(root);
           }
 
           if (querying) {

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -31,8 +31,7 @@ var parent = exports.parent = function(selector) {
 
 var parents = exports.parents = function(selector) {
   if (this[0] && this[0].parent) {
-    var elems = traverseParents(this, this[0].parent, selector, Infinity);
-    return elems.length ? elems : this;
+    return traverseParents(this, this[0].parent, selector, Infinity);
   }
   return this;
 };

--- a/test/api.traversing.js
+++ b/test/api.traversing.js
@@ -166,7 +166,7 @@ describe('$(...)', function() {
       expect(result).to.have.length(2);
       expect(result[0].attribs.id).to.be('fruits');
       expect(result[1].attribs.id).to.be('food');
-      result = $('#food', food).parents()
+      result = $('#fruits', food).parents()
       expect(result).to.have.length(1);
       expect(result[0].attribs.id).to.be('food');
     })
@@ -183,6 +183,10 @@ describe('$(...)', function() {
       var result = $('.saladbar', food).parents();
       expect(result).to.have.length(0);
     })
+    it('() : should return an empty set for top-level elements', function() {
+      var result = $('#food', food).parents();
+      expect(result).to.have.length(0);
+    });
   });
 
   describe('.parent', function() {


### PR DESCRIPTION
As we discovered in issue #229, there is a bug in the implementation of `Cheerio#parents`. When invoked on a top-level element, the method returns the original Cheerio collection. In this case, it should return an empty set.

Correcting this behavior makes `Cheerio#parents` slightly simpler (one less branch) and also improves a ([somewhat dubious-looking](https://github.com/MatthewMueller/cheerio/pull/229#pullrequestreviewcomment-5435741)) [traversal in `Cheerio#val`](https://github.com/MatthewMueller/cheerio/blob/2cac9e48593b485cd908308d13410b95e8b7eaf2/lib/api/attributes.js#L75-L79).

Commit message:

> When invoked on a top-level element, `parents` should return an empty
> set.
> 
> Because a unit test for `Cheerio#parents` and the implementation of
> `Cheerio#val` depends on the erroneous behavior, this code must also be
> updated.
