### PR TITLE
Remove "root" node

### DIFF
--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -150,7 +150,7 @@ var val = exports.val = function(value) {
           // Go up until we hit a form or root
           parentEl = this.closest('form');
           if (parentEl.length === 0) {
-            root = (this.parents().last()[0] || this[0]).parent;
+            root = (this.parents().last()[0] || this[0]).root;
             parentEl = this._make(root);
           }
 

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -49,7 +49,8 @@ var after = exports.after = function() {
       dom = makeDomArray(elems);
 
   this.each(function(i, el) {
-    var siblings = el.parent.children,
+    var parent = el.parent || el.root,
+        siblings = parent.children,
         index = siblings.indexOf(el);
 
     // If not found, move on
@@ -63,8 +64,8 @@ var after = exports.after = function() {
     siblings.splice.apply(siblings, [++index, 0].concat(dom));
 
     // Update next, prev, and parent pointers
-    updateDOM(siblings, el.parent);
-    el.parent.children = siblings;
+    updateDOM(siblings, parent);
+    parent.children = siblings;
 
   });
 
@@ -76,7 +77,8 @@ var before = exports.before = function() {
       dom = makeDomArray(elems);
 
   this.each(function(i, el) {
-    var siblings = el.parent.children,
+    var parent = el.parent || el.root,
+        siblings = parent.children,
         index = siblings.indexOf(el);
 
     // If not found, move on
@@ -90,8 +92,8 @@ var before = exports.before = function() {
     siblings.splice.apply(siblings, [index, 0].concat(dom));
 
     // Update next, prev, and parent pointers
-    updateDOM(siblings, el.parent);
-    el.parent.children = siblings;
+    updateDOM(siblings, parent);
+    parent.children = siblings;
 
   });
 
@@ -109,7 +111,8 @@ var remove = exports.remove = function(selector) {
     elems = elems.filter(selector);
 
   elems.each(function(i, el) {
-    var siblings = el.parent.children,
+    var parent = el.parent || el.root,
+        siblings = parent.children,
         index = siblings.indexOf(el);
 
     if (!~index) return;
@@ -117,8 +120,8 @@ var remove = exports.remove = function(selector) {
     siblings.splice(index, 1);
 
     // Update next, prev, and parent pointers
-    updateDOM(siblings, el.parent);
-    el.parent.children = siblings;
+    updateDOM(siblings, parent);
+    parent.children = siblings;
   });
 
   return this;
@@ -128,8 +131,8 @@ var replaceWith = exports.replaceWith = function(content) {
   var dom = makeDomArray(content);
 
   this.each(function(i, el) {
-    var siblings = el.parent.children,
-        parent = el.parent,
+    var parent = el.parent || el.root,
+        siblings = parent.children,
         index;
 
     if (_.isFunction(content)) {

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -15,7 +15,7 @@ var parent = exports.parent = function(selector) {
 
   this.each(function(idx, elem) {
     var parentElem = elem.parent;
-    if (set.indexOf(parentElem) < 0 && parentElem.type !== 'root') {
+    if (parentElem && set.indexOf(parentElem) < 0) {
       set.push(parentElem);
     }
   });
@@ -236,7 +236,7 @@ var slice = exports.slice = function() {
 
 function traverseParents(self, elem, selector, limit) {
   var elems = [];
-  while (elems.length < limit && elem.type !== 'root') {
+  while (elem && elems.length < limit) {
     if (!selector || self._make(elem).filter(selector).length) {
       elems.push(elem);
     }

--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -5,7 +5,6 @@
 var path = require('path'),
     parse = require('./parse'),
     evaluate = parse.evaluate,
-    updateDOM = parse.update,
     _ = require('underscore');
 
 /*

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -74,7 +74,14 @@ var update = exports.update = function(arr, parent) {
 
     node.prev = arr[i - 1] || null;
     node.next = arr[i + 1] || null;
-    node.parent = parent;
+
+    if (parent && parent.type === 'root') {
+      node.root = parent;
+      node.parent = null;
+    } else {
+      delete node.root;
+      node.parent = parent;
+    }
   }
 
   return parent;

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -127,6 +127,11 @@ describe('cheerio', function() {
     expect($a[0].children[0].data).to.equal('Save');
   });
 
+  it('should not create a top-level node', function() {
+    var $elem = $('* div', '<div>');
+    expect($elem).to.have.length(0);
+  });
+
   it('should be able to select multiple elements: $(".apple, #fruits")', function() {
     var $elems = $('.apple, #fruits', fruits);
     expect($elems).to.have.length(2);

--- a/test/parse.js
+++ b/test/parse.js
@@ -158,7 +158,7 @@ describe('parse', function() {
       expect(root.parent).to.be(null);
 
       var child = root.children[0];
-      expect(child.parent).to.equal(root);
+      expect(child.parent).to.be(null);
     }
 
     it('should add root to: ' + basic, function() {
@@ -174,7 +174,7 @@ describe('parse', function() {
       expect(root.children).to.have.length(2);
       expect(root.children[0].name).to.equal('h2');
       expect(root.children[1].name).to.equal('p');
-      expect(root.children[1].parent.name).to.equal('root');
+      expect(root.children[1].parent).to.equal(null);
     });
 
     it('should add root to: ' + comment, function() {


### PR DESCRIPTION
This should resolve issue #162. Note that I had to change some tests, but this was only necessary in those cases with explicit references to the `root` object.

Commit message:

> Cheerio uses a "root" object internally to collect parsed markup with
> multiple top-level nodes. This object is not itself a node, but
> modelling it as such can interfere with the parsing and traversing logic
> that Cheerio relies on.
> 
> Attach the "root" object via an API that is not recognized by the
> traversal logic so that it is not exposed through querying operations.
