### PR TITLE
parse: removed unused variables

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2,9 +2,7 @@
   Module Dependencies
 */
 var htmlparser = require('htmlparser2'),
-    _ = require('lodash'),
-    utils = require('./utils'),
-    isTag = utils.isTag;
+    utils = require('./utils');
 
 /*
   Parser


### PR DESCRIPTION
Removed unused variables `_` and `isTag` from `parse`.
