### PR TITLE
Rename `Cheerio#make` to document private status

### DIFF
--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -151,7 +151,7 @@ var val = exports.val = function(value) {
           parentEl = this.closest('form');
           if (parentEl.length === 0) {
             root = (this.parents().last()[0] || this[0]).parent;
-            parentEl = this.make(root);
+            parentEl = this._make(root);
           }
 
           if (querying) {
@@ -252,7 +252,7 @@ var addClass = exports.addClass = function(value) {
 
 
   for (var i = 0; i < numElements; i++) {
-    $elem = this.make(this[i]);
+    $elem = this._make(this[i]);
     // If selected element isnt a tag, move on
     if (!isTag(this[i])) continue;
 
@@ -319,7 +319,7 @@ var toggleClass = exports.toggleClass = function(value, stateVal) {
     state;
 
   for (var i = 0; i < numElements; i++) {
-    $elem = this.make(this[i]);
+    $elem = this._make(this[i]);
     // If selected element isnt a tag, move on
     if (!isTag(this[i])) continue;
 

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -208,5 +208,5 @@ var text = exports.text = function(str) {
 var clone = exports.clone = function() {
   // Turn it into HTML, then recreate it,
   // Seems to be the easiest way to reconnect everything correctly
-  return this.make($.html(this));
+  return this._make($.html(this));
 };

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -4,7 +4,7 @@ var _ = require('underscore'),
     isTag = utils.isTag;
 
 var find = exports.find = function(selector) {
-  return this.make(select(selector, [].slice.call(this.children())));
+  return this._make(select(selector, [].slice.call(this.children())));
 };
 
 // Get the parent of each element in the current set of matched elements,
@@ -20,7 +20,7 @@ var parent = exports.parent = function(selector) {
     }
   });
 
-  $set = this.make(set);
+  $set = this._make(set);
 
   if (arguments.length) {
     $set = $set.filter(selector);
@@ -45,7 +45,7 @@ var parents = exports.parents = function(selector) {
     );
   }, this);
 
-  return this.make(parentNodes);
+  return this._make(parentNodes);
 };
 
 // For each element in the set, get the first element that matches the selector
@@ -55,7 +55,7 @@ var closest = exports.closest = function(selector) {
   var set = [];
 
   if (!selector) {
-    return this.make(set);
+    return this._make(set);
   }
 
   this.each(function(idx, elem) {
@@ -67,35 +67,35 @@ var closest = exports.closest = function(selector) {
     }
   }.bind(this));
 
-  return this.make(set);
+  return this._make(set);
 };
 
 var next = exports.next = function() {
   if (!this[0]) { return this; }
   var elem = this[0];
-  while ((elem = elem.next)) if (isTag(elem)) return this.make(elem);
-  return this.make([]);
+  while ((elem = elem.next)) if (isTag(elem)) return this._make(elem);
+  return this._make([]);
 };
 
 var nextAll = exports.nextAll = function(selector) {
   if (!this[0]) { return this; }
   var elems = [], elem = this[0];
   while ((elem = elem.next)) if (isTag(elem)) elems.push(elem);
-  return this.make(selector ? select(selector, elems) : elems);
+  return this._make(selector ? select(selector, elems) : elems);
 };
 
 var prev = exports.prev = function() {
   if (!this[0]) { return this; }
   var elem = this[0];
-  while ((elem = elem.prev)) if (isTag(elem)) return this.make(elem);
-  return this.make([]);
+  while ((elem = elem.prev)) if (isTag(elem)) return this._make(elem);
+  return this._make([]);
 };
 
 var prevAll = exports.prevAll = function(selector) {
   if (!this[0]) { return this; }
   var elems = [], elem = this[0];
   while ((elem = elem.prev)) if (isTag(elem)) elems.push(elem);
-  return this.make(selector ? select(selector, elems) : elems);
+  return this._make(selector ? select(selector, elems) : elems);
 };
 
 var siblings = exports.siblings = function(selector) {
@@ -105,9 +105,9 @@ var siblings = exports.siblings = function(selector) {
     this
   );
   if (selector !== undefined) {
-    elems = this.make(select(selector, elems));
+    elems = this._make(select(selector, elems));
   }
-  return this.make(elems);
+  return this._make(elems);
 };
 
 var children = exports.children = function(selector) {
@@ -116,14 +116,14 @@ var children = exports.children = function(selector) {
     return memo.concat(_.filter(elem.children, isTag));
   }, []);
 
-  if (selector === undefined) return this.make(elems);
-  else if (_.isNumber(selector)) return this.make(elems[selector]);
+  if (selector === undefined) return this._make(elems);
+  else if (_.isNumber(selector)) return this._make(elems[selector]);
 
-  return this.make(elems).filter(selector);
+  return this._make(elems).filter(selector);
 };
 
 var contents = exports.contents = function() {
-  return this.make(_.reduce(this, function(all, elem) {
+  return this._make(_.reduce(this, function(all, elem) {
     all.push.apply(all, elem.children);
     return all;
   }, []));
@@ -131,19 +131,19 @@ var contents = exports.contents = function() {
 
 var each = exports.each = function(fn) {
   var i = 0, len = this.length;
-  while (i < len && fn.call(this.make(this[i]), i, this[i]) !== false) ++i;
+  while (i < len && fn.call(this._make(this[i]), i, this[i]) !== false) ++i;
   return this;
 };
 
 var map = exports.map = function(fn) {
-  return this.make(_.reduce(this, function(memo, el, i) {
+  return this._make(_.reduce(this, function(memo, el, i) {
     var val = fn.call(el, i, el);
     return val == null ? memo : memo.concat(val);
   }, []));
 };
 
 var filter = exports.filter = function(match) {
-  var make = _.bind(this.make, this);
+  var make = _.bind(this._make, this);
   var filterFn;
 
   if (_.isString(match)) {
@@ -166,28 +166,28 @@ var filter = exports.filter = function(match) {
 };
 
 var first = exports.first = function() {
-  return this[0] ? this.make(this[0]) : this;
+  return this[0] ? this._make(this[0]) : this;
 };
 
 var last = exports.last = function() {
-  return this[0] ? this.make(this[this.length - 1]) : this;
+  return this[0] ? this._make(this[this.length - 1]) : this;
 };
 
 // Reduce the set of matched elements to the one at the specified index.
 var eq = exports.eq = function(i) {
   i = +i;
   if (i < 0) i = this.length + i;
-  return this[i] ? this.make(this[i]) : this.make([]);
+  return this[i] ? this._make(this[i]) : this._make([]);
 };
 
 var slice = exports.slice = function() {
-  return this.make([].slice.apply(this, arguments));
+  return this._make([].slice.apply(this, arguments));
 };
 
 function traverseParents(self, elem, selector, limit) {
   var elems = [];
   while (elems.length < limit && elem.type !== 'root') {
-    if (!selector || self.make(elem).filter(selector).length) {
+    if (!selector || self._make(elem).filter(selector).length) {
       elems.push(elem);
     }
     elem = elem.parent;
@@ -198,5 +198,5 @@ function traverseParents(self, elem, selector, limit) {
 // End the most recent filtering operation in the current chain and return the
 // set of matched elements to its previous state.
 var end = exports.end = function() {
-  return this.prevObject || this.make([]);
+  return this.prevObject || this._make([]);
 };

--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -125,9 +125,11 @@ var isHtml = function(str) {
 
 /*
  * Make a cheerio object
+ *
+ * @api private
  */
 
-Cheerio.prototype.make = function(dom) {
+Cheerio.prototype._make = function(dom) {
   var cheerio = new Cheerio(dom);
   cheerio.prevObject = this;
   return cheerio;


### PR DESCRIPTION
The confusion in issue #329 made me realize that `Cheerio#make` is a private method that violates the project's naming conventions.

Commit message:

> `Cheerio.prototype.make` is a method intended for internal use only. It
> is attached to the prototype for ease-of-use, as recommended by the
> project's style guide. In order to prevent confusion, this method's name
> should be prefixed with an underscore ("_") character.
