### PR TITLE
Correct arguments for 'replaceWith' callback

### DIFF
--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -165,7 +165,7 @@ var replaceWith = exports.replaceWith = function(content) {
         index;
 
     if (_.isFunction(content)) {
-      dom = makeDomArray(content.call(el, i));
+      dom = makeDomArray(content.call(el, i, el));
     }
 
     // In the case that `dom` contains nodes that already exist in other

--- a/test/api.manipulation.js
+++ b/test/api.manipulation.js
@@ -595,7 +595,11 @@ describe('$(...)', function() {
         return '<li class="first">';
       });
 
-      expect(args).to.eql([[0], [1], [2]]);
+      expect(args).to.eql([
+        [0, origChildren[0]],
+        [1, origChildren[1]],
+        [2, origChildren[2]]
+      ]);
       expect(thisValues).to.eql([
         origChildren[0],
         origChildren[1],


### PR DESCRIPTION
This should resolve #409

Commit message:

> Ensure that when `replaceWith` is invoked with a function, that function
> is invoked with both the iteration index _and_ element.
