### PR TITLE
Update to latest version of expect.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "mocha": "*",
-    "expect.js": "0.2",
+    "expect.js": "~0.3.1",
     "jshint": "~2.3.0",
     "benchmark": "~1.0.0",
     "jsdom": "~0.8.9"

--- a/test/api.attributes.js
+++ b/test/api.attributes.js
@@ -6,6 +6,7 @@ var vegetables = require('./fixtures').vegetables;
 var food = require('./fixtures').food;
 var chocolates = require('./fixtures').chocolates;
 var inputs = require('./fixtures').inputs;
+var toArray = Function.call.bind(Array.prototype.slice);
 
 describe('$(...)', function() {
 
@@ -321,7 +322,7 @@ describe('$(...)', function() {
       var toAdd = ['apple red', '', undefined];
 
       $fruits.addClass(function(idx, currentClass) {
-        args.push(arguments);
+        args.push(toArray(arguments));
         thisVals.push(this);
         return toAdd[idx];
       });
@@ -424,7 +425,7 @@ describe('$(...)', function() {
       var toAdd = ['apple red', '', undefined];
 
       $fruits.removeClass(function(idx, currentClass) {
-        args.push(arguments);
+        args.push(toArray(arguments));
         thisVals.push(this);
         return toAdd[idx];
       });

--- a/test/api.manipulation.js
+++ b/test/api.manipulation.js
@@ -1,6 +1,7 @@
 var expect = require('expect.js'),
     $ = require('../'),
-    fruits = require('./fixtures').fruits;
+    fruits = require('./fixtures').fruits,
+    toArray = Function.call.bind(Array.prototype.slice);
 
 describe('$(...)', function() {
 
@@ -54,7 +55,7 @@ describe('$(...)', function() {
       var thisValues = [];
 
       $fruits.append(function() {
-        args.push(arguments);
+        args.push(toArray(arguments));
         thisValues.push(this);
       });
 
@@ -182,7 +183,7 @@ describe('$(...)', function() {
       var thisValues = [];
 
       $fruits.prepend(function() {
-        args.push(arguments);
+        args.push(toArray(arguments));
         thisValues.push(this);
       });
 
@@ -302,7 +303,7 @@ describe('$(...)', function() {
       var thisValues = [];
 
       $fruits.after(function() {
-        args.push(arguments);
+        args.push(toArray(arguments));
         thisValues.push(this);
       });
 
@@ -406,7 +407,7 @@ describe('$(...)', function() {
       var thisValues = [];
 
       $fruits.before(function() {
-        args.push(arguments);
+        args.push(toArray(arguments));
         thisValues.push(this);
       });
 
@@ -537,7 +538,7 @@ describe('$(...)', function() {
       var thisValues = [];
 
       $fruits.children().replaceWith(function() {
-        args.push(arguments);
+        args.push(toArray(arguments));
         thisValues.push(this);
         return '<li class="first">';
       });

--- a/test/api.traversing.js
+++ b/test/api.traversing.js
@@ -532,7 +532,7 @@ describe('$(...)', function() {
       var thisVals = [];
 
       $fruits.map(function() {
-        args.push(arguments);
+        args.push(Array.prototype.slice.call(arguments));
         thisVals.push(this);
       });
 


### PR DESCRIPTION
In #350, @fb55 and I discovered that the latest version of `expect.js` (0.3.1) caused false positives in Cheerio's unit test suite. Worse, the generated error was causing Mocha to crash, so TravisCI was unaware that the build was failing. (Actually, you might say this was a good thing because the errors were false positives anyway. But I would argue with you :P)

This problem was introduced [when `expect.js` corrected the parameter order of its `eql` comparator](https://github.com/LearnBoost/expect.js/pull/56). This was a legitimate bug fix--it corrected semantics where (functionally speaking) order has no value.

Or it _should_ have no value. Actually, the comparison internal logic has a flaw which makes it non-reflexive. [I've submitted a patch against `expect.js` to remedy this](https://github.com/LearnBoost/expect.js/pull/102) and [a separate patch to Node.js](https://github.com/joyent/node/pull/7178) (since `expect.js`'s implementation is derived from there).

...but that has little significance to the problem in our test suite--an `arguments` object should never be considered equivalent to an Array instance. That's why I'm updating the tests to convert all `arguments` into Arrays before comparison.

As for Mocha: it was crashing while rendering string diffs for the errors generated by `expect.js`. [I've submitted a patch for that, too](https://github.com/visionmedia/mocha/pull/1140), but it shouldn't have any bearing on this change.

Commit message:

> In version 0.3, expect.js corrected the order of its `eql` assertion.
> This exposed several bugs in Cheerio's unit tests, where `aguments`
> objects were being tested for deep equality with Array instances.
