### PR TITLE
Add regression test for `children` filtering

### DIFF
--- a/test/api.traversing.js
+++ b/test/api.traversing.js
@@ -66,7 +66,9 @@ describe('$(...)', function() {
       expect($('ul', fruits).children('.lulz')).to.have.length(0);
     });
 
-    it('should only match immediate children, not ancestors');
+    it('should only match immediate children, not ancestors', function() {
+      expect($(food).children('li')).to.have.length(0);
+    });
 
   });
 


### PR DESCRIPTION
This test confirms that the bug described in issue #17 is no longer present (and helps prevent future regressions).

Commit message:

> The filtering bug in the `children` method was indirectly resolved by
> commit 0464dd8b870e5b2cf04b934d8e79ae5e928a1c6f .
