### PR TITLE
.replaceWith now replaces all selected elements.

### DIFF
--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -157,16 +157,11 @@ var remove = exports.remove = function(selector) {
 };
 
 var replaceWith = exports.replaceWith = function(content) {
-  var dom = makeDomArray(content);
-
   domEach(this, function(i, el) {
     var parent = el.parent || el.root,
         siblings = parent.children,
+        dom = makeDomArray(_.isFunction(content) ? content.call(el, i, el) : content),
         index;
-
-    if (_.isFunction(content)) {
-      dom = makeDomArray(content.call(el, i, el));
-    }
 
     // In the case that `dom` contains nodes that already exist in other
     // structures, ensure those nodes are properly removed.

--- a/test/api.manipulation.js
+++ b/test/api.manipulation.js
@@ -583,6 +583,13 @@ describe('$(...)', function() {
       expect($.html($src)).to.equal('<h2>hi <div>here</div></h2>');
     });
 
+    it('(str) : should replace all selected elements', function() {
+      var $src = $('<b>a<br>b<br>c<br>d</b>');
+      var $replaced = $src.find('br').replaceWith(' ');
+      expect($replaced[0].parent).to.equal(null);
+      expect($.html($src)).to.equal('<b>a b c d</b>');
+    });
+
     it('(fn) : should invoke the callback with the correct argument and context', function() {
       var $fruits = $(fruits);
       var origChildren = $fruits.children().toArray();


### PR DESCRIPTION
Currently `.replaceWith` only replaces the last selected element (#368).  This change ensures that all selected elements are replaced like jquery's `.replaceWith`.
