### PR TITLE
makefile: add release-* targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 REPORTER = dot
+XYZ = node_modules/.bin/xyz --message 'Release X.Y.Z' --tag X.Y.Z --script scripts/prepublish
 
 test:
 	@./node_modules/.bin/jshint lib/ test/
@@ -18,5 +19,13 @@ lib-cov:
 
 bench:
 	@./benchmark/benchmark.js
+
+.PHONY: release-major release-minor release-patch
+release-major: LEVEL = major
+release-minor: LEVEL = minor
+release-patch: LEVEL = patch
+
+release-major release-minor release-patch:
+	@$(XYZ) --increment $(LEVEL)
 
 .PHONY: test build setup subl

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "expect.js": "~0.3.1",
     "jsdom": "~0.8.9",
     "jshint": "~2.3.0",
-    "mocha": "*"
+    "mocha": "*",
+    "xyz": "~0.3.0"
   },
   "scripts": {
     "test": "make test"

--- a/scripts/prepublish
+++ b/scripts/prepublish
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+tmp="$(mktemp -t "$(basename "$0").XXXXXXXXXX")"
+
+printf "
+$VERSION / $(date +"%Y-%m-%d")
+==================
+
+$(git --no-pager log --no-merges --pretty="format: * %s (%an)" $PREVIOUS_VERSION..)
+" >"$tmp"
+
+cat History.md >>"$tmp"
+mv "$tmp" History.md
+git add History.md


### PR DESCRIPTION
Closes #475

This doesn't exactly replicate the process @MatthewMueller outlined in #475. Differences:
- no manual steps (this is the point, after all)
- confirmation prompt
- xyz will abort if run from any branch other than master
- xyz will _not_ abort if git index is dirty
- author name used in place of GitHub username (to avoid manual intervention or the complexity of fetching usernames from GitHub)
