### PR TITLE
Extend manipulation methods to accept Arrays

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -29,6 +29,9 @@ exports = module.exports = function(content, options) {
 
 var evaluate = exports.evaluate = function(content, options) {
   // options = options || $.fn.options;
+  if (_.isArray(content) && typeof content[0] !== 'string') {
+    return content;
+  }
 
   var handler = new htmlparser.DomHandler(options),
       parser = new htmlparser.Parser(handler, options);

--- a/test/api.manipulation.js
+++ b/test/api.manipulation.js
@@ -32,6 +32,15 @@ describe('$(...)', function() {
       expect($fruits.children(4).hasClass('grape')).to.be.ok();
     });
 
+    it('(Array) : should append all elements in the array', function() {
+      var $fruits = $(fruits);
+      var more = $('<li class="plum">Plum</li><li class="grape">Grape</li>')
+        .toArray();
+      $fruits.append(more);
+      expect($fruits.children(3).hasClass('plum')).to.be.ok();
+      expect($fruits.children(4).hasClass('grape')).to.be.ok();
+    });
+
     it('(fn) : should add returned element as last child');
 
     it('should maintain correct object state (Issue: #10)', function() {
@@ -64,6 +73,15 @@ describe('$(...)', function() {
       expect($fruits.children(0).hasClass('plum')).to.be.ok();
     });
 
+    it('(Array) : should add all elements in the array as inital children', function() {
+      var $fruits = $(fruits);
+      var more = $('<li class="plum">Plum</li><li class="grape">Grape</li>')
+        .toArray();
+      $fruits.prepend(more);
+      expect($fruits.children(0).hasClass('plum')).to.be.ok();
+      expect($fruits.children(1).hasClass('grape')).to.be.ok();
+    });
+
     it('(html, $(...), html) : should add multiple elements as first children', function() {
       var $fruits = $(fruits);
       var $plum = $('<li class="plum">Plum</li>');
@@ -88,6 +106,15 @@ describe('$(...)', function() {
       var grape = '<li class="grape">Grape</li>';
       $('.apple', $fruits).after(grape);
       expect($('.apple', $fruits).next().hasClass('grape')).to.be.ok();
+    });
+
+    it('(Array) : should add all elements in the array as next sibling', function() {
+      var $fruits = $(fruits);
+      var more = $('<li class="plum">Plum</li><li class="grape">Grape</li>')
+        .toArray();
+      $('.apple', $fruits).after(more);
+      expect($fruits.children(1).hasClass('plum')).to.be.ok();
+      expect($fruits.children(2).hasClass('grape')).to.be.ok();
     });
 
     it('($(...)) : should add element as next sibling', function() {
@@ -130,6 +157,15 @@ describe('$(...)', function() {
       expect($('.apple', $fruits).prev().hasClass('plum')).to.be.ok();
     });
 
+    it('(Array) : should add all elements in the array as previous sibling', function() {
+      var $fruits = $(fruits);
+      var more = $('<li class="plum">Plum</li><li class="grape">Grape</li>')
+        .toArray();
+      $('.apple', $fruits).before(more);
+      expect($fruits.children(0).hasClass('plum')).to.be.ok();
+      expect($fruits.children(1).hasClass('grape')).to.be.ok();
+    });
+
     it('($(...), html) : should add multiple elements as previous siblings', function() {
       var $fruits = $(fruits);
       var $plum = $('<li class="plum">Plum</li>');
@@ -167,6 +203,16 @@ describe('$(...)', function() {
       $('.pear', $fruits).replaceWith($plum);
       expect($('.orange', $fruits).next().hasClass('plum')).to.be.ok();
       expect($('.orange', $fruits).next().html()).to.equal('Plum');
+    });
+
+    it('(Array) : should replace one <li> tag with the elements in the array', function() {
+      var $fruits = $(fruits);
+      var more = $('<li class="plum">Plum</li><li class="grape">Grape</li>')
+        .toArray();
+      $('.pear', $fruits).replaceWith(more);
+
+      expect($fruits.children(2).hasClass('plum')).to.be.ok();
+      expect($fruits.children(3).hasClass('grape')).to.be.ok();
     });
 
     it('(elem) : should replace the selected element with given element', function() {


### PR DESCRIPTION
The jQuery API supports specifying an Array of DOM nodes when invoking
the following functions: `$.fn.append`, `$.fn.prepend`, `$.fn.after`,
`$.fn.before`, and `$.fn.replaceWith`. Update the Cheerio API to match.
- http://api.jquery.com/append/
- http://api.jquery.com/prepend/
- http://api.jquery.com/after/
- http://api.jquery.com/before/
- http://api.jquery.com/replaceWith/
