### PR TITLE
cheerio: rm unused variable

### DIFF
--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -23,12 +23,6 @@ var api = [
 
 var quickExpr = /^(?:[^#<]*(<[\w\W]+>)[^>]*$|#([\w\-]*)$)/;
 
-/**
- * Static Methods
- */
-
-var $ = require('./static');
-
 /*
  * Instance of cheerio
  */


### PR DESCRIPTION
Removed unused variable `$` from `cheerio.js`.
`static` is required little bit later, but anyway it do not need variable for this.

``` js
_.extend(Cheerio, require('./static'));
```
