### PR TITLE
Fixed error that occurs when Cheerio context is a DOM element.

### DIFF
--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -25,6 +25,10 @@ var quickExpr = /^(?:[^#<]*(<[\w\W]+>)[^>]*$|#([\w\-]*)$)/;
 
 var $ = require('./static');
 
+var isDom = function(selector) {
+  return (selector.name || selector.type === 'text' || selector.type === 'comment');
+};
+
 /*
  * Instance of cheerio
  */
@@ -44,7 +48,7 @@ var Cheerio = module.exports = function(selector, context, root) {
   if (selector.cheerio) return selector;
 
   // $(dom)
-  if (selector.name || selector.type === 'text' || selector.type === 'comment')
+  if (isDom(selector))
     selector = [selector];
 
   // $([dom])
@@ -64,6 +68,8 @@ var Cheerio = module.exports = function(selector, context, root) {
   // If we don't have a context, maybe we have a root, from loading
   if (!context) {
     context = this._root;
+  } else if (isDom(context)) {
+    context = Cheerio.call(this, context);
   } else if (typeof context === 'string') {
     if (isHtml(context)) {
       // $('li', '<ul>...</ul>')


### PR DESCRIPTION
Hello,

I ran across an error that occurs when this bit of code is executed:

``` javascript
var cheerio = require("cheerio");
var $ = cheerio.load("<b>hey <i>everybody</i>!</b>");
$("b").map(function() { return $("i", this).text(); })
// Exception thrown -- TypeError: Object #<Object> has no method 'find'
```

Which is unfortunately because I feel the example above is fairly idiomatic jQuery.  I took a look at the code (which is very well factored!) and put together a possible fix.

Thanks for taking a look.
