### PR TITLE
Correct the implementation `filter` and `is`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -202,8 +202,10 @@ $('.apple').addClass('red').removeClass().html()
 > See http://api.jquery.com/removeClass/ for more information.
 
 #### .is( selector )
+#### .is( element )
+#### .is( selection )
 #### .is( function(index) )
-Checks the current list of elements and returns `true` if _any_ of the elements match the selector. If using a predicate function, the function is executed in the context of the selected element, so `this` refers to the current element.
+Checks the current list of elements and returns `true` if _any_ of the elements match the selector. If using an element or Cheerio selection, returns `true` if _any_ of the elements match. If using a predicate function, the function is executed in the context of the selected element, so `this` refers to the current element.
 
 
 ### Traversing
@@ -338,9 +340,9 @@ $('li').map(function(i, el) {
 //=> apple, orange, pear
 ```
 
-#### .filter( selector ) <br /> .filter( function(index) )
+#### .filter( selector ) <br /> .filter( selection ) <br /> .filter( element ) <br /> .filter( function(index) )
 
-Iterates over a cheerio object, reducing the set of selector elements to those that match the selector or pass the function's test. If using the function method, the function is executed in the context of the selected element, so `this` refers to the current element.
+Iterates over a cheerio object, reducing the set of selector elements to those that match the selector or pass the function's test. When a Cheerio selection is specified, return only the elements contained in that selection. When an element is specified, return only that element (if it is contained in the original selection). If using the function method, the function is executed in the context of the selected element, so `this` refers to the current element.
 
 Selector:
 

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -131,10 +131,25 @@ var map = exports.map = function(fn) {
 
 var filter = exports.filter = function(match) {
   var make = _.bind(this.make, this);
-  return make(_.filter(this, _.isString(match) ?
-    function(el) { return select(match, el)[0] === el; }
-  : function(el, i) { return match.call(make(el), i, el); }
-  ));
+  var filterFn;
+
+  if (_.isString(match)) {
+    filterFn = function(el) {
+      return select(match, el)[0] === el;
+    };
+  } else if (_.isFunction(match)) {
+    filterFn = function(el, i) {
+      return match.call(make(el), i, el);
+    };
+  } else if (match.cheerio) {
+    filterFn = match.is.bind(match);
+  } else {
+    filterFn = function(el) {
+      return match === el;
+    };
+  }
+
+  return make(_.filter(this, filterFn));
 };
 
 var first = exports.first = function() {

--- a/test/api.attributes.js
+++ b/test/api.attributes.js
@@ -295,6 +295,28 @@ describe('$(...)', function() {
       expect($('#vegetables', vegetables).is('div')).to.be(false);
     });
 
+    it('(true selection) : should return true', function() {
+      var $vegetables = $('li', vegetables);
+      expect($vegetables.is($vegetables.eq(1))).to.be(true);
+    });
+
+    it('(false selection) : should return false', function() {
+      var $vegetableList = $(vegetables);
+      var $vegetables = $vegetableList.find('li');
+      expect($vegetables.is($vegetableList)).to.be(false);
+    });
+
+    it('(true element) : should return true', function() {
+      var $vegetables = $('li', vegetables);
+      expect($vegetables.is($vegetables[0])).to.be(true);
+    });
+
+    it('(false element) : should return false', function() {
+      var $vegetableList = $(vegetables);
+      var $vegetables = $vegetableList.find('li');
+      expect($vegetables.is($vegetableList[0])).to.be(false);
+    });
+
     it('(true predicate) : should return true', function() {
       var result = $('li', fruits).is(function() {
         return this.hasClass('pear');

--- a/test/api.traversing.js
+++ b/test/api.traversing.js
@@ -316,6 +316,18 @@ describe('$(...)', function() {
       expect(lis).to.have.length(0);
     });
 
+    it('(selection) : should reduce the set of matched elements to those that are contained in the provided selection', function() {
+      var $fruits = $('li', fruits);
+      var $pear = $fruits.filter('.pear, .apple');
+      expect($fruits.filter($pear)).to.have.length(2);
+    });
+
+    it('(element) : should reduce the set of matched elements to those that specified directly', function() {
+      var $fruits = $('li', fruits);
+      var pear = $fruits.filter('.pear')[0];
+      expect($fruits.filter(pear)).to.have.length(1);
+    });
+
     it('(fn) : should reduce the set of matched elements to those that pass the function\'s test', function() {
       var orange = $('li', fruits).filter(function(i, el) {
         expect(this[0]).to.be(el);


### PR DESCRIPTION
According to [the jQuery API documentation on `$.fn.filter`](http://api.jquery.com/filter/) and [`$.fn.is`](http://api.jquery.com/is/), these methods accept any of the following argument types:
- selector string
- function
- element
- jQuery object

Extend the `$.fn.filter` method to accept elements and Cheerio collections. This implicitly fixes the corresponding bug in `$.fn.is`.
