### PR TITLE
Document `contents` and add tests

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -315,6 +315,14 @@ $('#fruits').children('.pear').text()
 //=> Pear
 ```
 
+#### .contents()
+Gets the children of each element in the set of matched elements, including text and comment nodes.
+
+```js
+$('#fruits').contents().length
+//=> 3
+```
+
 #### .each( function(index, element) )
 Iterates over a cheerio object, executing a function for each matched element. When the callback is fired, the function is fired in the context of the DOM element, so `this` refers to the current element, which is equivalent to the function parameter `element`. To break out of the `each` loop early, return with `false`.
 

--- a/test/api.traversing.js
+++ b/test/api.traversing.js
@@ -77,6 +77,10 @@ describe('$(...)', function() {
       expect($('p', text).contents().first()[0].type).to.equal('text');
     });
 
+    it('() : should include comment nodes', function() {
+      expect($('p', text).contents().last()[0].type).to.equal('comment');
+    });
+
   });
 
   describe('.next', function() {

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -30,5 +30,5 @@ exports.inputs = [
 
 exports.text = [
   '<p>Apples, <b>oranges</b> and pears.</p>',
-  '<p>Carrots and <b>sweetcorn</b></p>'
+  '<p>Carrots and <!-- sweetcorn --></p>'
 ].join('');


### PR DESCRIPTION
`$.fn.contents` was added about 2 months ago in #234, obsoleting #164. Document the method ([taken from api.jquery.com](http://api.jquery.com/contents/)) to prevent future confusion, and add a test to assert correct handling of comment nodes.
