### PR TITLE
Use CSSselect library directly

### DIFF
--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -1,5 +1,5 @@
 var _ = require('underscore'),
-    select = require('cheerio-select'),
+    select = require('CSSselect'),
     utils = require('../utils'),
     isTag = utils.isTag;
 
@@ -151,7 +151,7 @@ var filter = exports.filter = function(match) {
 
   if (_.isString(match)) {
     filterFn = function(el) {
-      return select(match, el)[0] === el;
+      return select(match, [el])[0] === el;
     };
   } else if (_.isFunction(match)) {
     filterFn = function(el, i) {

--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -3,7 +3,6 @@
 */
 
 var path = require('path'),
-    select = require('cheerio-select'),
     parse = require('./parse'),
     evaluate = parse.evaluate,
     updateDOM = parse.update,

--- a/lib/static.js
+++ b/lib/static.js
@@ -2,7 +2,7 @@
  * Module dependencies
  */
 
-var select = require('cheerio-select'),
+var select = require('CSSselect'),
     parse = require('./parse'),
     render = require('./render'),
     decode = require('./utils').decode;

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "node": ">= 0.6"
   },
   "dependencies": {
-    "cheerio-select": "*",
     "htmlparser2": "~3.3.0",
     "underscore": "~1.4",
-    "entities": "0.x"
+    "entities": "0.x",
+    "CSSselect": "~0.3.11"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
@MatthewMueller I may be misinterpreting the goal of cheerio-select, but it seems unnecessary.

Commit message:

> The "cheerio-select" library does not offer additional functionality,
> serving as a simple wrapper around the "CSSselect" library. Its
> inclusion in Cheerio it makes the project:
> - More difficult to understand (contributors must read through that
>   library's source before recognizing CSS selector bugs originate from
>   CSSselect)
> - Less efficient (it introduces an additional function call and
>   processing overhead)
> - More difficult to maintain (CSSselect releases must first be approved
>   by "cheerio-select" before they can reach Cheerio itself)
