### PR TITLE
Remove unecessary DOM maintenance logic

### DIFF
--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -65,8 +65,6 @@ var after = exports.after = function() {
 
     // Update next, prev, and parent pointers
     updateDOM(siblings, parent);
-    parent.children = siblings;
-
   });
 
   return this;
@@ -93,8 +91,6 @@ var before = exports.before = function() {
 
     // Update next, prev, and parent pointers
     updateDOM(siblings, parent);
-    parent.children = siblings;
-
   });
 
   return this;
@@ -121,7 +117,6 @@ var remove = exports.remove = function(selector) {
 
     // Update next, prev, and parent pointers
     updateDOM(siblings, parent);
-    parent.children = siblings;
   });
 
   return this;


### PR DESCRIPTION
This logic was incorporated into the `parse` module's `update` method in
commmit 973c8f44d56cd6051284eaaf83b3dc0d34ec2eaa.
