### PR TITLE
Simplify `make` method

### DIFF
--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -208,5 +208,5 @@ var text = exports.text = function(str) {
 var clone = exports.clone = function() {
   // Turn it into HTML, then recreate it,
   // Seems to be the easiest way to reconnect everything correctly
-  return this.constructor($.html(this));
+  return this.make($.html(this));
 };

--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -39,19 +39,26 @@ var Cheerio = module.exports = function(selector, context, root) {
 
   if (root) {
     if (typeof root === 'string') root = parse(root);
-    this._root = this.make(root, this);
+    this._root = Cheerio.call(this, root);
   }
 
   // $($)
   if (selector.cheerio) return selector;
 
   // $(dom)
-  if (selector.name || Array.isArray(selector))
-    return this.make(selector, this);
+  if (selector.name || selector.type === 'text' || selector.type === 'comment')
+    selector = [selector];
+
+  // $([dom])
+  if (Array.isArray(selector)) {
+    _.defaults(this, selector);
+    this.length = selector.length;
+    return this;
+  }
 
   // $(<html>)
   if (typeof selector === 'string' && isHtml(selector)) {
-    return this.make(parse(selector).children);
+    return Cheerio.call(this, parse(selector).children);
   }
 
   // If we don't have a context, maybe we have a root, from loading
@@ -61,7 +68,7 @@ var Cheerio = module.exports = function(selector, context, root) {
     if (isHtml(context)) {
       // $('li', '<ul>...</ul>')
       context = parse(context);
-      context = this.make(context, this);
+      context = Cheerio.call(this, context);
     } else {
       // $('li', 'ul')
       selector = [context, selector].join(' ');
@@ -77,10 +84,10 @@ var Cheerio = module.exports = function(selector, context, root) {
 };
 
 /**
- * Inherit from `static`
+ * Mix in `static`
  */
 
-Cheerio.__proto__ = require('./static');
+_.extend(Cheerio, require('./static'));
 
 /*
  * Set a signature of the object
@@ -121,13 +128,8 @@ var isHtml = function(str) {
  * Make a cheerio object
  */
 
-Cheerio.prototype.make = function(dom, cheerio) {
-  var made;
-  if (dom.cheerio) return dom;
-  dom = (Array.isArray(dom)) ? dom : [dom];
-  made = _.defaults(cheerio || new Cheerio(), dom);
-  made.length = dom.length;
-  return made;
+Cheerio.prototype.make = function(dom) {
+  return new Cheerio(dom);
 };
 
 /**


### PR DESCRIPTION
Organize all logic for creating Cheerio objects within the Cheerio
constructor itself. Ensure that the `Function` prototype exists in the
constructor's prototype chain so that it defines a `call` method.
Re-define `Cheerio#make` as a simple proxy for the Cheerio constructor
for those methods that need to create new Cheerio instances (thus
avoiding compile-time cyclic dependencies).
