### PR TITLE
Fix parents

### DIFF
--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -33,10 +33,22 @@ var parent = exports.parent = function(selector) {
 };
 
 var parents = exports.parents = function(selector) {
-  if (this[0] && this[0].parent) {
-    return this.make(traverseParents(this, this[0].parent, selector, Infinity));
-  }
-  return this;
+  var parentNodes = [];
+
+  // When multiple DOM elements are in the original set, the resulting set will
+  // be in *reverse* order of the original elements as well, with duplicates
+  // removed.
+  this.toArray().reverse().forEach(function(elem) {
+    traverseParents(this, elem.parent, selector, Infinity)
+      .forEach(function(node) {
+        if (parentNodes.indexOf(node) === -1) {
+          parentNodes.push(node);
+        }
+      }
+    );
+  }, this);
+
+  return this.make(parentNodes);
 };
 
 // For each element in the set, get the first element that matches the selector

--- a/test/api.traversing.js
+++ b/test/api.traversing.js
@@ -207,6 +207,15 @@ describe('$(...)', function() {
       var result = $('#food', food).parents();
       expect(result).to.have.length(0);
     });
+    it('() : should return the parents of every element in the *reveresed* collection, omitting duplicates', function() {
+      var $food = $(food);
+      var $parents = $food.find('li').parents();
+
+      expect($parents).to.have.length(3);
+      expect($parents[0]).to.be($food.find('#vegetables')[0]);
+      expect($parents[1]).to.be($food[0]);
+      expect($parents[2]).to.be($food.find('#fruits')[0]);
+    });
   });
 
   describe('.parent', function() {


### PR DESCRIPTION
To do this more efficiently, I've modified the internal `traverseParents` function. This should resolve issue #317.
