### PR TITLE
Update HtmlParser2 version

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -88,7 +88,7 @@ of the default parsing options:
 
 ```js
 $ = cheerio.load('<ul id="fruits">...</ul>', {
-    ignoreWhitespace: true,
+    normalizeWhitespace: true,
     xmlMode: true
 });
 ```
@@ -98,7 +98,7 @@ are valid in cheerio as well. The default options are:
 
 ```js
 {
-    ignoreWhitespace: false,
+    normalizeWhitespace: false,
     xmlMode: false,
     lowerCaseTags: false
 }

--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -100,7 +100,7 @@ Cheerio.prototype.cheerio = '[cheerio object]';
  */
 
 Cheerio.prototype.options = {
-  ignoreWhitespace: false,
+  normalizeWhitespace: false,
   xmlMode: false,
   lowerCaseTags: false
 };

--- a/lib/render.js
+++ b/lib/render.js
@@ -72,8 +72,7 @@ var render = module.exports = function(dom, opts) {
   opts = opts || {};
 
   var output = [],
-      xmlMode = opts.xmlMode || false,
-      ignoreWhitespace = opts.ignoreWhitespace || false;
+      xmlMode = opts.xmlMode || false;
 
   _.each(dom, function(elem) {
     var pushVal;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "cheerio-select": "*",
-    "htmlparser2": "3.1.4",
+    "htmlparser2": "~3.3.0",
     "underscore": "~1.4",
     "entities": "0.x"
   },

--- a/test/api.utils.js
+++ b/test/api.utils.js
@@ -51,9 +51,9 @@ describe('$', function() {
       expect($html.html()).to.be('<body><ul id="fruits"></ul></body>');
     });
 
-    it('(html) : should handle the ignore whitepace option', function() {
-      var $html = $.load('<body><a href="http://yahoo.com">Yahoo</a> <a href="http://google.com">Google</a></body>', { ignoreWhitespace : true });
-      expect($html.html()).to.be('<body><a href="http://yahoo.com">Yahoo</a><a href="http://google.com">Google</a></body>');
+    it('(html) : should handle the `normalizeWhitepace` option', function() {
+      var $html = $.load('<body><b>foo</b>  <b>bar</b></body>', { normalizeWhitespace : true });
+      expect($html.html()).to.be('<body><b>foo</b> <b>bar</b></body>');
     });
 
     // TODO:

--- a/test/render.js
+++ b/test/render.js
@@ -47,9 +47,9 @@ describe('render', function() {
       expect(html(str)).to.equal(str);
     });
 
-    it('should ignore whitespace if specified', function() {
+    it('should normalize whitespace if specified', function() {
       var str = '<a href="./haha.html">hi</a> <a href="./blah.html">blah  </a>';
-      expect(html(str, {ignoreWhitespace: true})).to.equal('<a href="./haha.html">hi</a><a href="./blah.html">blah  </a>');
+      expect(html(str, { normalizeWhitespace: true })).to.equal('<a href="./haha.html">hi</a> <a href="./blah.html">blah </a>');
     });
 
     it('should preserve multiple hyphens in data attributes', function() {


### PR DESCRIPTION
HtmlParser2's `normalizeWhitespace` option is not functionally equivalent to the previous behavior of the `ignoreWhitespace` option, so two tests must be updated. Basically, instead of completely removing instances of two-or-more whitespace characters, such instances are now replaced with a single space character.

This could be considered a "breaking" change by some, so this probably warrants an increment to Cheerio's minor version.

This should resolve issues #265 and #262.

Commit message:

> The latest version of HtmlParser2 has deprecated the `ignoreWhitespace`
> option in favor of a new option, `normalizeWhitespace`.
> 
> Allow for future patch releases of HtmlParser2 to automatically
> "upstream" into Cheerio.
