### PR TITLE
Optimize manipulation methods

### DIFF
--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -31,13 +31,11 @@ var _insert = function(concatenator) {
     if (_.isFunction(elems[0])) {
       return this.each(function(i, el) {
         dom = makeDomArray(elems[0].call(el, i, this.html()));
-        concatenator(dom, el.children);
-        updateDOM(el.children, el);
+        concatenator(dom, el.children, el);
       });
     } else {
       return domEach(this, function(i, el) {
-        concatenator(dom, el.children);
-        updateDOM(el.children, el);
+        concatenator(dom, el.children, el);
       });
     }
   };
@@ -54,28 +52,46 @@ var _insert = function(concatenator) {
  *
  * @api private
  */
-var uniqueSplice = function(array, spliceIdx, spliceCount, newElems) {
-  var spliceArgs = [spliceIdx, spliceCount].concat(newElems);
-  var idx, len, prevIdx;
+var uniqueSplice = function(array, spliceIdx, spliceCount, newElems, parent) {
+  var spliceArgs = [spliceIdx, spliceCount].concat(newElems),
+      prev = array[spliceIdx - 1] || null,
+      next = array[spliceIdx] || null;
+  var idx, len, prevIdx, node;
 
   // Before splicing in new elements, ensure they do not already appear in the
   // current array.
   for (idx = 0, len = newElems.length; idx < len; ++idx) {
-    prevIdx = array.indexOf(newElems[idx]);
-    if (prevIdx > -1) {
+    node = newElems[idx];
+    prevIdx = node.parent && array.indexOf(newElems[idx]);
+
+    if (node.parent && prevIdx > -1) {
       array.splice(prevIdx, 1);
+      if (spliceIdx > prevIdx) {
+        spliceArgs[0]--;
+      }
     }
+
+    node.parent = parent;
+    node.prev = newElems[idx - 1] || prev;
+    node.next = newElems[idx + 1] || next;
+  }
+
+  if (prev) {
+    prev.next = newElems[0];
+  }
+  if (next) {
+    next.prev = newElems[newElems.length - 1];
   }
 
   return array.splice.apply(array, spliceArgs);
 };
 
-var append = exports.append = _insert(function(dom, children) {
-  uniqueSplice(children, children.length, 0, dom);
+var append = exports.append = _insert(function(dom, children, parent) {
+  uniqueSplice(children, children.length, 0, dom, parent);
 });
 
-var prepend = exports.prepend = _insert(function(dom, children) {
-  uniqueSplice(children, 0, 0, dom);
+var prepend = exports.prepend = _insert(function(dom, children, parent) {
+  uniqueSplice(children, 0, 0, dom, parent);
 });
 
 var after = exports.after = function() {
@@ -95,10 +111,7 @@ var after = exports.after = function() {
     }
 
     // Add element after `this` element
-    uniqueSplice(siblings, ++index, 0, dom);
-
-    // Update next, prev, and parent pointers
-    updateDOM(siblings, parent);
+    uniqueSplice(siblings, ++index, 0, dom, parent);
   });
 
   return this;
@@ -121,10 +134,7 @@ var before = exports.before = function() {
     }
 
     // Add element before `el` element
-    uniqueSplice(siblings, index, 0, dom);
-
-    // Update next, prev, and parent pointers
-    updateDOM(siblings, parent);
+    uniqueSplice(siblings, index, 0, dom, parent);
   });
 
   return this;
@@ -147,10 +157,15 @@ var remove = exports.remove = function(selector) {
 
     if (!~index) return;
 
-    siblings.splice(index, 1);
 
-    // Update next, prev, and parent pointers
-    updateDOM(siblings, parent);
+    siblings.splice(index, 1);
+    if (el.prev) {
+      el.prev.next = el.next;
+    }
+    if (el.next) {
+      el.next.prev = el.prev;
+    }
+    el.prev = el.next = el.parent = null;
   });
 
   return this;
@@ -170,10 +185,8 @@ var replaceWith = exports.replaceWith = function(content) {
     index = siblings.indexOf(el);
 
     // Completely remove old element
-    siblings.splice.apply(siblings, [index, 1].concat(dom));
+    uniqueSplice(siblings, index, 1, dom, parent);
     el.parent = el.prev = el.next = null;
-
-    updateDOM(siblings, parent);
   });
 
   return this;
@@ -181,6 +194,10 @@ var replaceWith = exports.replaceWith = function(content) {
 
 var empty = exports.empty = function() {
   domEach(this, function(i, el) {
+    _.each(el.children, function(el) {
+      el.next = el.prev = el.parent = null;
+    });
+
     el.children = [];
   });
   return this;
@@ -198,8 +215,11 @@ var html = exports.html = function(str) {
   str = str.cheerio ? str.toArray() : evaluate(str);
 
   domEach(this, function(i, el) {
-    el.children = str;
-    updateDOM(el.children, el);
+    _.each(el.children, function(el) {
+      el.next = el.prev = el.parent = null;
+    });
+
+    updateDOM(str, el);
   });
 
   return this;
@@ -231,8 +251,11 @@ var text = exports.text = function(str) {
 
   // Append text node to each selected elements
   domEach(this, function(i, el) {
-    el.children = elem;
-    updateDOM(el.children, el);
+    _.each(el.children, function(el) {
+      el.next = el.prev = el.parent = null;
+    });
+
+    updateDOM(elem, el);
   });
 
   return this;

--- a/test/api.manipulation.js
+++ b/test/api.manipulation.js
@@ -647,13 +647,28 @@ describe('$(...)', function() {
   });
 
   describe('.empty', function() {
-
     it('() : should remove all children from selected elements', function() {
       var $fruits = $(fruits);
-      $('#fruits', $fruits).empty();
-      expect($('#fruits', $fruits).children()).to.have.length(0);
+      expect($fruits.children()).to.have.length(3);
+
+      $fruits.empty();
+      expect($fruits.children()).to.have.length(0);
     });
 
+    it('() : should allow element reinsertion', function() {
+      var $fruits = $(fruits),
+          $children = $fruits.children();
+
+      $fruits.empty();
+      expect($fruits.children()).to.have.length(0);
+      expect($children).to.have.length(3);
+
+      $fruits.append($('<div></div><div></div>'));
+      var $remove = $fruits.children().eq(0),
+          $keep = $fruits.children().eq(1);
+      $remove.replaceWith($children);
+      expect($fruits.children()).to.have.length(4);
+    });
   });
 
   describe('.html', function() {
@@ -691,6 +706,18 @@ describe('$(...)', function() {
       expect(html).to.equal('<li class="durian">Durian</li>');
     });
 
+    it('() : should allow element reinsertion', function() {
+      var $fruits = $(fruits),
+          $children = $fruits.children();
+
+      $fruits.html('<div></div><div></div>');
+      expect($fruits.children()).to.have.length(2);
+
+      var $remove = $fruits.children().eq(0),
+          $keep = $fruits.children().eq(1);
+      $remove.replaceWith($children);
+      expect($fruits.children()).to.have.length(4);
+    });
   });
 
   describe('.toString', function() {


### PR DESCRIPTION
Does reduce empty performance but this is due to a bug fix that caused replaceWith to corrupt the siblings object on reinsert.

Test: manipulation - append (file: jquery.html)
  cheerio x 4,579 ops/sec ±18.36% (57 runs sampled)
  old x 1,692 ops/sec ±13.21% (39 runs sampled)
  Fastest: cheerio

Test: manipulation - prepend (file: jquery.html)
  cheerio x 2,886 ops/sec ±35.24% (39 runs sampled)
  old x 1,627 ops/sec ±19.80% (26 runs sampled)
  Fastest: cheerio

Test: manipulation - after (file: jquery.html)
  cheerio x 2,383 ops/sec ±53.63% (39 runs sampled)
  old x 1,569 ops/sec ±29.27% (33 runs sampled)
  Fastest: cheerio

Test: manipulation - before (file: jquery.html)
  cheerio x 2,547 ops/sec ±64.05% (43 runs sampled)
  old x 1,682 ops/sec ±22.53% (35 runs sampled)
  Fastest: cheerio

Test: manipulation - remove (file: jquery.html)
  cheerio x 48,693 ops/sec ±4.05% (81 runs sampled)
  old x 32,029 ops/sec ±41.81% (68 runs sampled)
  Fastest: cheerio

Test: manipulation - replaceWith (file: jquery.html)
  cheerio x 345 ops/sec ±3.95% (75 runs sampled)
  old x 303 ops/sec ±5.46% (74 runs sampled)
  Fastest: cheerio

Test: manipulation - empty (file: jquery.html)
  cheerio x 80,074 ops/sec ±5.88% (78 runs sampled)
  old x 265,760 ops/sec ±9.57% (68 runs sampled)
  Fastest: cheerio
