### PR TITLE
Remove extraneous call to `_.uniq`

### DIFF
--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -4,10 +4,7 @@ var _ = require('underscore'),
     isTag = utils.isTag;
 
 var find = exports.find = function(selector) {
-  // TODO: Remove the call to _.uniq when the underlying bug in CSSselect has
-  // been resolved:
-  // https://github.com/fb55/CSSselect/issues/12
-  return this.make(_.uniq(select(selector, [].slice.call(this.children()))));
+  return this.make(select(selector, [].slice.call(this.children())));
 };
 
 // Get the parent of each element in the current set of matched elements,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "htmlparser2": "~3.3.0",
     "underscore": "~1.4",
     "entities": "0.x",
-    "CSSselect": "~0.3.11"
+    "CSSselect": "~0.4.0"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
This call served as a guard against a bug in the CSSselect library. [That bug has been fixed in the latest version of the library](https://github.com/fb55/CSSselect/pull/15), so it may be removed.
