### PR TITLE
Refactor Cheerio array creation

### DIFF
--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -11,9 +11,15 @@ var _ = require('underscore'),
   parsing strings if necessary
 */
 var makeCheerioArray = function(elems) {
-  return _.reduce(elems, function(dom, elem) {
-    return dom.concat(elem.cheerio ? elem.toArray() : evaluate(elem));
-  }, []);
+  return _.chain(elems).map(function(elem) {
+    if (elem.cheerio) {
+      return elem.toArray();
+    } else if (!_.isArray(elem)) {
+      return evaluate(elem);
+    } else {
+      return elem;
+    }
+  }).flatten().value();
 };
 
 var _insert = function(concatenator) {
@@ -109,7 +115,7 @@ var remove = exports.remove = function(selector) {
 };
 
 var replaceWith = exports.replaceWith = function(content) {
-  content = content.cheerio ? content.toArray() : evaluate(content);
+  content = makeCheerioArray([content]);
 
   this.each(function(i, el) {
     var siblings = el.parent.children,

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -29,9 +29,6 @@ exports = module.exports = function(content, options) {
 
 var evaluate = exports.evaluate = function(content, options) {
   // options = options || $.fn.options;
-  if (_.isArray(content) && typeof content[0] !== 'string') {
-    return content;
-  }
 
   var handler = new htmlparser.DomHandler(options),
       parser = new htmlparser.Parser(handler, options);


### PR DESCRIPTION
Because so many of jQuery's methods accept "mixed" arrays, the array
normalization logic should be abstracted into a function that is shared
across the manipulation methods.

This approach is also slightly more efficient because it eliminates a
conditional in the heavily-used `evaluate` method.
