### PR TITLE
Fix for underscore v1.4 causing an exception to be thrown

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "htmlparser2": "~3.4.0",
-    "underscore": "~1.5.3",
+    "underscore": "~1.5",
     "entities": "0.x",
     "CSSselect": "~0.4.0"
   },


### PR DESCRIPTION
This gist here was causing an exception to be thrown by cheerio using v1.4 of underscore: https://gist.github.com/2020steve/8211226

I updated the package.json file to underscore v~1.5 of underscore and that gist runs fine.
