### PR TITLE
Avoid shadowing instance methods from arrays

### DIFF
--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -121,10 +121,13 @@ var isHtml = function(str) {
  * Make a cheerio object
  */
 
-Cheerio.prototype.make = function(dom, context) {
+Cheerio.prototype.make = function(dom, cheerio) {
+  var made;
   if (dom.cheerio) return dom;
   dom = (Array.isArray(dom)) ? dom : [dom];
-  return _.extend(context || new Cheerio(), dom, { length: dom.length });
+  made = _.defaults(cheerio || new Cheerio(), dom);
+  made.length = dom.length;
+  return made;
 };
 
 /**

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -198,4 +198,14 @@ describe('cheerio', function() {
     expect($elem).to.have.length(0); // []
   });
 
+  it('(extended Array) should not interfere with prototype methods (issue #119)', function() {
+    var extended = [];
+    var custom = extended.find = extended.children = extended.each = function() {};
+    var $empty = $(extended);
+
+    expect($empty.find).to.be($.prototype.find);
+    expect($empty.children).to.be($.prototype.children);
+    expect($empty.each).to.be($.prototype.each);
+  });
+
 });


### PR DESCRIPTION
Ignore instance properties on Arrays that are shared with the Cheerio
constructor (excepting `length`).

This should resolve issues #119 and #133.
