### PR TITLE
Fix bugs in "next*" and "prev*" methods

### DIFF
--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -148,8 +148,16 @@ var prev = exports.prev = function() {
 
 var prevAll = exports.prevAll = function(selector) {
   if (!this[0]) { return this; }
-  var elems = [], elem = this[0];
-  while ((elem = elem.prev)) if (isTag(elem)) elems.push(elem);
+  var elems = [];
+
+  _.forEach(this, function(elem) {
+    while ((elem = elem.prev)) {
+      if (isTag(elem) && elems.indexOf(elem) === -1) {
+        elems.push(elem);
+      }
+    }
+  });
+
   return this._make(selector ? select(selector, elems) : elems);
 };
 

--- a/test/api.traversing.js
+++ b/test/api.traversing.js
@@ -240,6 +240,15 @@ describe('$(...)', function() {
       expect($('.banana', fruits).prevAll()).to.have.length(0);
     });
 
+    it('() : should operate over all elements in the selection', function() {
+      expect($('.orange, .sweetcorn', food).prevAll()).to.have.length(2);
+    });
+
+    it('() : should not contain duplicate elements', function() {
+      var elems = $('.orange, .pear', food);
+      expect(elems.prevAll()).to.have.length(2);
+    });
+
   });
 
   describe('.prevUntil', function() {


### PR DESCRIPTION
The traversal methods `next`, `nextAll`, `nextUntil`, `prev`, `prevAll`, `prevUntil` should all operate over every node in the selection.
