### PR TITLE
Perform manual string parsing for hasClass

### DIFF
--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -216,8 +216,21 @@ var removeAttr = exports.removeAttr = function(name) {
 
 var hasClass = exports.hasClass = function(className) {
   return _.any(this, function(elem) {
-    var attrs = elem.attribs;
-    return attrs && _.contains((attrs['class'] || '').split(rspace), className);
+    var attrs = elem.attribs,
+        clazz = attrs && attrs['class'],
+        idx = -1,
+        end;
+
+    if (clazz) {
+      while ((idx = clazz.indexOf(className, idx+1)) > -1) {
+        end = idx + className.length;
+
+        if ((idx === 0 || rspace.test(clazz[idx-1]))
+            && (end === clazz.length || rspace.test(clazz[end]))) {
+          return true;
+        }
+      }
+    }
   });
 };
 

--- a/test/api.attributes.js
+++ b/test/api.attributes.js
@@ -263,16 +263,27 @@ describe('$(...)', function() {
   });
 
   describe('.hasClass', function() {
+    function test(attr) {
+      return $('<div class="' + attr + '"></div>');
+    }
 
     it('(valid class) : should return true', function() {
       var $fruits = $(fruits);
       var cls = $('.apple', $fruits).hasClass('apple');
       expect(cls).to.be.ok();
+
+      expect(test('foo').hasClass('foo')).to.be.ok();
+      expect(test('foo bar').hasClass('foo')).to.be.ok();
+      expect(test('bar foo').hasClass('foo')).to.be.ok();
+      expect(test('bar foo bar').hasClass('foo')).to.be.ok();
     });
 
     it('(invalid class) : should return false', function() {
       var cls = $('#fruits', fruits).hasClass('fruits');
       expect(cls).to.not.be.ok();
+      expect(test('foo-bar').hasClass('foo')).to.not.be.ok();
+      expect(test('foo-bar').hasClass('foo')).to.not.be.ok();
+      expect(test('foo-bar').hasClass('foo-ba')).to.not.be.ok();
     });
 
     it('should check multiple classes', function() {


### PR DESCRIPTION
This is faster and avoids additional memory pressure from temporary array objects.

Test: attributes - Has class (file: jquery.html)
        cheerio x 46,072 ops/sec ±15.20% (61 runs sampled)
    old x 4,477 ops/sec ±19.32% (46 runs sampled)
    jsdom x 3,123 ops/sec ±2.84% (89 runs sampled)
    Fastest: cheerio
