### PR TITLE
Fix variable declaration in depedency import

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -3,7 +3,7 @@
 */
 var htmlparser = require('htmlparser2'),
     _ = require('underscore'),
-    isTag = require('./utils').isTag;
+    isTag = require('./utils').isTag,
     camelCase = require('./utils').camelCase;
 
 /*


### PR DESCRIPTION
Came across this, when running node with `--use_strict`.
