### PR TITLE
options: add notEncodeEntities

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -570,6 +570,7 @@ $.html()
 
 #### .html( [htmlString] )
 Gets an html content string from the first selected element. If `htmlString` is specified, each selected element's content is replaced by the new content.
+In `options` could be set `notEncodeEntities` wich could be great for inline styles and scripts.
 
 ```js
 $('.orange').html()
@@ -577,6 +578,11 @@ $('.orange').html()
 
 $('#fruits').html('<li class="mango">Mango</li>').html()
 //=> <li class="mango">Mango</li>
+
+$().html(null, {
+  notEncodeEntities: true
+})
+
 ```
 
 #### .text( [textString] )

--- a/lib/render.js
+++ b/lib/render.js
@@ -106,8 +106,10 @@ var render = module.exports = function(dom, opts) {
       pushVal = renderComment(elem);
     else if (elem.type === 'cdata')
       pushVal = renderCdata(elem);
-    else
+    else if (!opts.notEncodeEntities)
       pushVal = renderText(elem);
+    else
+      pushVal = elem.data;
 
     if (elem.children && elem.type !== 'cdata')
       pushVal += render(elem.children, opts);

--- a/lib/static.js
+++ b/lib/static.js
@@ -36,12 +36,12 @@ var load = exports.load = function(content, options) {
  * $.html([selector | dom])
  */
 
-var html = exports.html = function(dom) {
+var html = exports.html = function(dom, options) {
   if (dom) {
-    dom = (typeof dom === 'string') ? select(dom, this._root, this.options) : dom;
-    return render(dom, this.options);
+    dom = (typeof dom === 'string') ? select(dom, this._root, options) : dom;
+    return render(dom, options);
   } else if (this._root && this._root.children) {
-    return render(this._root.children, this.options);
+    return render(this._root.children, options);
   } else {
     return '';
   }
@@ -51,12 +51,14 @@ var html = exports.html = function(dom) {
  * $.xml([selector | dom])
  */
 
-var xml = exports.xml = function(dom) {
+var xml = exports.xml = function(dom, options) {
+  options = _.defaults(options || {}, { xmlMode: true });
+  
   if (dom) {
-    dom = (typeof dom === 'string') ? select(dom, this._root, this.options) : dom;
-    return render(dom, { xmlMode: true });
+    dom = (typeof dom === 'string') ? select(dom, this._root, options) : dom;
+    return render(dom, options);
   } else if (this._root && this._root.children) {
-    return render(this._root.children, { xmlMode: true });
+    return render(this._root.children, options);
   } else {
     return '';
   }


### PR DESCRIPTION
Added option `notEncodeEntities` which could be used to work with inline scripts and styles in `html` and `xml` functions.
Any way `this.options` which is used now is always `undefined` and have no sense.

This would fix #484 #460. I think it's little bit better than [this solution](https://github.com/cheeriojs/cheerio/pull/461).
For now I use this thing

``` js
data = entities.decodeHTML($.html());
```

for inline styles and scripts in [minify](http://coderaiser.github.io/minify), but it's adds one more dependency and looks very bad. 

P.S.: Build failed because of `travis`.
