### PR TITLE
Fix existing element removal

### DIFF
--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -58,21 +58,23 @@ var uniqueSplice = function(array, spliceIdx, spliceCount, newElems, parent) {
   var spliceArgs = [spliceIdx, spliceCount].concat(newElems),
       prev = array[spliceIdx - 1] || null,
       next = array[spliceIdx] || null;
-  var idx, len, prevIdx, node;
+  var idx, len, prevIdx, node, oldParent;
 
   // Before splicing in new elements, ensure they do not already appear in the
   // current array.
   for (idx = 0, len = newElems.length; idx < len; ++idx) {
     node = newElems[idx];
-    prevIdx = node.parent && array.indexOf(newElems[idx]);
+    oldParent = node.parent || node.root;
+    prevIdx = oldParent && oldParent.children.indexOf(newElems[idx]);
 
-    if (node.parent && prevIdx > -1) {
-      array.splice(prevIdx, 1);
-      if (spliceIdx > prevIdx) {
+    if (oldParent && prevIdx > -1) {
+      oldParent.children.splice(prevIdx, 1);
+      if (parent === oldParent && spliceIdx > prevIdx) {
         spliceArgs[0]--;
       }
     }
 
+    node.root = null;
     node.parent = parent;
     node.prev = newElems[idx - 1] || prev;
     node.next = newElems[idx + 1] || next;
@@ -169,7 +171,7 @@ var remove = exports.remove = function(selector) {
     if (el.next) {
       el.next.prev = el.prev;
     }
-    el.prev = el.next = el.parent = null;
+    el.prev = el.next = el.parent = el.root = null;
   });
 
   return this;
@@ -192,7 +194,7 @@ var replaceWith = exports.replaceWith = function(content) {
 
     // Completely remove old element
     uniqueSplice(siblings, index, 1, dom, parent);
-    el.parent = el.prev = el.next = null;
+    el.parent = el.prev = el.next = el.root = null;
   });
 
   return this;

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -65,7 +65,8 @@ var update = exports.update = function(arr, parent) {
     var node = arr[i];
 
     // Cleanly remove existing nodes from their previous structures.
-    var oldSiblings = node.parent && node.parent.children;
+    var oldParent = node.parent || node.root,
+        oldSiblings = oldParent && oldParent.children;
     if (oldSiblings && oldSiblings !== arr) {
       oldSiblings.splice(oldSiblings.indexOf(node), 1);
       if (node.prev) {

--- a/test/api.manipulation.js
+++ b/test/api.manipulation.js
@@ -45,6 +45,23 @@ describe('$(...)', function() {
       expect($children[2]).to.equal(apple);
     });
 
+    it('(existing Node) : should remove existing node from previous location', function() {
+      var $fruits = $(fruits);
+      var apple = $fruits.children()[0];
+      var $children;
+      var $dest = $('<div></div>');
+
+      expect($fruits.children()).to.have.length(3);
+      $dest.append(apple);
+      $children = $fruits.children();
+
+      expect($children).to.have.length(2);
+      expect($children[0]).to.not.equal(apple);
+
+      expect($dest.children()).to.have.length(1);
+      expect($dest.children()[0]).to.equal(apple);
+    });
+
     it('($(...), html) : should add multiple elements as last children', function() {
       var $fruits = $(fruits);
       var $plum = $('<li class="plum">Plum</li>');
@@ -145,6 +162,16 @@ describe('$(...)', function() {
       expect($obj).to.be.ok();
     });
 
+    it('($(...)) : should remove from root element', function() {
+      var $fruits = $(fruits);
+      var $plum = $('<li class="plum">Plum</li>');
+      var root = $plum[0].root;
+      expect(root).to.be.ok();
+
+      $fruits.append($plum);
+      expect($plum[0].root).to.not.be.ok();
+      expect(root.children).to.not.contain($plum[0]);
+    });
   });
 
   describe('.prepend', function() {
@@ -278,6 +305,17 @@ describe('$(...)', function() {
       expect($pear.find('.third')[0]).to.equal($pear.contents()[0]);
     });
 
+
+    it('($(...)) : should remove from root element', function() {
+      var $fruits = $(fruits);
+      var $plum = $('<li class="plum">Plum</li>');
+      var root = $plum[0].root;
+      expect(root).to.be.ok();
+
+      $fruits.prepend($plum);
+      expect($plum[0].root).to.not.be.ok();
+      expect(root.children).to.not.contain($plum[0]);
+    });
   });
 
   describe('.after', function() {
@@ -394,6 +432,16 @@ describe('$(...)', function() {
       expect($list.find('.third')[2]).to.equal($list.contents()[5]);
     });
 
+    it('($(...)) : should remove from root element', function() {
+      var $fruits = $(fruits);
+      var $plum = $('<li class="plum">Plum</li>');
+      var root = $plum[0].root;
+      expect(root).to.be.ok();
+
+      $fruits.after($plum);
+      expect($plum[0].root).to.not.be.ok();
+      expect(root.children).to.not.contain($plum[0]);
+    });
   });
 
   describe('.before', function() {
@@ -510,6 +558,16 @@ describe('$(...)', function() {
       expect($list.find('.third')[2]).to.equal($list.contents()[4]);
     });
 
+    it('($(...)) : should remove from root element', function() {
+      var $fruits = $(fruits);
+      var $plum = $('<li class="plum">Plum</li>');
+      var root = $plum[0].root;
+      expect(root).to.be.ok();
+
+      $fruits.before($plum);
+      expect($plum[0].root).to.not.be.ok();
+      expect(root.children).to.not.contain($plum[0]);
+    });
   });
 
   describe('.remove', function() {
@@ -526,6 +584,16 @@ describe('$(...)', function() {
       expect($fruits.find('.apple')).to.have.length(0);
     });
 
+    it('($(...)) : should remove from root element', function() {
+      var $fruits = $(fruits);
+      var $plum = $('<li class="plum">Plum</li>');
+      var root = $plum[0].root;
+      expect(root).to.be.ok();
+
+      $plum.remove();
+      expect($plum[0].root).to.not.be.ok();
+      expect(root.children).to.not.contain($plum[0]);
+    });
   });
 
   describe('.replaceWith', function() {
@@ -644,6 +712,16 @@ describe('$(...)', function() {
       expect($fruits.find('.third')).to.have.length(3);
     });
 
+    it('($(...)) : should remove from root element', function() {
+      var $fruits = $(fruits);
+      var $plum = $('<li class="plum">Plum</li>');
+      var root = $plum[0].root;
+      expect(root).to.be.ok();
+
+      $fruits.children().replaceWith($plum);
+      expect($plum[0].root).to.not.be.ok();
+      expect(root.children).to.not.contain($plum[0]);
+    });
   });
 
   describe('.empty', function() {


### PR DESCRIPTION
Fixes element removal from both existing nodes and root nodes. The former is a bug in the implementation. For the later case there is a fair amount of memory overhead introduced due to root objects not being possible to reclaim.
