### PR TITLE
Coerce JSON values returned by `data`

### DIFF
--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -3,10 +3,21 @@ var _ = require('underscore'),
   isTag = utils.isTag,
   decode = utils.decode,
   encode = utils.encode,
+  hasOwn = Object.prototype.hasOwnProperty,
   rspace = /\s+/,
 
+  // Lookup table for coercing string data-* attributes to their corresponding
+  // JavaScript primitives
+  primitives = {
+    null: null,
+    true: true,
+    false: false
+  },
+
   // Attributes that are booleans
-  rboolean = /^(?:autofocus|autoplay|async|checked|controls|defer|disabled|hidden|loop|multiple|open|readonly|required|scoped|selected)$/i;
+  rboolean = /^(?:autofocus|autoplay|async|checked|controls|defer|disabled|hidden|loop|multiple|open|readonly|required|scoped|selected)$/i,
+  // Matches strings that look like JSON objects or arrays
+  rbrace = /^(?:\{[\w\W]*\}|\[[\w\W]*\])$/;
 
 
 var setAttr = function(el, name, value) {
@@ -50,7 +61,7 @@ var attr = exports.attr = function(name, value) {
     return elem.attribs;
   }
 
-  if (Object.prototype.hasOwnProperty.call(elem.attribs, name)) {
+  if (hasOwn.call(elem.attribs, name)) {
     // Get the (decoded) attribute
     return decode(elem.attribs[name]);
   }
@@ -95,9 +106,19 @@ var data = exports.data = function(name, value) {
       el.data = setData(el, name, value);
     });
     return this;
-  } else if (Object.hasOwnProperty.call(elem.data, name)) {
+  } else if (hasOwn.call(elem.data, name)) {
     // Get the (decoded) data
-    return decode(elem.data[name]);
+    var val = decode(elem.data[name]);
+
+    if (hasOwn.call(primitives, val)) {
+      val = primitives[val];
+    } else if (val === String(Number(val))) {
+      val = Number(val);
+    } else if (rbrace.test(val)) {
+      val = JSON.parse(val);
+    }
+
+    return val;
   } else if (typeof name === 'string' && value === undefined) {
     return undefined;
   }

--- a/test/api.attributes.js
+++ b/test/api.attributes.js
@@ -143,6 +143,39 @@ describe('$(...)', function() {
       expect(data.url).to.equal('http://www.cailler.ch/');
     });
 
+    describe('(attr) : data-* attribute type coercion :', function() {
+      it('boolean', function() {
+        var $el = $('<div data-bool="true">');
+        expect($el.data('bool')).to.be(true);
+      });
+
+      it('number', function() {
+        var $el = $('<div data-number="23">');
+        expect($el.data('number')).to.be(23);
+      });
+
+      it('number (scientific notation is not coerced)', function() {
+        var $el = $('<div data-sci="1E10">');
+        expect($el.data('sci')).to.be('1E10');
+      });
+
+      it('null', function() {
+        var $el = $('<div data-null="null">');
+        expect($el.data('null')).to.be(null);
+      });
+
+      it('object', function() {
+        var $el = $('<div data-obj=\'{ "a": 45 }\'>');
+        expect($el.data('obj')).to.eql({ a: 45 });
+      });
+
+      it('array', function() {
+        var $el = $('<div data-array="[1, 2, 3]">');
+        expect($el.data('array')).to.eql([1, 2, 3]);
+      });
+
+    });
+
   });
 
 


### PR DESCRIPTION
From the jQuery API documentation on `$.fn.data` [1]:

> Every attempt is made to convert the string to a JavaScript value
> (this includes booleans, numbers, objects, arrays, and null). A value
> is only converted to a number if doing so doesn't change the value's
> representation. For example, "1E02" and "100.000" are equivalent as
> numbers (numeric value 100) but converting them would alter their
> representation so they are left as strings. The string value "100" is
> converted to the number 100.

[1] http://api.jquery.com/data/
