### PR TITLE
Replace the `utils.decode` and `utils.encode` with the underscore's html escape/unescape function

### DIFF
--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -1,8 +1,6 @@
 var _ = require('underscore'),
   utils = require('../utils'),
   isTag = utils.isTag,
-  decode = utils.decode,
-  encode = utils.encode,
   hasOwn = Object.prototype.hasOwnProperty,
   rspace = /\s+/,
 
@@ -26,7 +24,7 @@ var setAttr = function(el, name, value) {
   if (value === null) {
     removeAttribute(el, name);
   } else {
-    el.attribs[name] = encode(value);
+    el.attribs[name] = _.escape(value);
   }
 
   return el.attribs;
@@ -56,25 +54,25 @@ var attr = exports.attr = function(name, value) {
   // Return the entire attribs object if no attribute specified
   if (!name) {
     for (var a in elem.attribs) {
-      elem.attribs[a] = decode(elem.attribs[a]);
+      elem.attribs[a] = _.unescape(elem.attribs[a]);
     }
     return elem.attribs;
   }
 
   if (hasOwn.call(elem.attribs, name)) {
-    // Get the (decoded) attribute
-    return decode(elem.attribs[name]);
+    // Get the (_.unescaped) attribute
+    return _.unescape(elem.attribs[name]);
   }
 };
 
 var setData = function(el, name, value) {
   if (typeof name === 'object') return _.extend(el.data, name);
   if (typeof name === 'string' && value !== undefined) {
-    el.data[name] = encode(value);
+    el.data[name] = _.escape(value);
   } else if (typeof name === 'object') {
     // If its an object, loop through it
     _.each(name, function(value, key) {
-      el.data[key] = encode(value);
+      el.data[key] = _.escape(value);
     });
   }
 
@@ -94,7 +92,7 @@ var data = exports.data = function(name, value) {
   if (!name) {
 
     _.each(elem.data, function(value, key) {
-      elem.data[key] = decode(value);
+      elem.data[key] = _.unescape(value);
     });
 
     return elem.data;
@@ -107,8 +105,8 @@ var data = exports.data = function(name, value) {
     });
     return this;
   } else if (hasOwn.call(elem.data, name)) {
-    // Get the (decoded) data
-    var val = decode(elem.data[name]);
+    // Get the (_.unescaped) data
+    var val = _.unescape(elem.data[name]);
 
     if (hasOwn.call(primitives, val)) {
       val = primitives[val];

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -3,7 +3,6 @@ var _ = require('underscore'),
     $ = require('../static'),
     updateDOM = parse.update,
     evaluate = parse.evaluate,
-    encode = require('../utils').encode,
     slice = Array.prototype.slice;
 
 // Create an array of nodes, recursing into arrays and parsing strings if
@@ -188,7 +187,7 @@ var text = exports.text = function(str) {
   }
 
   var elem = {
-    data: encode(str),
+    data: _.escape(str),
     type: 'text',
     parent: null,
     prev: null,

--- a/lib/render.js
+++ b/lib/render.js
@@ -2,10 +2,6 @@
   Module dependencies
 */
 var _ = require('underscore');
-var utils = require('./utils');
-
-var decode = utils.decode;
-var encode = utils.encode;
 
 /*
   Boolean Attributes
@@ -27,7 +23,7 @@ var formatAttrs = function(attributes) {
     if (!value && (rboolean.test(key) || key === '/')) {
       output.push(key);
     } else {
-      output.push(key + '="' + encode(decode(value)) + '"');
+      output.push(key + '="' + _.escape(_.unescape(value)) + '"');
     }
   }
 

--- a/lib/static.js
+++ b/lib/static.js
@@ -2,10 +2,10 @@
  * Module dependencies
  */
 
-var select = require('CSSselect'),
+var _ = require('underscore'),
+    select = require('CSSselect'),
     parse = require('./parse'),
-    render = require('./render'),
-    decode = require('./utils').decode;
+    render = require('./render');
 
 /**
  * $.load(str)
@@ -71,7 +71,7 @@ var text = exports.text = function(elems) {
 
   for (var i = 0; i < len; i ++) {
     elem = elems[i];
-    if (elem.type === 'text') ret += decode(elem.data);
+    if (elem.type === 'text') ret += _.escape(elem.data);
     else if (elem.children && elem.type !== 'comment') {
       ret += text(elem.children);
     }


### PR DESCRIPTION
Replace the `utils.decode` and `utils.encode` with the underscore's html escape/unescape function. Much faster and more stable.

For example, when a tag's attribute contains Chinese characters, the `$.html()` will produce unexpected value.

```
cheerio = require('cheerio');
$ = cheerio.load('<div title="你好世界"></div>');

console.log($.html());
// Result: '<div title="&#20320;&#22909;&#19990;&#30028;"></div>'
```

The result `&#20320;&#22909;&#19990;&#30028;` is not what it expected to be. You should only escape html special chars in attributes, such as these `<>"&';` , not all utf-8 chars.
