### PR TITLE
fix the encode issue  of  attribute's value

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -27,7 +27,7 @@ var formatAttrs = function(attributes) {
     if (!value && (rboolean.test(key) || key === '/')) {
       output.push(key);
     } else {
-      output.push(key + '="' + encode(decode(value)) + '"');
+      output.push(key + '="' + value + '"');
     }
   }
 


### PR DESCRIPTION
when the value of attribute has chinese character or 'ä' and so on，the
output of $.html() or $.xml() is not correct, the character of output is
convert just like  htmlentities.
