### PR TITLE
Ignore benchmark folder

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+benchmark/
 src/
 support/
 tests/


### PR DESCRIPTION
Ignore benchmark folder when installing cheerio through npm.
