### PR TITLE
Rewrite `data` internals with caching behavior

### DIFF
--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -3,7 +3,10 @@ var _ = require('lodash'),
   isTag = utils.isTag,
   domEach = utils.domEach,
   hasOwn = Object.prototype.hasOwnProperty,
+  camelCase = utils.camelCase,
+  cssCase = utils.cssCase,
   rspace = /\s+/,
+  dataAttrPrefix = 'data-',
 
   // Lookup table for coercing string data-* attributes to their corresponding
   // JavaScript primitives
@@ -79,6 +82,47 @@ var setData = function(el, name, value) {
   }
 };
 
+// Read the specified attribute from the equivalent HTML5 `data-*` attribute,
+// and (if present) cache the value in the node's internal data store. If no
+// attribute name is specified, read *all* HTML5 `data-*` attributes in this
+// manner.
+var readData = function(el, name) {
+  var readAll = arguments.length === 1;
+  var domNames, domName, jsNames, jsName, value, idx, length;
+
+  if (readAll) {
+    domNames = Object.keys(el.attribs).filter(function(attrName) {
+      return attrName.slice(0, dataAttrPrefix.length) === dataAttrPrefix;
+    });
+    jsNames = domNames.map(function(domName) {
+      return camelCase(domName.slice(dataAttrPrefix.length));
+    });
+  } else {
+    domNames = [dataAttrPrefix + cssCase(name)];
+    jsNames = [name];
+  }
+
+  for (idx = 0, length = domNames.length; idx < length; ++idx) {
+    domName = domNames[idx];
+    jsName = jsNames[idx];
+    if (hasOwn.call(el.attribs, domName)) {
+      value = el.attribs[domName];
+
+      if (hasOwn.call(primitives, value)) {
+        value = primitives[value];
+      } else if (value === String(Number(value))) {
+        value = Number(value);
+      } else if (rbrace.test(value)) {
+        value = JSON.parse(value);
+      }
+
+      el.data[jsName] = value;
+    }
+  }
+
+  return readAll ? el.data : value;
+};
+
 var data = exports.data = function(name, value) {
   var elem = this[0];
 
@@ -90,7 +134,7 @@ var data = exports.data = function(name, value) {
 
   // Return the entire data object if no data specified
   if (!name) {
-    return elem.data;
+    return readData(elem);
   }
 
   // Set the value (with attr map support)
@@ -100,23 +144,10 @@ var data = exports.data = function(name, value) {
     });
     return this;
   } else if (hasOwn.call(elem.data, name)) {
-    // Get the (decoded) data
-    var val = elem.data[name];
-
-    if (hasOwn.call(primitives, val)) {
-      val = primitives[val];
-    } else if (val === String(Number(val))) {
-      val = Number(val);
-    } else if (rbrace.test(val)) {
-      val = JSON.parse(val);
-    }
-
-    return val;
-  } else if (typeof name === 'string' && value === undefined) {
-    return undefined;
+    return elem.data[name];
   }
 
-  return this;
+  return readData(elem, name);
 };
 
 /**

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -4,8 +4,7 @@
 var htmlparser = require('htmlparser2'),
     _ = require('lodash'),
     utils = require('./utils'),
-    isTag = utils.isTag,
-    camelCase = require('./utils').camelCase;
+    isTag = utils.isTag;
 
 /*
   Parser
@@ -39,8 +38,6 @@ var evaluate = exports.evaluate = function(content, options) {
   } else {
     dom = content;
   }
-
-  _.forEach(dom, parseData);
 
   return dom;
 };
@@ -93,31 +90,6 @@ var update = exports.update = function(arr, parent) {
   }
 
   return parent;
-};
-
-/**
- * Extract element data according to `data-*` element attributes and store in
- * a key-value hash on the element's `data` attribute. Repeat for any and all
- * descendant elements.
- *
- * @param  {Object} elem Element
- */
-var parseData = exports.parseData = function(elem) {
-  if (elem.data === undefined) elem.data = {};
-  var value;
-  for (var key in elem.attribs) {
-    value = elem.attribs[key];
-
-    if (key.substr(0, 5) === 'data-') {
-      key = key.slice(5);
-      key = camelCase(key);
-      elem.data[key] = value;
-    } else {
-      elem.attribs[key] = value;
-    }
-  }
-
-  _.forEach(elem.children, parseData);
 };
 
 // module.exports = $.extend(exports);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -28,6 +28,16 @@ exports.camelCase = function(str) {
 };
 
 /**
+ * Convert a string from camel case to "CSS case", where word boundaries are
+ * described by hyphens ("-") and all characters are lower-case.
+ * @param  {String} str String to be converted.
+ * @return {string}     String in "CSS case".
+ */
+exports.cssCase = function(str) {
+  return str.replace(/[A-Z]/g, '-$&').toLowerCase();
+};
+
+/**
  * Iterate over each DOM element without creating intermediary Cheerio instances.
  *
  * This is indented for use internally to avoid otherwise unnecessary memory pressure introduced

--- a/test/api.attributes.js
+++ b/test/api.attributes.js
@@ -99,11 +99,32 @@ describe('$(...)', function() {
 
   describe('.data', function() {
 
-    it('() : should get all data attributes', function() {
+    it('() : should get all data attributes initially declared in the markup', function() {
       var data = $('.linth', chocolates).data();
       expect(data).to.eql({
         highlight: 'Lindor',
         origin: 'swiss'
+      });
+    });
+
+    it('() : should get all data set via `data`', function() {
+      var $el = $('<div>');
+      $el.data('a', 1);
+      $el.data('b', 2);
+
+      expect($el.data()).to.eql({
+        a: 1,
+        b: 2
+      });
+    });
+
+    it('() : should get all data attributes initially declared in the markup merged with all data additionally set via `data`', function() {
+      var $el = $('<div data-a="a">');
+      $el.data('b', 'b');
+
+      expect($el.data()).to.eql({
+        a: 'a',
+        b: 'b'
       });
     });
 
@@ -123,6 +144,46 @@ describe('$(...)', function() {
 
       expect(highlight).to.equal('Lindor');
       expect(origin).to.equal('swiss');
+    });
+
+    it('(key) : should translate camel-cased key values to hyphen-separated versions', function() {
+      var $el = $('<div data--three-word-attribute="a" data-foo-Bar_BAZ-="b">');
+
+      expect($el.data('ThreeWordAttribute')).to.be('a');
+      expect($el.data('fooBar_baz-')).to.be('b');
+    });
+
+    it('(key) : should retrieve object values', function() {
+      var data = {};
+      var $el = $('<div>');
+
+      $el.data('test', data);
+
+      expect($el.data('test')).to.be(data);
+    });
+
+    it('(key) : should parse JSON data derived from the markup', function() {
+      var $el = $('<div data-json="[1, 2, 3]">');
+
+      expect($el.data('json')).to.eql([1,2,3]);
+    });
+
+    it('(key) : should not parse JSON data set via the `data` API', function() {
+      var $el = $('<div>');
+      $el.data('json', '[1, 2, 3]');
+
+      expect($el.data('json')).to.be('[1, 2, 3]');
+    });
+
+    // See http://api.jquery.com/data/ and http://bugs.jquery.com/ticket/14523
+    it('(key) : should ignore the markup value after the first access', function() {
+      var $el = $('<div data-test="a">');
+
+      expect($el.data('test')).to.be('a');
+
+      $el.attr('data-test', 'b');
+
+      expect($el.data('test')).to.be('a');
     });
 
     it('(hyphen key) : data addribute with hyphen should be camelized ;-)', function() {


### PR DESCRIPTION
In #283, we identified some strange behavior in jQuery's `$.fn.data` method. We also confirmed that it is intentional and not likely to change. Since it seems so surprising, no one rushed to implement it.

More recently, #472 was filed against `data`'s automatic type coercion behavior. The underlying problem there is that jQuery makes a distinction between data set via the `data` method and data read from the markup--only the latter is type coerced.

In order to properly resolve #472, I had to also resolve #283. One upside to this is that we defer the "read" operation for `data-*` attributes until they are actually needed, so parse times for large documents with lots of `data-*` attributes should improve.

Commit message:

> Defer the storage and type coercion of HTML5 `data-*` attributes until a
> read operation. At this time, cache the value of the data attribute so
> that the DOM is not referenced again, as per the jQuery implementation:
> 
> > The data- attributes are pulled in the first time the data property is
> > accessed and then are no longer accessed or mutated (all data values
> > are then stored internally in jQuery). [1]
> 
> [1] http://api.jquery.com/data/
