### PR TITLE
Fix bug in `siblings`

### DIFF
--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -89,7 +89,7 @@ var prevAll = exports.prevAll = function(selector) {
 var siblings = exports.siblings = function(selector) {
   var elems = _.filter(
     this.parent() ? this.parent().children() : this.siblingsAndMe(),
-    function(elem) { return isTag(elem) && elem !== this[0]; },
+    function(elem) { return isTag(elem) && !this.is(elem); },
     this
   );
   if (selector !== undefined) {

--- a/test/api.traversing.js
+++ b/test/api.traversing.js
@@ -156,6 +156,7 @@ describe('$(...)', function() {
     it('() : should get all the siblings', function() {
       expect($('.orange', fruits).siblings()).to.have.length(2);
       expect($('#fruits', fruits).siblings()).to.have.length(0);
+      expect($('.apple, .carrot', food).siblings()).to.have.length(3);
     });
 
     it('(selector) : should get all siblings that match the selector', function() {

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -8,8 +8,8 @@ exports.fruits = [
 
 exports.vegetables = [
   '<ul id="vegetables">',
-    '<li>Carrot</li>',
-    '<li>Sweetcorn</li>',
+    '<li class="carrot">Carrot</li>',
+    '<li class="sweetcorn">Sweetcorn</li>',
   '</ul>'
 ].join('');
 


### PR DESCRIPTION
The selection returned by the `siblings` method should not contain _any_
of the elements in the original selection.

This should resolve issue #244.
