### PR TITLE
Fix passing context as dom node

### DIFF
--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -44,7 +44,7 @@ var Cheerio = module.exports = function(selector, context, root) {
   if (selector.cheerio) return selector;
 
   // $(dom)
-  if (selector.name || selector.type === 'text' || selector.type === 'comment')
+  if (isNode(selector))
     selector = [selector];
 
   // $([dom])
@@ -74,7 +74,8 @@ var Cheerio = module.exports = function(selector, context, root) {
       selector = [context, selector].join(' ');
       context = this._root;
     }
-  }
+  } else if (isNode(context))
+    context = Cheerio.call(this, context);
 
   // If we still don't have a context, return
   if (!context) return this;
@@ -150,3 +151,7 @@ Cheerio.prototype.toArray = function() {
 api.forEach(function(mod) {
   _.extend(Cheerio.prototype, require('./api/' + mod));
 });
+
+var isNode = function(obj) {
+  return obj.name || obj.type === 'text' || obj.type === 'comment';
+};

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -70,6 +70,11 @@ describe('cheerio', function() {
     testAppleSelect($apple);
   });
 
+  it('should be able to select .apple with a node as context', function() {
+    var $apple = $('.apple', $(fruits)[0]);
+    testAppleSelect($apple);
+  });
+
   it('should be able to select .apple with only a root', function() {
     var $apple = $('.apple', null, fruits);
     testAppleSelect($apple);


### PR DESCRIPTION
Currently you can do this in JQuery:

```
var $div = $('<div><p></p></div')
$('p', $div[0])
```

But it throws in Cheerio. Fixed it.
