### PR TITLE
Changed from decode to decodeStrict

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,4 +27,4 @@ exports.isTag = function(type) {
  */
 
 exports.encode = function(str) { return entities.encode(String(str), 0); };
-exports.decode = function(str) { return entities.decode(str, 2); };
+exports.decode = function(str) { return entities.decodeStrict(str, 2); };


### PR DESCRIPTION
Related to this issue: https://github.com/MatthewMueller/cheerio/issues/194

It looks like the solution in node-entities was to have decodeStrict and that issue was closed when it was implemented, but Cheerio doesn't use the new function yet.
