### PR TITLE
allow custom boolean attributes

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -8,11 +8,6 @@ var decode = utils.decode;
 var encode = utils.encode;
 
 /*
-  Boolean Attributes
-*/
-var rboolean = /^(?:autofocus|autoplay|async|checked|controls|defer|disabled|hidden|loop|multiple|open|readonly|required|scoped|selected)$/i;
-
-/*
   Format attributes
 */
 var formatAttrs = function(attributes) {
@@ -24,7 +19,7 @@ var formatAttrs = function(attributes) {
   // Loop through the attributes
   for (var key in attributes) {
     value = attributes[key];
-    if (!value && (rboolean.test(key) || key === '/')) {
+    if (!value) {
       output.push(key);
     } else {
       output.push(key + '="' + encode(decode(value)) + '"');


### PR DESCRIPTION
Should allow custom boolean attributes (the are legal HTML).

Note that currently, in order to set a custom boolean attribute you need to write something like: elm[0].attribs['name'] = null. It would be nice to implement http://api.jquery.com/prop/ at some point.
