### PR TITLE
render.js cleanup

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -9,7 +9,24 @@ var encode = utils.encode;
 /*
   Boolean Attributes
 */
-var rboolean = /^(?:autofocus|autoplay|async|checked|controls|defer|disabled|hidden|loop|multiple|open|readonly|required|scoped|selected)$/i;
+var booleanAttributes = {
+  __proto__: null,
+  autofocus: true,
+  autoplay: true,
+  async: true,
+  checked: true,
+  controls: true,
+  defer: true,
+  disabled: true,
+  hidden: true,
+  loop: true,
+  multiple: true,
+  open: true,
+  readonly: true,
+  required: true,
+  scoped: true,
+  selected: true
+};
 
 /*
   Format attributes
@@ -27,7 +44,7 @@ var formatAttrs = function(attributes) {
       output += ' ';
     }
 
-    if (!value && (rboolean.test(key) || key === '/')) {
+    if (!value && booleanAttributes[key]) {
       output += key;
     } else {
       output += key + '="' + encode(value) + '"';


### PR DESCRIPTION
Please review the changes, some of them might be breaking (eg. the `domhandler` never emits a `template` node, but there might be other uses I don't know about).
