### PR TITLE
Run CI against Node v0.11 as an allowed failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,8 @@ node_js:
   - 0.6
   - 0.8
   - "0.10"
+  - 0.11
+matrix:
+  fast_finish: true
+  allow_failures:
+    - node_js: 0.11


### PR DESCRIPTION
Building against the latest unstable release of Node.js should help the
project stay on top of any bugs or breaking changes to the platform.
Specifying that build as an allowed failure guarantees that unforeseen
errors do not block ongoing work.
