### PR TITLE
Implement `$.fn.end`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -426,6 +426,14 @@ $('li').eq(-1).text()
 //=> Pear
 ```
 
+#### .end()
+End the most recent filtering operation in the current chain and return the set of matched elements to its previous state.
+
+```js
+$('li').eq(0).end().length
+//=> 3
+```
+
 ### Manipulation
 Methods for modifying the DOM structure.
 

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -185,3 +185,9 @@ function traverseParents(self, elem, selector, limit) {
   }
   return self.make(elems);
 }
+
+// End the most recent filtering operation in the current chain and return the
+// set of matched elements to its previous state.
+var end = exports.end = function() {
+  return this.prevObject || this.make([]);
+};

--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -129,7 +129,9 @@ var isHtml = function(str) {
  */
 
 Cheerio.prototype.make = function(dom) {
-  return new Cheerio(dom);
+  var cheerio = new Cheerio(dom);
+  cheerio.prevObject = this;
+  return cheerio;
 };
 
 /**

--- a/test/api.traversing.js
+++ b/test/api.traversing.js
@@ -505,4 +505,67 @@ describe('$(...)', function() {
 
   });
 
+  describe('.end() :', function() {
+    var $fruits = $(fruits).children();
+
+    it('returns an empty object at the end of the chain', function() {
+      expect($fruits.end().end()).to.be.ok();
+      expect($fruits.end().end()).to.have.length(0);
+    });
+    it('find', function() {
+      expect($fruits.find('.apple').end()).to.be($fruits);
+    });
+    it('filter', function() {
+      expect($fruits.filter('.apple').end()).to.be($fruits);
+    });
+    it('map', function() {
+      expect($fruits.map(function() { return this; }).end()).to.be($fruits);
+    });
+    it('contents', function() {
+      expect($fruits.contents().end()).to.be($fruits);
+    });
+    it('eq', function() {
+      expect($fruits.eq(1).end()).to.be($fruits);
+    });
+    it('first', function() {
+      expect($fruits.first().end()).to.be($fruits);
+    });
+    it('last', function() {
+      expect($fruits.last().end()).to.be($fruits);
+    });
+    it('slice', function() {
+      expect($fruits.slice(1).end()).to.be($fruits);
+    });
+    it('children', function() {
+      expect($fruits.children().end()).to.be($fruits);
+    });
+    it('parent', function() {
+      expect($fruits.parent().end()).to.be($fruits);
+    });
+    it('parents', function() {
+      expect($fruits.parents().end()).to.be($fruits);
+    });
+    it('closest', function() {
+      expect($fruits.closest('ul').end()).to.be($fruits);
+    });
+    it('siblings', function() {
+      expect($fruits.siblings().end()).to.be($fruits);
+    });
+    it('next', function() {
+      expect($fruits.next().end()).to.be($fruits);
+    });
+    it('nextAll', function() {
+      expect($fruits.nextAll().end()).to.be($fruits);
+    });
+    it('prev', function() {
+      expect($fruits.prev().end()).to.be($fruits);
+    });
+    it('prevAll', function() {
+      expect($fruits.prevAll().end()).to.be($fruits);
+    });
+    it('clone', function() {
+      expect($fruits.clone().end()).to.be($fruits);
+    });
+  });
+
 });


### PR DESCRIPTION
From the jQuery API documentation[1]:

> **Description**: End the most recent filtering operation in the
> current chain and return the set of matched elements to its previous
> state.
> 
> Most of jQuery's DOM traversal methods operate on a jQuery object
> instance and produce a new one, matching a different set of DOM
> elements. When this happens, it is as if the new set of elements is
> pushed onto a stack that is maintained inside the object. Each
> successive filtering method pushes a new element set onto the stack.
> If we need an older element set, we can use end() to pop the sets back
> off of the stack.

[1] http://api.jquery.com/end/

This should resolve issue #199
