### PR TITLE
Accept one or more node references as a context

### DIFF
--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -74,6 +74,9 @@ var Cheerio = module.exports = function(selector, context, root) {
       selector = [context, selector].join(' ');
       context = this._root;
     }
+  // $('li', node), $('li', [nodes])
+  } else if (!context.cheerio) {
+    context = new Cheerio(context);
   }
 
   // If we still don't have a context, return

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -96,6 +96,16 @@ describe('cheerio', function() {
     expect(lis).to.have.length(3);
   });
 
+  it('should accept a node reference as a context', function() {
+    var $elems = $('<div><span></span></div>');
+    expect($('span', $elems[0])).to.have.length(1);
+  });
+
+  it('should accept an array of node references as a context', function() {
+    var $elems = $('<div><span></span></div>');
+    expect($('span', $elems.toArray())).to.have.length(1);
+  });
+
   it('should select only elements inside given context (Issue #193)', function() {
     var q = $.load(food),
         fruits = q('#fruits'),


### PR DESCRIPTION
From the jQuery API documentation on the `jQuery` function [1]:

> ## Using DOM elements
> 
> The second and third formulations of this function create a jQuery
> object using one or more DOM elements that were already selected in
> some other way.

[1] http://api.jquery.com/jQuery/#using-dom-elements
