### PR TITLE
Correct inconsistency in `$.fn.map`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -368,14 +368,14 @@ fruits.join(', ');
 ```
 
 #### .map( function(index, element) )
-Iterates over a cheerio object, executing a function for each selected element. Map will return an `array` of return values from each of the functions it iterated over. The function is fired in the context of the DOM element, so `this` refers to the current element, which is equivalent to the function parameter `element`.
+Pass each element in the current matched set through a function, producing a new Cheerio object containing the return values. The function can return an individual data item or an array of data items to be inserted into the resulting set. If an array is returned, the elements inside the array are inserted into the set. If the function returns null or undefined, no element will be inserted.
 
 ```js
 $('li').map(function(i, el) {
   // this === el
-  return $(this).attr('class');
-}).join(', ');
-//=> apple, orange, pear
+  return $('<div>').text($(this).text());
+}).html();
+//=> <div>apple</div><div>orange</div><div>pear</div>
 ```
 
 #### .filter( selector ) <br /> .filter( selection ) <br /> .filter( element ) <br /> .filter( function(index) )

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -127,9 +127,10 @@ var each = exports.each = function(fn) {
 };
 
 var map = exports.map = function(fn) {
-  return _.map(this, function(el, i) {
-    return fn.call(this.make(el), i, el);
-  }, this);
+  return this.make(_.reduce(this, function(memo, el, i) {
+    var val = fn.call(el, i, el);
+    return val == null ? memo : memo.concat(val);
+  }, []));
 };
 
 var filter = exports.filter = function(match) {

--- a/test/api.traversing.js
+++ b/test/api.traversing.js
@@ -299,15 +299,78 @@ describe('$(...)', function() {
   });
 
   describe('.map', function() {
-    it('(fn) : should return an array of mapped items', function() {
-      var classes = $('li', fruits).map(function(i, el) {
-        expect(this[0]).to.be(el);
-        expect(el.name).to.be('li');
-        expect(i).to.be.a('number');
-        return el.attribs['class'];
-      }).join(', ');
+    it('(fn) : should be invoked with the correct arguments and context', function() {
+      var $fruits = $('li', fruits);
+      var args = [];
+      var thisVals = [];
 
-      expect(classes).to.be('apple, orange, pear');
+      $fruits.map(function() {
+        args.push(arguments);
+        thisVals.push(this);
+      });
+
+      expect(args).to.eql([
+        [0, $fruits[0]],
+        [1, $fruits[1]],
+        [2, $fruits[2]]
+      ]);
+      expect(thisVals).to.eql([
+        $fruits[0],
+        $fruits[1],
+        $fruits[2]
+      ]);
+    });
+
+    it('(fn) : should return an Cheerio object wrapping the returned items', function() {
+      var $fruits = $('li', fruits);
+      var $mapped = $fruits.map(function(i, el) {
+        return $fruits[2 - i];
+      });
+
+      expect($mapped).to.have.length(3);
+      expect($mapped[0]).to.be($fruits[2]);
+      expect($mapped[1]).to.be($fruits[1]);
+      expect($mapped[2]).to.be($fruits[0]);
+    });
+
+    it('(fn) : should ignore `null` and `undefined` returned by iterator', function() {
+      var $fruits = $('li', fruits);
+      var retVals = [null, undefined, $fruits[1]];
+
+      var $mapped = $fruits.map(function(i, el) {
+        return retVals[i];
+      });
+
+      expect($mapped).to.have.length(1);
+      expect($mapped[0]).to.be($fruits[1]);
+    });
+
+    it('(fn) : should preform a shallow merge on arrays returned by iterator', function() {
+      var $fruits = $('li', fruits);
+
+      var $mapped = $fruits.map(function(i, el) {
+        return [1, [3, 4]];
+      });
+
+      expect($mapped.toArray()).to.eql([
+        1, [3, 4],
+        1, [3, 4],
+        1, [3, 4]
+      ]);
+    });
+
+    it('(fn) : should tolerate `null` and `undefined` when flattening arrays returned by iterator', function() {
+      var $fruits = $('li', fruits);
+
+      var $mapped = $fruits.map(function(i, el) {
+        return [null, undefined];
+      });
+
+      expect($mapped.toArray()).to.eql([
+        null, undefined,
+        null, undefined,
+        null, undefined,
+      ]);
     });
   });
 


### PR DESCRIPTION
Update Cheerio's `map` method to more closely match jQuery's
implementation.
1. Invoke the specified callback in the context of the element
2. Wrap the returned elements in a Cheerio object

Update the documentation and unit tests to reflect this change.
