### PR TITLE
Fix bug in Cheerio function

### DIFF
--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -49,7 +49,9 @@ var Cheerio = module.exports = function(selector, context, root) {
 
   // $([dom])
   if (Array.isArray(selector)) {
-    _.defaults(this, selector);
+    _.forEach(selector, function(elem, idx) {
+      this[idx] = elem;
+    }, this);
     this.length = selector.length;
     return this;
   }

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -32,6 +32,13 @@ describe('cheerio', function() {
     expect($('#fruits')).to.be.empty();
   });
 
+  it('$(node) : should override previously-loaded nodes', function() {
+    var C = $.load('<div><span></span></div>');
+    var spanNode = C('span')[0];
+    var $span = C(spanNode);
+    expect($span[0]).to.equal(spanNode);
+  });
+
   it('should be able to create html without a root or context', function() {
     var $h2 = $('<h2>');
     expect($h2).to.not.be.empty();


### PR DESCRIPTION
When used with a context set through the static `load` method, the
instance will already have numeric properties corresponding to the
originally-loaded nodes. These properties should be overwritten by the
elements passed to the Cheerio function in all cases.
