### PR TITLE
Initial browserify support

### DIFF
--- a/index.browser.js
+++ b/index.browser.js
@@ -1,0 +1,12 @@
+/**
+ * Export cheerio (with )
+ */
+
+exports = require('./lib/cheerio');
+
+/*
+  Export the version
+*/
+
+// Browserify currently requires the .json extension.
+exports.version = require('./package.json').version;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "url": "git://github.com/MatthewMueller/cheerio.git"
   },
   "main": "./index.js",
+  "browser": "./index.browser.js",
   "engines": {
     "node": ">= 0.6"
   },


### PR DESCRIPTION
Initial stab at #268.

Depends on fb55/node-entities#12, as well as fb55/CSSselect#16.
