### PR TITLE
Document new branching strategy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,9 @@ how we'd like to work with you:
        commit message
 3. Open a pull request, and reference the initial issue in the pull request
    message.
+    - If your patch **fixes a bug**, file it against the `master` branch.
+    - If your patch **adds new functionality** or **introduces a
+      backwards-breaking change**, file it against the `dev` branch.
 
 # Documentation
 


### PR DESCRIPTION
It's been a while since we last published a release, but since `master` currently contains bug fixes _and_ feature additions, our next release will require a minor version increase. With a slightly more complex branching strategy, we can "queue" feature additions until we've collected enough to warrant a minor version release, but we can still publish new patch versions after every bug fix.

@MatthewMueller @fb55 @davidchambers It's easy to change the `CONTRIBUTING.md` file, but I don't expect many contributors will likely know to follow this guideline. This means we'll all have to be in agreement around this--it will likely entail either:
1. Manually merging incorrectly-filed pull requests via the command line
2. Asking contributors to re-create incorrectly-filed pull requests

That seems worth it to me. What do you think?

Commit message:

> Reserving the `master` branch exclusively for bug fixes will allow for
> more frequent patch releases.
