### PR TITLE
Correct implementation of `$.fn.text`

### DIFF
--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -163,8 +163,8 @@ var toString = exports.toString = function() {
 };
 
 var text = exports.text = function(str) {
-  // If `str` blank or an object
-  if (!str || typeof str === 'object') {
+  // If `str` is undefined, act as a "getter"
+  if (str === undefined) {
     return $.text(this);
   } else if (_.isFunction(str)) {
     // Function support

--- a/test/api.manipulation.js
+++ b/test/api.manipulation.js
@@ -343,6 +343,25 @@ describe('$(...)', function() {
       expect(text).to.equal('M&M');
     });
 
+    it('( undefined ) : should act as an accessor', function() {
+      var $div = $('<div>test</div>');
+      expect($div.text(undefined)).to.be.a('string');
+      expect($div.text()).to.be('test');
+    });
+
+    it('( "" ) : should convert to string', function() {
+      var $div = $('<div>test</div>');
+      expect($div.text('').text()).to.equal('');
+    });
+
+    it('( null ) : should convert to string', function() {
+      expect($('<div>').text(null).text()).to.equal('null');
+    });
+
+    it('( 0 ) : should convert to string', function() {
+      expect($('<div>').text(0).text()).to.equal('0');
+    });
+
     it('(str) should encode then decode unsafe characters', function() {
       var $apple = $('.apple', fruits);
       


### PR DESCRIPTION
This should resolve issue #255

Commit message:

> This method should only act as a "getter" when the first argument is
> undefined. If any other "falsey" value is specified, it should be
> coerced to its String form and set as the node's text content.
> 
> The analogous logic in jQuery passes the value to the DOM
> `createTextNode` method, which behaves in this way:
> 
> https://github.com/jquery/jquery/blob/2.0.3/src/manipulation.js#L35-L37
