### PR TITLE
Use "loaded" instance of Cheerio in unit tests

### DIFF
--- a/test/api.attributes.js
+++ b/test/api.attributes.js
@@ -1,6 +1,6 @@
 var expect = require('expect.js');
 
-var $ = require('../');
+var cheerio = require('..');
 var fruits = require('./fixtures').fruits;
 var vegetables = require('./fixtures').vegetables;
 var food = require('./fixtures').food;
@@ -9,33 +9,37 @@ var inputs = require('./fixtures').inputs;
 var toArray = Function.call.bind(Array.prototype.slice);
 
 describe('$(...)', function() {
+  var $;
+
+  beforeEach(function() {
+    $ = cheerio.load(fruits);
+  });
 
   describe('.attr', function() {
 
     it('() : should get all the attributes', function() {
-      var attrs = $('ul', fruits).attr();
+      var attrs = $('ul').attr();
       expect(attrs.id).to.equal('fruits');
     });
 
     it('(invalid key) : invalid attr should get undefined', function() {
-      var attr = $('.apple', fruits).attr('lol');
+      var attr = $('.apple').attr('lol');
       expect(attr).to.be(undefined);
     });
 
     it('(valid key) : valid attr should get value', function() {
-      var cls = $('.apple', fruits).attr('class');
+      var cls = $('.apple').attr('class');
       expect(cls).to.equal('apple');
     });
 
     it('(key, value) : should set attr', function() {
-      var $fruits = $(fruits);
-      var $pear = $('.pear', $fruits).attr('id', 'pear');
-      expect($('#pear', $fruits)).to.have.length(1);
+      var $pear = $('.pear').attr('id', 'pear');
+      expect($('#pear')).to.have.length(1);
       expect($pear.cheerio).to.not.be(undefined);
     });
 
     it('(key, value) : should set attr', function() {
-      var $el = $('<div></div> <div></div>').attr('class', 'pear');
+      var $el = cheerio('<div></div> <div></div>').attr('class', 'pear');
 
       expect($el[0].attribs['class']).to.equal('pear');
       expect($el[1].attribs).to.equal(undefined);
@@ -49,20 +53,19 @@ describe('$(...)', function() {
     });
 
     it('(map) : object map should set multiple attributes', function() {
-      var $fruits = $(fruits);
-      $('.apple', $fruits).attr({
+      $('.apple').attr({
         id: 'apple',
         style: 'color:red;',
         'data-url': 'http://apple.com'
       });
-      var attrs = $('.apple', $fruits).attr();
+      var attrs = $('.apple').attr();
       expect(attrs.id).to.equal('apple');
       expect(attrs.style).to.equal('color:red;');
       expect(attrs['data-url']).to.equal('http://apple.com');
     });
 
     it('(key, function) : should call the function and update the attribute with the return value', function() {
-      var $fruits = $(fruits);
+      var $fruits = $('#fruits');
       $fruits.attr('id', function(index, value) {
         expect(index).to.equal(0);
         expect(value).to.equal('fruits');
@@ -73,7 +76,7 @@ describe('$(...)', function() {
     });
 
     it('(key, value) : should correctly encode then decode unsafe values', function() {
-      var $apple = $('.apple', fruits);
+      var $apple = $('.apple');
       $apple.attr('href', 'http://github.com/"><script>alert("XSS!")</script><br');
       expect($apple.attr('href')).to.equal('http://github.com/"><script>alert("XSS!")</script><br');
 
@@ -82,14 +85,14 @@ describe('$(...)', function() {
     });
 
     it('(key, value) : should coerce values to a string', function() {
-      var $apple = $('.apple', fruits);
+      var $apple = $('.apple');
       $apple.attr('data-test', 1);
       expect($apple[0].attribs['data-test']).to.equal('1');
       expect($apple.attr('data-test')).to.equal('1');
     });
 
     it('(key, value) : handle removed boolean attributes', function() {
-      var $apple = $('.apple', fruits);
+      var $apple = $('.apple');
       $apple.attr('autofocus', 'autofocus');
       expect($apple.attr('autofocus')).to.equal('autofocus');
       $apple.removeAttr('autofocus');
@@ -97,7 +100,7 @@ describe('$(...)', function() {
     });
 
     it('(key, value) : should remove non-boolean attributes with names or values similar to boolean ones', function() {
-      var $apple = $('.apple', fruits);
+      var $apple = $('.apple');
       $apple.attr('data-autofocus', 'autofocus');
       expect($apple.attr('data-autofocus')).to.equal('autofocus');
       $apple.removeAttr('data-autofocus');
@@ -107,8 +110,12 @@ describe('$(...)', function() {
 
   describe('.data', function() {
 
+    beforeEach(function() {
+      $ = cheerio.load(chocolates);
+    });
+
     it('() : should get all data attributes initially declared in the markup', function() {
-      var data = $('.linth', chocolates).data();
+      var data = $('.linth').data();
       expect(data).to.eql({
         highlight: 'Lindor',
         origin: 'swiss'
@@ -116,7 +123,7 @@ describe('$(...)', function() {
     });
 
     it('() : should get all data set via `data`', function() {
-      var $el = $('<div>');
+      var $el = cheerio('<div>');
       $el.data('a', 1);
       $el.data('b', 2);
 
@@ -127,7 +134,7 @@ describe('$(...)', function() {
     });
 
     it('() : should get all data attributes initially declared in the markup merged with all data additionally set via `data`', function() {
-      var $el = $('<div data-a="a">');
+      var $el = cheerio('<div data-a="a">');
       $el.data('b', 'b');
 
       expect($el.data()).to.eql({
@@ -137,25 +144,25 @@ describe('$(...)', function() {
     });
 
     it('() : no data attribute should return an empty object', function() {
-      var data = $('.cailler', chocolates).data();
+      var data = $('.cailler').data();
       expect(data).to.be.empty();
     });
 
     it('(invalid key) : invalid data attribute should return `undefined` ', function() {
-      var data = $('.frey', chocolates).data('lol');
+      var data = $('.frey').data('lol');
       expect(data).to.be(undefined);
     });
 
     it('(valid key) : valid data attribute should get value', function() {
-      var highlight = $('.linth', chocolates).data('highlight');
-      var origin = $('.linth', chocolates).data('origin');
+      var highlight = $('.linth').data('highlight');
+      var origin = $('.linth').data('origin');
 
       expect(highlight).to.equal('Lindor');
       expect(origin).to.equal('swiss');
     });
 
     it('(key) : should translate camel-cased key values to hyphen-separated versions', function() {
-      var $el = $('<div data--three-word-attribute="a" data-foo-Bar_BAZ-="b">');
+      var $el = cheerio('<div data--three-word-attribute="a" data-foo-Bar_BAZ-="b">');
 
       expect($el.data('ThreeWordAttribute')).to.be('a');
       expect($el.data('fooBar_baz-')).to.be('b');
@@ -163,7 +170,7 @@ describe('$(...)', function() {
 
     it('(key) : should retrieve object values', function() {
       var data = {};
-      var $el = $('<div>');
+      var $el = cheerio('<div>');
 
       $el.data('test', data);
 
@@ -171,13 +178,13 @@ describe('$(...)', function() {
     });
 
     it('(key) : should parse JSON data derived from the markup', function() {
-      var $el = $('<div data-json="[1, 2, 3]">');
+      var $el = cheerio('<div data-json="[1, 2, 3]">');
 
       expect($el.data('json')).to.eql([1,2,3]);
     });
 
     it('(key) : should not parse JSON data set via the `data` API', function() {
-      var $el = $('<div>');
+      var $el = cheerio('<div>');
       $el.data('json', '[1, 2, 3]');
 
       expect($el.data('json')).to.be('[1, 2, 3]');
@@ -185,7 +192,7 @@ describe('$(...)', function() {
 
     // See http://api.jquery.com/data/ and http://bugs.jquery.com/ticket/14523
     it('(key) : should ignore the markup value after the first access', function() {
-      var $el = $('<div data-test="a">');
+      var $el = cheerio('<div data-test="a">');
 
       expect($el.data('test')).to.be('a');
 
@@ -195,7 +202,7 @@ describe('$(...)', function() {
     });
 
     it('(hyphen key) : data addribute with hyphen should be camelized ;-)', function() {
-      var data = $('.frey', chocolates).data();
+      var data = $('.frey').data();
       expect(data).to.eql({
         taste: 'sweet',
         bestCollection: 'Mahony'
@@ -204,18 +211,18 @@ describe('$(...)', function() {
 
     it('(key, value) : should set data attribute', function() {
       // Adding as object.
-      var a = $('.frey', chocolates).data({
+      var a = $('.frey').data({
         balls: 'giandor'
       });
       // Adding as string.
-      var b = $('.linth', chocolates).data('snack', 'chocoletti');
+      var b = $('.linth').data('snack', 'chocoletti');
 
       expect(a.data('balls')).to.eql('giandor');
       expect(b.data('snack')).to.eql('chocoletti');
     });
 
     it('(map) : object map should set multiple data attributes', function() {
-      var data = $('.linth', chocolates).data({
+      var data = $('.linth').data({
         id: 'Cailler',
         flop: 'Pippilotti Rist',
         top: 'Frigor',
@@ -230,32 +237,32 @@ describe('$(...)', function() {
 
     describe('(attr) : data-* attribute type coercion :', function() {
       it('boolean', function() {
-        var $el = $('<div data-bool="true">');
+        var $el = cheerio('<div data-bool="true">');
         expect($el.data('bool')).to.be(true);
       });
 
       it('number', function() {
-        var $el = $('<div data-number="23">');
+        var $el = cheerio('<div data-number="23">');
         expect($el.data('number')).to.be(23);
       });
 
       it('number (scientific notation is not coerced)', function() {
-        var $el = $('<div data-sci="1E10">');
+        var $el = cheerio('<div data-sci="1E10">');
         expect($el.data('sci')).to.be('1E10');
       });
 
       it('null', function() {
-        var $el = $('<div data-null="null">');
+        var $el = cheerio('<div data-null="null">');
         expect($el.data('null')).to.be(null);
       });
 
       it('object', function() {
-        var $el = $('<div data-obj=\'{ "a": 45 }\'>');
+        var $el = cheerio('<div data-obj=\'{ "a": 45 }\'>');
         expect($el.data('obj')).to.eql({ a: 45 });
       });
 
       it('array', function() {
-        var $el = $('<div data-array="[1, 2, 3]">');
+        var $el = cheerio('<div data-array="[1, 2, 3]">');
         expect($el.data('array')).to.eql([1, 2, 3]);
       });
 
@@ -265,52 +272,57 @@ describe('$(...)', function() {
 
 
   describe('.val', function() {
+
+    beforeEach(function() {
+      $ = cheerio.load(inputs);
+    });
+
     it('.val(): on select should get value', function() {
-      var val = $('select#one', inputs).val();
+      var val = $('select#one').val();
       expect(val).to.equal('option_selected');
     });
     it('.val(): on option should get value', function() {
-      var val = $('select#one option', inputs).eq(0).val();
+      var val = $('select#one option').eq(0).val();
       expect(val).to.equal('option_not_selected');
     });
     it('.val(): on text input should get value', function() {
-      var val = $('input[type="text"]', inputs).val();
+      var val = $('input[type="text"]').val();
       expect(val).to.equal('input_text');
     });
     it('.val(): on checked checkbox should get value', function() {
-      var val = $('input[name="checkbox_on"]', inputs).val();
+      var val = $('input[name="checkbox_on"]').val();
       expect(val).to.equal('on');
     });
     it('.val(): on unchecked checkbox should get value', function() {
-      var val = $('input[name="checkbox_off"]', inputs).val();
+      var val = $('input[name="checkbox_off"]').val();
       expect(val).to.equal('off');
     });
     it('.val(): on radio should get value', function() {
-      var val = $('input[type="radio"]', inputs).val();
+      var val = $('input[type="radio"]').val();
       expect(val).to.equal('on');
     });
     it('.val(): on multiple select should get an array of values', function() {
-      var val = $('select#multi', inputs).val();
+      var val = $('select#multi').val();
       expect(val).to.have.length(2);
     });
     it('.val(value): on input text should set value', function() {
-      var element = $('input[type="text"]', inputs).val('test');
+      var element = $('input[type="text"]').val('test');
       expect(element.val()).to.equal('test');
     });
     it('.val(value): on select should set value', function() {
-      var element = $('select#one', inputs).val('option_not_selected');
+      var element = $('select#one').val('option_not_selected');
       expect(element.val()).to.equal('option_not_selected');
     });
     it('.val(value): on option should set value', function() {
-      var element = $('select#one option', inputs).eq(0).val('option_changed');
+      var element = $('select#one option').eq(0).val('option_changed');
       expect(element.val()).to.equal('option_changed');
     });
     it('.val(value): on radio should set value', function() {
-      var element = $('input[name="radio"]', inputs).val('off');
+      var element = $('input[name="radio"]').val('off');
       expect(element.val()).to.equal('off');
     });
     it('.val(values): on multiple select should set multiple values', function() {
-      var element = $('select#multi', inputs).val(['1', '3', '4']);
+      var element = $('select#multi').val(['1', '3', '4']);
       expect(element.val()).to.have.length(3);
     });
   });
@@ -318,14 +330,14 @@ describe('$(...)', function() {
   describe('.removeAttr', function() {
 
     it('(key) : should remove a single attr', function() {
-      var $fruits = $(fruits);
+      var $fruits = $('#fruits');
       expect($fruits.attr('id')).to.not.be(undefined);
       $fruits.removeAttr('id');
       expect($fruits.attr('id')).to.be(undefined);
     });
 
     it('should return cheerio object', function() {
-      var obj = $('ul', fruits).removeAttr('id').cheerio;
+      var obj = $('ul').removeAttr('id').cheerio;
       expect(obj).to.be.ok();
     });
 
@@ -333,12 +345,11 @@ describe('$(...)', function() {
 
   describe('.hasClass', function() {
     function test(attr) {
-      return $('<div class="' + attr + '"></div>');
+      return cheerio('<div class="' + attr + '"></div>');
     }
 
     it('(valid class) : should return true', function() {
-      var $fruits = $(fruits);
-      var cls = $('.apple', $fruits).hasClass('apple');
+      var cls = $('.apple').hasClass('apple');
       expect(cls).to.be.ok();
 
       expect(test('foo').hasClass('foo')).to.be.ok();
@@ -348,7 +359,7 @@ describe('$(...)', function() {
     });
 
     it('(invalid class) : should return false', function() {
-      var cls = $('#fruits', fruits).hasClass('fruits');
+      var cls = $('#fruits').hasClass('fruits');
       expect(cls).to.not.be.ok();
       expect(test('foo-bar').hasClass('foo')).to.not.be.ok();
       expect(test('foo-bar').hasClass('foo')).to.not.be.ok();
@@ -356,16 +367,14 @@ describe('$(...)', function() {
     });
 
     it('should check multiple classes', function() {
-      var $fruits = $(fruits);
-
       // Add a class
-      $('.apple', $fruits).addClass('red');
-      expect($('.apple', $fruits).hasClass('apple')).to.be.ok();
-      expect($('.apple', $fruits).hasClass('red')).to.be.ok();
+      $('.apple').addClass('red');
+      expect($('.apple').hasClass('apple')).to.be.ok();
+      expect($('.apple').hasClass('red')).to.be.ok();
 
       // Remove one and test again
-      $('.apple', $fruits).removeClass('apple');
-      expect($('li', $fruits).eq(0).hasClass('apple')).to.not.be.ok();
+      $('.apple').removeClass('apple');
+      expect($('li').eq(0).hasClass('apple')).to.not.be.ok();
       // expect($('li', $fruits).eq(0).hasClass('red')).to.be.ok();
     });
   });
@@ -373,38 +382,35 @@ describe('$(...)', function() {
   describe('.addClass', function() {
 
     it('(first class) : should add the class to the element', function() {
-      var $fruits = $(fruits);
+      var $fruits = $('#fruits');
       $fruits.addClass('fruits');
       var cls = $fruits.hasClass('fruits');
       expect(cls).to.be.ok();
     });
 
     it('(single class) : should add the class to the element', function() {
-      var $fruits = $(fruits);
-      $('.apple', $fruits).addClass('fruit');
-      var cls = $('.apple', $fruits).hasClass('fruit');
+      $('.apple').addClass('fruit');
+      var cls = $('.apple').hasClass('fruit');
       expect(cls).to.be.ok();
     });
 
     it('(class): adds classes to many selected items', function() {
-      var $fruits = $(fruits);
-      $('li', $fruits).addClass('fruit');
-      expect($('.apple', $fruits).hasClass('fruit')).to.be.ok();
-      expect($('.orange', $fruits).hasClass('fruit')).to.be.ok();
-      expect($('.pear', $fruits).hasClass('fruit')).to.be.ok();
+      $('li').addClass('fruit');
+      expect($('.apple').hasClass('fruit')).to.be.ok();
+      expect($('.orange').hasClass('fruit')).to.be.ok();
+      expect($('.pear').hasClass('fruit')).to.be.ok();
     });
 
     it('(class class class) : should add multiple classes to the element', function() {
-      var $fruits = $(fruits);
-      $('.apple', $fruits).addClass('fruit red tasty');
-      expect($('.apple', $fruits).hasClass('apple')).to.be.ok();
-      expect($('.apple', $fruits).hasClass('fruit')).to.be.ok();
-      expect($('.apple', $fruits).hasClass('red')).to.be.ok();
-      expect($('.apple', $fruits).hasClass('tasty')).to.be.ok();
+      $('.apple').addClass('fruit red tasty');
+      expect($('.apple').hasClass('apple')).to.be.ok();
+      expect($('.apple').hasClass('fruit')).to.be.ok();
+      expect($('.apple').hasClass('red')).to.be.ok();
+      expect($('.apple').hasClass('tasty')).to.be.ok();
     });
 
     it('(fn) : should add classes returned from the function', function() {
-      var $fruits = $(fruits).children();
+      var $fruits = $('#fruits').children();
       var args = [];
       var thisVals = [];
       var toAdd = ['apple red', '', undefined];
@@ -436,26 +442,24 @@ describe('$(...)', function() {
   describe('.removeClass', function() {
 
     it('() : should remove all the classes', function() {
-      var $fruits = $(fruits);
-      $('.pear', $fruits).addClass('fruit');
-      $('.pear', $fruits).removeClass();
-      expect($('.pear', $fruits).attr('class')).to.be(undefined);
+      $('.pear').addClass('fruit');
+      $('.pear').removeClass();
+      expect($('.pear').attr('class')).to.be(undefined);
     });
 
     it('("") : should not modify class list', function() {
-      var $fruits = $(fruits);
+      var $fruits = $('#fruits');
       $fruits.children().removeClass('');
-      expect($('.apple', $fruits)).to.have.length(1);
+      expect($('.apple')).to.have.length(1);
     });
 
     it('(invalid class) : should not remove anything', function() {
-      var $fruits = $(fruits);
-      $('.pear', $fruits).removeClass('fruit');
-      expect($('.pear', $fruits).hasClass('pear')).to.be.ok();
+      $('.pear').removeClass('fruit');
+      expect($('.pear').hasClass('pear')).to.be.ok();
     });
 
     it('(no class attribute) : should not throw an exception', function() {
-      var $vegetables = $(vegetables);
+      var $vegetables = cheerio(vegetables);
       var thrown = null;
       expect(function() {
         $('li', $vegetables).removeClass('vegetable');
@@ -464,50 +468,46 @@ describe('$(...)', function() {
     });
 
     it('(single class) : should remove a single class from the element', function() {
-      var $fruits = $(fruits);
-      $('.pear', $fruits).addClass('fruit');
-      expect($('.pear', $fruits).hasClass('fruit')).to.be.ok();
-      $('.pear', $fruits).removeClass('fruit');
-      expect($('.pear', $fruits).hasClass('fruit')).to.not.be.ok();
-      expect($('.pear', $fruits).hasClass('pear')).to.be.ok();
+      $('.pear').addClass('fruit');
+      expect($('.pear').hasClass('fruit')).to.be.ok();
+      $('.pear').removeClass('fruit');
+      expect($('.pear').hasClass('fruit')).to.not.be.ok();
+      expect($('.pear').hasClass('pear')).to.be.ok();
     });
 
     it('(single class) : should remove a single class from multiple classes on the element', function() {
-      var $fruits = $(fruits);
-      $('.pear', $fruits).addClass('fruit green tasty');
-      expect($('.pear', $fruits).hasClass('fruit')).to.be.ok();
-      expect($('.pear', $fruits).hasClass('green')).to.be.ok();
-      expect($('.pear', $fruits).hasClass('tasty')).to.be.ok();
+      $('.pear').addClass('fruit green tasty');
+      expect($('.pear').hasClass('fruit')).to.be.ok();
+      expect($('.pear').hasClass('green')).to.be.ok();
+      expect($('.pear').hasClass('tasty')).to.be.ok();
 
-      $('.pear', $fruits).removeClass('green');
-      expect($('.pear', $fruits).hasClass('fruit')).to.be.ok();
-      expect($('.pear', $fruits).hasClass('green')).to.not.be.ok();
-      expect($('.pear', $fruits).hasClass('tasty')).to.be.ok();
+      $('.pear').removeClass('green');
+      expect($('.pear').hasClass('fruit')).to.be.ok();
+      expect($('.pear').hasClass('green')).to.not.be.ok();
+      expect($('.pear').hasClass('tasty')).to.be.ok();
     });
 
     it('(class class class) : should remove multiple classes from the element', function() {
-      var $fruits = $(fruits);
+      $('.apple').addClass('fruit red tasty');
+      expect($('.apple').hasClass('apple')).to.be.ok();
+      expect($('.apple').hasClass('fruit')).to.be.ok();
+      expect($('.apple').hasClass('red')).to.be.ok();
+      expect($('.apple').hasClass('tasty')).to.be.ok();
 
-      $('.apple', $fruits).addClass('fruit red tasty');
-      expect($('.apple', $fruits).hasClass('apple')).to.be.ok();
-      expect($('.apple', $fruits).hasClass('fruit')).to.be.ok();
-      expect($('.apple', $fruits).hasClass('red')).to.be.ok();
-      expect($('.apple', $fruits).hasClass('tasty')).to.be.ok();
-
-      $('.apple', $fruits).removeClass('apple red tasty');
-      expect($('.fruit', $fruits).hasClass('apple')).to.not.be.ok();
-      expect($('.fruit', $fruits).hasClass('red')).to.not.be.ok();
-      expect($('.fruit', $fruits).hasClass('tasty')).to.not.be.ok();
-      expect($('.fruit', $fruits).hasClass('fruit')).to.be.ok();
+      $('.apple').removeClass('apple red tasty');
+      expect($('.fruit').hasClass('apple')).to.not.be.ok();
+      expect($('.fruit').hasClass('red')).to.not.be.ok();
+      expect($('.fruit').hasClass('tasty')).to.not.be.ok();
+      expect($('.fruit').hasClass('fruit')).to.be.ok();
     });
 
     it('(class) : should remove all occurrences of a class name', function() {
-      var $div = $('<div class="x x y x z"></div>');
+      var $div = cheerio('<div class="x x y x z"></div>');
       expect($div.removeClass('x').hasClass('x')).to.be(false);
     });
 
     it('(fn) : should remove classes returned from the function', function() {
-      var $fruits = $(fruits).children();
+      var $fruits = $('#fruits').children();
       var args = [];
       var thisVals = [];
       var toAdd = ['apple red', '', undefined];
@@ -539,120 +539,114 @@ describe('$(...)', function() {
   describe('.toggleClass', function() {
 
     it('(class class) : should toggle multiple classes from the element', function() {
-      var $fruits = $(fruits);
+      $('.apple').addClass('fruit');
+      expect($('.apple').hasClass('apple')).to.be.ok();
+      expect($('.apple').hasClass('fruit')).to.be.ok();
+      expect($('.apple').hasClass('red')).to.not.be.ok();
 
-      $('.apple', $fruits).addClass('fruit');
-      expect($('.apple', $fruits).hasClass('apple')).to.be.ok();
-      expect($('.apple', $fruits).hasClass('fruit')).to.be.ok();
-      expect($('.apple', $fruits).hasClass('red')).to.not.be.ok();
-
-      $('.apple', $fruits).toggleClass('apple red');
-      expect($('.fruit', $fruits).hasClass('apple')).to.not.be.ok();
-      expect($('.fruit', $fruits).hasClass('red')).to.be.ok();
-      expect($('.fruit', $fruits).hasClass('fruit')).to.be.ok();
+      $('.apple').toggleClass('apple red');
+      expect($('.fruit').hasClass('apple')).to.not.be.ok();
+      expect($('.fruit').hasClass('red')).to.be.ok();
+      expect($('.fruit').hasClass('fruit')).to.be.ok();
     });
 
     it('(class class, true) : should add multiple classes to the element', function() {
-      var $fruits = $(fruits);
+      $('.apple').addClass('fruit');
+      expect($('.apple').hasClass('apple')).to.be.ok();
+      expect($('.apple').hasClass('fruit')).to.be.ok();
+      expect($('.apple').hasClass('red')).to.not.be.ok();
 
-      $('.apple', $fruits).addClass('fruit');
-      expect($('.apple', $fruits).hasClass('apple')).to.be.ok();
-      expect($('.apple', $fruits).hasClass('fruit')).to.be.ok();
-      expect($('.apple', $fruits).hasClass('red')).to.not.be.ok();
-
-      $('.apple', $fruits).toggleClass('apple red', true);
-      expect($('.fruit', $fruits).hasClass('apple')).to.be.ok();
-      expect($('.fruit', $fruits).hasClass('red')).to.be.ok();
-      expect($('.fruit', $fruits).hasClass('fruit')).to.be.ok();
+      $('.apple').toggleClass('apple red', true);
+      expect($('.fruit').hasClass('apple')).to.be.ok();
+      expect($('.fruit').hasClass('red')).to.be.ok();
+      expect($('.fruit').hasClass('fruit')).to.be.ok();
     });
 
     it('(class class, false) : should remove multiple classes from the element', function() {
-      var $fruits = $(fruits);
+      $('.apple').addClass('fruit');
+      expect($('.apple').hasClass('apple')).to.be.ok();
+      expect($('.apple').hasClass('fruit')).to.be.ok();
+      expect($('.apple').hasClass('red')).to.not.be.ok();
 
-      $('.apple', $fruits).addClass('fruit');
-      expect($('.apple', $fruits).hasClass('apple')).to.be.ok();
-      expect($('.apple', $fruits).hasClass('fruit')).to.be.ok();
-      expect($('.apple', $fruits).hasClass('red')).to.not.be.ok();
-
-      $('.apple', $fruits).toggleClass('apple red', false);
-      expect($('.fruit', $fruits).hasClass('apple')).to.not.be.ok();
-      expect($('.fruit', $fruits).hasClass('red')).to.not.be.ok();
-      expect($('.fruit', $fruits).hasClass('fruit')).to.be.ok();
+      $('.apple').toggleClass('apple red', false);
+      expect($('.fruit').hasClass('apple')).to.not.be.ok();
+      expect($('.fruit').hasClass('red')).to.not.be.ok();
+      expect($('.fruit').hasClass('fruit')).to.be.ok();
     });
 
     it('(fn) : should toggle classes returned from the function', function() {
-      var $food = $(food);
+      $ = cheerio.load(food);
 
-      $('.apple', $food).addClass('fruit');
-      $('.carrot', $food).addClass('vegetable');
-      expect($('.apple', $food).hasClass('fruit')).to.be.ok();
-      expect($('.apple', $food).hasClass('vegetable')).to.not.be.ok();
-      expect($('.orange', $food).hasClass('fruit')).to.not.be.ok();
-      expect($('.orange', $food).hasClass('vegetable')).to.not.be.ok();
-      expect($('.carrot', $food).hasClass('fruit')).to.not.be.ok();
-      expect($('.carrot', $food).hasClass('vegetable')).to.be.ok();
-      expect($('.sweetcorn', $food).hasClass('fruit')).to.not.be.ok();
-      expect($('.sweetcorn', $food).hasClass('vegetable')).to.not.be.ok();
+      $('.apple').addClass('fruit');
+      $('.carrot').addClass('vegetable');
+      expect($('.apple').hasClass('fruit')).to.be.ok();
+      expect($('.apple').hasClass('vegetable')).to.not.be.ok();
+      expect($('.orange').hasClass('fruit')).to.not.be.ok();
+      expect($('.orange').hasClass('vegetable')).to.not.be.ok();
+      expect($('.carrot').hasClass('fruit')).to.not.be.ok();
+      expect($('.carrot').hasClass('vegetable')).to.be.ok();
+      expect($('.sweetcorn').hasClass('fruit')).to.not.be.ok();
+      expect($('.sweetcorn').hasClass('vegetable')).to.not.be.ok();
 
-      $('li', $food).toggleClass(function(index, className, switchVal) {
+      $('li').toggleClass(function(index, className, switchVal) {
         return $(this).parent().is('#fruits') ? 'fruit' : 'vegetable';
       });
-      expect($('.apple', $food).hasClass('fruit')).to.not.be.ok();
-      expect($('.apple', $food).hasClass('vegetable')).to.not.be.ok();
-      expect($('.orange', $food).hasClass('fruit')).to.be.ok();
-      expect($('.orange', $food).hasClass('vegetable')).to.not.be.ok();
-      expect($('.carrot', $food).hasClass('fruit')).to.not.be.ok();
-      expect($('.carrot', $food).hasClass('vegetable')).to.not.be.ok();
-      expect($('.sweetcorn', $food).hasClass('fruit')).to.not.be.ok();
-      expect($('.sweetcorn', $food).hasClass('vegetable')).to.be.ok();
+      expect($('.apple').hasClass('fruit')).to.not.be.ok();
+      expect($('.apple').hasClass('vegetable')).to.not.be.ok();
+      expect($('.orange').hasClass('fruit')).to.be.ok();
+      expect($('.orange').hasClass('vegetable')).to.not.be.ok();
+      expect($('.carrot').hasClass('fruit')).to.not.be.ok();
+      expect($('.carrot').hasClass('vegetable')).to.not.be.ok();
+      expect($('.sweetcorn').hasClass('fruit')).to.not.be.ok();
+      expect($('.sweetcorn').hasClass('vegetable')).to.be.ok();
     });
 
   });
 
   describe('.is', function () {
     it('() : should return false', function() {
-      expect($('li.apple', fruits).is()).to.be(false);
+      expect($('li.apple').is()).to.be(false);
     });
 
     it('(true selector) : should return true', function() {
-      expect($('#vegetables', vegetables).is('ul')).to.be(true);
+      expect(cheerio('#vegetables', vegetables).is('ul')).to.be(true);
     });
 
     it('(false selector) : should return false', function() {
-      expect($('#vegetables', vegetables).is('div')).to.be(false);
+      expect(cheerio('#vegetables', vegetables).is('div')).to.be(false);
     });
 
     it('(true selection) : should return true', function() {
-      var $vegetables = $('li', vegetables);
+      var $vegetables = cheerio('li', vegetables);
       expect($vegetables.is($vegetables.eq(1))).to.be(true);
     });
 
     it('(false selection) : should return false', function() {
-      var $vegetableList = $(vegetables);
+      var $vegetableList = cheerio(vegetables);
       var $vegetables = $vegetableList.find('li');
       expect($vegetables.is($vegetableList)).to.be(false);
     });
 
     it('(true element) : should return true', function() {
-      var $vegetables = $('li', vegetables);
+      var $vegetables = cheerio('li', vegetables);
       expect($vegetables.is($vegetables[0])).to.be(true);
     });
 
     it('(false element) : should return false', function() {
-      var $vegetableList = $(vegetables);
+      var $vegetableList = cheerio(vegetables);
       var $vegetables = $vegetableList.find('li');
       expect($vegetables.is($vegetableList[0])).to.be(false);
     });
 
     it('(true predicate) : should return true', function() {
-      var result = $('li', fruits).is(function() {
+      var result = $('li').is(function() {
         return this.name === 'li' && $(this).hasClass('pear');
       });
       expect(result).to.be(true);
     });
 
     it('(false predicate) : should return false', function () {
-      var result = $('li', fruits).last().is(function() {
+      var result = $('li').last().is(function() {
         return this.name === 'ul';
       });
       expect(result).to.be(false);

--- a/test/api.css.js
+++ b/test/api.css.js
@@ -1,50 +1,50 @@
 var expect = require('expect.js');
-var $ = require('..');
+var cheerio = require('..');
 
 describe('$(...)', function() {
 
   describe('.css', function() {
     it('(prop): should return a css property value', function() {
-      var el = $('<li style="hai: there">');
+      var el = cheerio('<li style="hai: there">');
       expect(el.css('hai')).to.equal('there');
     });
 
     it('([prop1, prop2]): should return the specified property values as an object', function() {
-      var el = $('<li style="margin: 1px; padding: 2px; color: blue;">');
+      var el = cheerio('<li style="margin: 1px; padding: 2px; color: blue;">');
       expect(el.css(['margin', 'color'])).to.eql({ margin: '1px', color: 'blue' });
     });
 
     it('(prop, val): should set a css property', function() {
-      var el = $('<li style="margin: 0;"></li><li></li>');
+      var el = cheerio('<li style="margin: 0;"></li><li></li>');
       el.css('color', 'red');
       expect(el.attr('style')).to.equal('margin: 0; color: red;');
       expect(el.eq(1).attr('style')).to.equal('color: red;');
     });
 
     it('(prop, ""): should unset a css property', function() {
-      var el = $('<li style="padding: 1px; margin: 0;">');
+      var el = cheerio('<li style="padding: 1px; margin: 0;">');
       el.css('padding', '');
       expect(el.attr('style')).to.equal('margin: 0;');
     });
 
     it('(prop): should not mangle embedded urls', function() {
-      var el = $('<li style="background-image:url(http://example.com/img.png);">');
+      var el = cheerio('<li style="background-image:url(http://example.com/img.png);">');
       expect(el.css('background-image')).to.equal('url(http://example.com/img.png)');
     });
 
     it('(prop): should ignore blank properties', function() {
-      var el = $('<li style=":#ccc;color:#aaa;">');
+      var el = cheerio('<li style=":#ccc;color:#aaa;">');
       expect(el.css()).to.eql({color:'#aaa'});
     });
 
     it('(prop): should ignore blank values', function() {
-      var el = $('<li style="color:;position:absolute;">');
+      var el = cheerio('<li style="color:;position:absolute;">');
       expect(el.css()).to.eql({position:'absolute'});
     });
 
     describe('(prop, function):', function() {
       beforeEach(function() {
-        this.$el = $('<div style="margin: 0;"></div><div style="margin: 0;"></div><div style="margin: 0;">');
+        this.$el = cheerio('<div style="margin: 0;"></div><div style="margin: 0;"></div><div style="margin: 0;">');
       });
 
       it('should iterate over the selection', function() {
@@ -71,7 +71,7 @@ describe('$(...)', function() {
     });
 
     it('(obj): should set each key and val', function() {
-      var el = $('<li style="padding: 0;"></li><li></li>');
+      var el = cheerio('<li style="padding: 0;"></li><li></li>');
       el.css({ foo: 0 });
       expect(el.eq(0).attr('style')).to.equal('padding: 0; foo: 0;');
       expect(el.eq(1).attr('style')).to.equal('foo: 0;');
@@ -79,7 +79,7 @@ describe('$(...)', function() {
 
     describe('parser', function(){
       it('should allow any whitespace between declarations', function() {
-        var el = $('<li style="one \t:\n 0;\n two \f\r:\v 1">');
+        var el = cheerio('<li style="one \t:\n 0;\n two \f\r:\v 1">');
         expect(el.css(['one', 'two'])).to.eql({ one: 0, two: 1 });
       });
     });

--- a/test/api.manipulation.js
+++ b/test/api.manipulation.js
@@ -1,38 +1,41 @@
 var expect = require('expect.js'),
-    $ = require('../'),
+    cheerio = require('..'),
     fruits = require('./fixtures').fruits,
     toArray = Function.call.bind(Array.prototype.slice);
 
 describe('$(...)', function() {
 
+  var $, $fruits;
+
+  beforeEach(function() {
+    $ = cheerio.load(fruits);
+    $fruits = $('#fruits');
+  });
+
   describe('.append', function() {
 
     it('() : should do nothing', function() {
-      expect($('#fruits', fruits).append()[0].name).to.equal('ul');
+      expect($('#fruits').append()[0].name).to.equal('ul');
     });
 
     it('(html) : should add element as last child', function() {
-      var $fruits = $(fruits);
       $fruits.append('<li class="plum">Plum</li>');
       expect($fruits.children(3).hasClass('plum')).to.be.ok();
     });
 
     it('($(...)) : should add element as last child', function() {
-      var $fruits = $(fruits);
       var $plum = $('<li class="plum">Plum</li>');
       $fruits.append($plum);
       expect($fruits.children(3).hasClass('plum')).to.be.ok();
     });
 
     it('(Node) : should add element as last child', function() {
-      var $fruits = $(fruits);
       var plum = $('<li class="plum">Plum</li>')[0];
       $fruits.append(plum);
       expect($fruits.children(3).hasClass('plum')).to.be.ok();
     });
 
     it('(existing Node) : should remove node from previous location', function() {
-      var $fruits = $(fruits);
       var apple = $fruits.children()[0];
       var $children;
 
@@ -46,7 +49,6 @@ describe('$(...)', function() {
     });
 
     it('(existing Node) : should remove existing node from previous location', function() {
-      var $fruits = $(fruits);
       var apple = $fruits.children()[0];
       var $children;
       var $dest = $('<div></div>');
@@ -63,8 +65,7 @@ describe('$(...)', function() {
     });
 
     it('(elem) : should NOP if removed', function() {
-      var $fruits = $(fruits);
-      var $apple = $('.apple', $fruits);
+      var $apple = $('.apple');
 
       $apple.remove();
       $fruits.append($apple);
@@ -72,7 +73,6 @@ describe('$(...)', function() {
     });
 
     it('($(...), html) : should add multiple elements as last children', function() {
-      var $fruits = $(fruits);
       var $plum = $('<li class="plum">Plum</li>');
       var grape = '<li class="grape">Grape</li>';
       $fruits.append($plum, grape);
@@ -81,7 +81,6 @@ describe('$(...)', function() {
     });
 
     it('(Array) : should append all elements in the array', function() {
-      var $fruits = $(fruits);
       var more = $('<li class="plum">Plum</li><li class="grape">Grape</li>')
         .get();
       $fruits.append(more);
@@ -90,7 +89,7 @@ describe('$(...)', function() {
     });
 
     it('(fn) : should invoke the callback with the correct argument and context', function() {
-      var $fruits = $(fruits).children();
+      $fruits = $fruits.children();
       var args = [];
       var thisValues = [];
 
@@ -112,7 +111,7 @@ describe('$(...)', function() {
     });
 
     it('(fn) : should add returned string as last child', function() {
-      var $fruits = $(fruits).children();
+      $fruits = $fruits.children();
       var $apple, $orange, $pear;
 
       $fruits.append(function() {
@@ -129,8 +128,8 @@ describe('$(...)', function() {
     });
 
     it('(fn) : should add returned Cheerio object as last child', function() {
-      var $fruits = $(fruits).children();
       var $apple, $orange, $pear;
+      $fruits = $fruits.children();
 
       $fruits.append(function() {
         return $('<div class="second">');
@@ -146,8 +145,8 @@ describe('$(...)', function() {
     });
 
     it('(fn) : should add returned Node as last child', function() {
-      var $fruits = $(fruits).children();
       var $apple, $orange, $pear;
+      $fruits = $fruits.children();
 
       $fruits.append(function() {
         return $('<div class="third">')[0];
@@ -172,7 +171,6 @@ describe('$(...)', function() {
     });
 
     it('($(...)) : should remove from root element', function() {
-      var $fruits = $(fruits);
       var $plum = $('<li class="plum">Plum</li>');
       var root = $plum[0].root;
       expect(root).to.be.ok();
@@ -186,31 +184,27 @@ describe('$(...)', function() {
   describe('.prepend', function() {
 
     it('() : should do nothing', function() {
-      expect($('#fruits', fruits).prepend()[0].name).to.equal('ul');
+      expect($('#fruits').prepend()[0].name).to.equal('ul');
     });
 
     it('(html) : should add element as first child', function() {
-      var $fruits = $(fruits);
       $fruits.prepend('<li class="plum">Plum</li>');
       expect($fruits.children(0).hasClass('plum')).to.be.ok();
     });
 
     it('($(...)) : should add element as first child', function() {
-      var $fruits = $(fruits);
       var $plum = $('<li class="plum">Plum</li>');
       $fruits.prepend($plum);
       expect($fruits.children(0).hasClass('plum')).to.be.ok();
     });
 
     it('(Node) : should add node as first child', function() {
-      var $fruits = $(fruits);
       var plum = $('<li class="plum">Plum</li>')[0];
       $fruits.prepend(plum);
       expect($fruits.children(0).hasClass('plum')).to.be.ok();
     });
 
     it('(existing Node) : should remove existing nodes from previous locations', function() {
-      var $fruits = $(fruits);
       var pear = $fruits.children()[2];
       var $children;
 
@@ -224,8 +218,7 @@ describe('$(...)', function() {
     });
 
     it('(elem) : should handle if removed', function() {
-      var $fruits = $(fruits);
-      var $apple = $('.apple', $fruits);
+      var $apple = $('.apple');
 
       $apple.remove();
       $fruits.prepend($apple);
@@ -233,7 +226,6 @@ describe('$(...)', function() {
     });
 
     it('(Array) : should add all elements in the array as inital children', function() {
-      var $fruits = $(fruits);
       var more = $('<li class="plum">Plum</li><li class="grape">Grape</li>')
         .get();
       $fruits.prepend(more);
@@ -242,7 +234,6 @@ describe('$(...)', function() {
     });
 
     it('(html, $(...), html) : should add multiple elements as first children', function() {
-      var $fruits = $(fruits);
       var $plum = $('<li class="plum">Plum</li>');
       var grape = '<li class="grape">Grape</li>';
       $fruits.prepend($plum, grape);
@@ -251,9 +242,9 @@ describe('$(...)', function() {
     });
 
     it('(fn) : should invoke the callback with the correct argument and context', function() {
-      var $fruits = $(fruits).children();
       var args = [];
       var thisValues = [];
+      $fruits = $fruits.children();
 
       $fruits.prepend(function() {
         args.push(toArray(arguments));
@@ -273,8 +264,8 @@ describe('$(...)', function() {
     });
 
     it('(fn) : should add returned string as first child', function() {
-      var $fruits = $(fruits).children();
       var $apple, $orange, $pear;
+      $fruits = $fruits.children();
 
       $fruits.prepend(function() {
         return '<div class="first">';
@@ -290,8 +281,8 @@ describe('$(...)', function() {
     });
 
     it('(fn) : should add returned Cheerio object as first child', function() {
-      var $fruits = $(fruits).children();
       var $apple, $orange, $pear;
+      $fruits = $fruits.children();
 
       $fruits.prepend(function() {
         return $('<div class="second">');
@@ -307,8 +298,8 @@ describe('$(...)', function() {
     });
 
     it('(fn) : should add returned Node as first child', function() {
-      var $fruits = $(fruits).children();
       var $apple, $orange, $pear;
+      $fruits = $fruits.children();
 
       $fruits.prepend(function() {
         return $('<div class="third">')[0];
@@ -325,7 +316,6 @@ describe('$(...)', function() {
 
 
     it('($(...)) : should remove from root element', function() {
-      var $fruits = $(fruits);
       var $plum = $('<li class="plum">Plum</li>');
       var root = $plum[0].root;
       expect(root).to.be.ok();
@@ -339,45 +329,40 @@ describe('$(...)', function() {
   describe('.after', function() {
 
     it('() : should do nothing', function() {
-      expect($('#fruits', fruits).after()[0].name).to.equal('ul');
+      expect($('#fruits').after()[0].name).to.equal('ul');
     });
 
     it('(html) : should add element as next sibling', function() {
-      var $fruits = $(fruits);
       var grape = '<li class="grape">Grape</li>';
-      $('.apple', $fruits).after(grape);
-      expect($('.apple', $fruits).next().hasClass('grape')).to.be.ok();
+      $('.apple').after(grape);
+      expect($('.apple').next().hasClass('grape')).to.be.ok();
     });
 
     it('(Array) : should add all elements in the array as next sibling', function() {
-      var $fruits = $(fruits);
       var more = $('<li class="plum">Plum</li><li class="grape">Grape</li>')
         .get();
-      $('.apple', $fruits).after(more);
+      $('.apple').after(more);
       expect($fruits.children(1).hasClass('plum')).to.be.ok();
       expect($fruits.children(2).hasClass('grape')).to.be.ok();
     });
 
     it('($(...)) : should add element as next sibling', function() {
-      var $fruits = $(fruits);
       var $plum = $('<li class="plum">Plum</li>');
-      $('.apple', $fruits).after($plum);
-      expect($('.apple', $fruits).next().hasClass('plum')).to.be.ok();
+      $('.apple').after($plum);
+      expect($('.apple').next().hasClass('plum')).to.be.ok();
     });
 
     it('(Node) : should add element as next sibling', function() {
-      var $fruits = $(fruits);
       var plum = $('<li class="plum">Plum</li>')[0];
-      $('.apple', $fruits).after(plum);
-      expect($('.apple', $fruits).next().hasClass('plum')).to.be.ok();
+      $('.apple').after(plum);
+      expect($('.apple').next().hasClass('plum')).to.be.ok();
     });
 
     it('(existing Node) : should remove existing nodes from previous locations', function() {
-      var $fruits = $(fruits);
       var pear = $fruits.children()[2];
       var $children;
 
-      $('.apple', $fruits).after(pear);
+      $('.apple').after(pear);
 
       $children = $fruits.children();
       expect($children).to.have.length(3);
@@ -385,8 +370,7 @@ describe('$(...)', function() {
     });
 
     it('(elem) : should handle if removed', function() {
-      var $fruits = $(fruits);
-      var $apple = $('.apple', $fruits);
+      var $apple = $('.apple');
       var $plum = $('<li class="plum">Plum</li>');
 
       $apple.remove();
@@ -395,18 +379,17 @@ describe('$(...)', function() {
     });
 
     it('($(...), html) : should add multiple elements as next siblings', function() {
-      var $fruits = $(fruits);
       var $plum = $('<li class="plum">Plum</li>');
       var grape = '<li class="grape">Grape</li>';
-      $('.apple', $fruits).after($plum, grape);
-      expect($('.apple', $fruits).next().hasClass('plum')).to.be.ok();
-      expect($('.plum', $fruits).next().hasClass('grape')).to.be.ok();
+      $('.apple').after($plum, grape);
+      expect($('.apple').next().hasClass('plum')).to.be.ok();
+      expect($('.plum').next().hasClass('grape')).to.be.ok();
     });
 
     it('(fn) : should invoke the callback with the correct argument and context', function() {
-      var $fruits = $(fruits).children();
       var args = [];
       var thisValues = [];
+      $fruits = $fruits.children();
 
       $fruits.after(function() {
         args.push(toArray(arguments));
@@ -422,46 +405,42 @@ describe('$(...)', function() {
     });
 
     it('(fn) : should add returned string as next sibling', function() {
-      var $list = $(fruits);
-      var $fruits = $list.children();
+      $fruits = $fruits.children();
 
       $fruits.after(function() {
         return '<li class="first">';
       });
 
-      expect($list.find('.first')[0]).to.equal($list.contents()[1]);
-      expect($list.find('.first')[1]).to.equal($list.contents()[3]);
-      expect($list.find('.first')[2]).to.equal($list.contents()[5]);
+      expect($('.first')[0]).to.equal($('#fruits').contents()[1]);
+      expect($('.first')[1]).to.equal($('#fruits').contents()[3]);
+      expect($('.first')[2]).to.equal($('#fruits').contents()[5]);
     });
 
     it('(fn) : should add returned Cheerio object as next sibling', function() {
-      var $list = $(fruits);
-      var $fruits = $list.children();
+      $fruits = $fruits.children();
 
       $fruits.after(function() {
         return $('<li class="second">');
       });
 
-      expect($list.find('.second')[0]).to.equal($list.contents()[1]);
-      expect($list.find('.second')[1]).to.equal($list.contents()[3]);
-      expect($list.find('.second')[2]).to.equal($list.contents()[5]);
+      expect($('.second')[0]).to.equal($('#fruits').contents()[1]);
+      expect($('.second')[1]).to.equal($('#fruits').contents()[3]);
+      expect($('.second')[2]).to.equal($('#fruits').contents()[5]);
     });
 
     it('(fn) : should add returned element as next sibling', function() {
-      var $list = $(fruits);
-      var $fruits = $list.children();
+      $fruits = $fruits.children();
 
       $fruits.after(function() {
         return $('<li class="third">')[0];
       });
 
-      expect($list.find('.third')[0]).to.equal($list.contents()[1]);
-      expect($list.find('.third')[1]).to.equal($list.contents()[3]);
-      expect($list.find('.third')[2]).to.equal($list.contents()[5]);
+      expect($('.third')[0]).to.equal($('#fruits').contents()[1]);
+      expect($('.third')[1]).to.equal($('#fruits').contents()[3]);
+      expect($('.third')[2]).to.equal($('#fruits').contents()[5]);
     });
 
     it('($(...)) : should remove from root element', function() {
-      var $fruits = $(fruits);
       var $plum = $('<li class="plum">Plum</li>');
       var root = $plum[0].root;
       expect(root).to.be.ok();
@@ -475,36 +454,32 @@ describe('$(...)', function() {
   describe('.before', function() {
 
     it('() : should do nothing', function() {
-      expect($('#fruits', fruits).before()[0].name).to.equal('ul');
+      expect($('#fruits').before()[0].name).to.equal('ul');
     });
 
     it('(html) : should add element as previous sibling', function() {
-      var $fruits = $(fruits);
       var grape = '<li class="grape">Grape</li>';
-      $('.apple', $fruits).before(grape);
-      expect($('.apple', $fruits).prev().hasClass('grape')).to.be.ok();
+      $('.apple').before(grape);
+      expect($('.apple').prev().hasClass('grape')).to.be.ok();
     });
 
     it('($(...)) : should add element as previous sibling', function() {
-      var $fruits = $(fruits);
       var $plum = $('<li class="plum">Plum</li>');
-      $('.apple', $fruits).before($plum);
-      expect($('.apple', $fruits).prev().hasClass('plum')).to.be.ok();
+      $('.apple').before($plum);
+      expect($('.apple').prev().hasClass('plum')).to.be.ok();
     });
 
     it('(Node) : should add element as previous sibling', function() {
-      var $fruits = $(fruits);
       var plum = $('<li class="plum">Plum</li>');
-      $('.apple', $fruits).before(plum);
-      expect($('.apple', $fruits).prev().hasClass('plum')).to.be.ok();
+      $('.apple').before(plum);
+      expect($('.apple').prev().hasClass('plum')).to.be.ok();
     });
 
     it('(existing Node) : should remove existing nodes from previous locations', function() {
-      var $fruits = $(fruits);
       var pear = $fruits.children()[2];
       var $children;
 
-      $('.apple', $fruits).before(pear);
+      $('.apple').before(pear);
 
       $children = $fruits.children();
       expect($children).to.have.length(3);
@@ -512,8 +487,7 @@ describe('$(...)', function() {
     });
 
     it('(elem) : should handle if removed', function() {
-      var $fruits = $(fruits);
-      var $apple = $('.apple', $fruits);
+      var $apple = $('.apple');
       var $plum = $('<li class="plum">Plum</li>');
 
       $apple.remove();
@@ -522,27 +496,25 @@ describe('$(...)', function() {
     });
 
     it('(Array) : should add all elements in the array as previous sibling', function() {
-      var $fruits = $(fruits);
       var more = $('<li class="plum">Plum</li><li class="grape">Grape</li>')
         .get();
-      $('.apple', $fruits).before(more);
+      $('.apple').before(more);
       expect($fruits.children(0).hasClass('plum')).to.be.ok();
       expect($fruits.children(1).hasClass('grape')).to.be.ok();
     });
 
     it('($(...), html) : should add multiple elements as previous siblings', function() {
-      var $fruits = $(fruits);
       var $plum = $('<li class="plum">Plum</li>');
       var grape = '<li class="grape">Grape</li>';
-      $('.apple', $fruits).before($plum, grape);
-      expect($('.apple', $fruits).prev().hasClass('grape')).to.be.ok();
-      expect($('.grape', $fruits).prev().hasClass('plum')).to.be.ok();
+      $('.apple').before($plum, grape);
+      expect($('.apple').prev().hasClass('grape')).to.be.ok();
+      expect($('.grape').prev().hasClass('plum')).to.be.ok();
     });
 
     it('(fn) : should invoke the callback with the correct argument and context', function() {
-      var $fruits = $(fruits).children();
       var args = [];
       var thisValues = [];
+      $fruits = $fruits.children();
 
       $fruits.before(function() {
         args.push(toArray(arguments));
@@ -558,46 +530,42 @@ describe('$(...)', function() {
     });
 
     it('(fn) : should add returned string as previous sibling', function() {
-      var $list = $(fruits);
-      var $fruits = $list.children();
+      $fruits = $fruits.children();
 
       $fruits.before(function() {
         return '<li class="first">';
       });
 
-      expect($list.find('.first')[0]).to.equal($list.contents()[0]);
-      expect($list.find('.first')[1]).to.equal($list.contents()[2]);
-      expect($list.find('.first')[2]).to.equal($list.contents()[4]);
+      expect($('.first')[0]).to.equal($('#fruits').contents()[0]);
+      expect($('.first')[1]).to.equal($('#fruits').contents()[2]);
+      expect($('.first')[2]).to.equal($('#fruits').contents()[4]);
     });
 
     it('(fn) : should add returned Cheerio object as previous sibling', function() {
-      var $list = $(fruits);
-      var $fruits = $list.children();
+      $fruits = $fruits.children();
 
       $fruits.before(function() {
         return $('<li class="second">');
       });
 
-      expect($list.find('.second')[0]).to.equal($list.contents()[0]);
-      expect($list.find('.second')[1]).to.equal($list.contents()[2]);
-      expect($list.find('.second')[2]).to.equal($list.contents()[4]);
+      expect($('.second')[0]).to.equal($('#fruits').contents()[0]);
+      expect($('.second')[1]).to.equal($('#fruits').contents()[2]);
+      expect($('.second')[2]).to.equal($('#fruits').contents()[4]);
     });
 
     it('(fn) : should add returned Node as previous sibling', function() {
-      var $list = $(fruits);
-      var $fruits = $list.children();
+      $fruits = $fruits.children();
 
       $fruits.before(function() {
         return $('<li class="third">')[0];
       });
 
-      expect($list.find('.third')[0]).to.equal($list.contents()[0]);
-      expect($list.find('.third')[1]).to.equal($list.contents()[2]);
-      expect($list.find('.third')[2]).to.equal($list.contents()[4]);
+      expect($('.third')[0]).to.equal($('#fruits').contents()[0]);
+      expect($('.third')[1]).to.equal($('#fruits').contents()[2]);
+      expect($('.third')[2]).to.equal($('#fruits').contents()[4]);
     });
 
     it('($(...)) : should remove from root element', function() {
-      var $fruits = $(fruits);
       var $plum = $('<li class="plum">Plum</li>');
       var root = $plum[0].root;
       expect(root).to.be.ok();
@@ -611,27 +579,23 @@ describe('$(...)', function() {
   describe('.remove', function() {
 
     it('() : should remove selected elements', function() {
-      var $fruits = $(fruits);
-      $('.apple', $fruits).remove();
+      $('.apple').remove();
       expect($fruits.find('.apple')).to.have.length(0);
     });
 
     it('() : should be reentrant', function() {
-      var $fruits = $(fruits),
-          $apple = $('.apple', $fruits);
+      var $apple = $('.apple');
       $apple.remove();
       $apple.remove();
       expect($fruits.find('.apple')).to.have.length(0);
     });
 
     it('(selector) : should remove matching selected elements', function() {
-      var $fruits = $(fruits);
-      $('li', $fruits).remove('.apple');
+      $('li').remove('.apple');
       expect($fruits.find('.apple')).to.have.length(0);
     });
 
     it('($(...)) : should remove from root element', function() {
-      var $fruits = $(fruits);
       var $plum = $('<li class="plum">Plum</li>');
       var root = $plum[0].root;
       expect(root).to.be.ok();
@@ -645,18 +609,16 @@ describe('$(...)', function() {
   describe('.replaceWith', function() {
 
     it('(elem) : should replace one <li> tag with another', function() {
-      var $fruits = $(fruits);
       var $plum = $('<li class="plum">Plum</li>');
-      $('.pear', $fruits).replaceWith($plum);
-      expect($('.orange', $fruits).next().hasClass('plum')).to.be.ok();
-      expect($('.orange', $fruits).next().html()).to.equal('Plum');
+      $('.pear').replaceWith($plum);
+      expect($('.orange').next().hasClass('plum')).to.be.ok();
+      expect($('.orange').next().html()).to.equal('Plum');
     });
 
     it('(Array) : should replace one <li> tag with the elements in the array', function() {
-      var $fruits = $(fruits);
       var more = $('<li class="plum">Plum</li><li class="grape">Grape</li>')
         .get();
-      $('.pear', $fruits).replaceWith(more);
+      $('.pear').replaceWith(more);
 
       expect($fruits.children(2).hasClass('plum')).to.be.ok();
       expect($fruits.children(3).hasClass('grape')).to.be.ok();
@@ -673,21 +635,19 @@ describe('$(...)', function() {
     });
 
     it('(existing element) : should remove element from its previous location', function() {
-      var $fruits = $(fruits);
-      $('.pear', $fruits).replaceWith($('.apple', $fruits));
+      $('.pear').replaceWith($('.apple'));
       expect($fruits.children()).to.have.length(2);
-      expect($fruits.children()[0]).to.equal($('.orange', $fruits)[0]);
-      expect($fruits.children()[1]).to.equal($('.apple', $fruits)[0]);
+      expect($fruits.children()[0]).to.equal($('.orange')[0]);
+      expect($fruits.children()[1]).to.equal($('.apple')[0]);
     });
 
     it('(elem) : should NOP if removed', function() {
-      var $fruits = $(fruits);
-      var $pear = $('.pear', $fruits);
+      var $pear = $('.pear');
       var $plum = $('<li class="plum">Plum</li>');
 
       $pear.remove();
       $pear.replaceWith($plum);
-      expect($('.orange', $fruits).next().hasClass('plum')).to.not.be.ok();
+      expect($('.orange').next().hasClass('plum')).to.not.be.ok();
     });
 
     it('(elem) : should replace the single selected element with given element', function() {
@@ -715,7 +675,6 @@ describe('$(...)', function() {
     });
 
     it('(fn) : should invoke the callback with the correct argument and context', function() {
-      var $fruits = $(fruits);
       var origChildren = $fruits.children().get();
       var args = [];
       var thisValues = [];
@@ -739,8 +698,6 @@ describe('$(...)', function() {
     });
 
     it('(fn) : should replace the selected element with the returned string', function() {
-      var $fruits = $(fruits);
-
       $fruits.children().replaceWith(function() {
         return '<li class="first">';
       });
@@ -749,8 +706,6 @@ describe('$(...)', function() {
     });
 
     it('(fn) : should replace the selected element with the returned Cheerio object', function() {
-      var $fruits = $(fruits);
-
       $fruits.children().replaceWith(function() {
         return $('<li class="second">');
       });
@@ -759,8 +714,6 @@ describe('$(...)', function() {
     });
 
     it('(fn) : should replace the selected element with the returned node', function() {
-      var $fruits = $(fruits);
-
       $fruits.children().replaceWith(function() {
         return $('<li class="third">')[0];
       });
@@ -769,7 +722,6 @@ describe('$(...)', function() {
     });
 
     it('($(...)) : should remove from root element', function() {
-      var $fruits = $(fruits);
       var $plum = $('<li class="plum">Plum</li>');
       var root = $plum[0].root;
       expect(root).to.be.ok();
@@ -782,7 +734,6 @@ describe('$(...)', function() {
 
   describe('.empty', function() {
     it('() : should remove all children from selected elements', function() {
-      var $fruits = $(fruits);
       expect($fruits.children()).to.have.length(3);
 
       $fruits.empty();
@@ -790,8 +741,7 @@ describe('$(...)', function() {
     });
 
     it('() : should allow element reinsertion', function() {
-      var $fruits = $(fruits),
-          $children = $fruits.children();
+      var $children = $fruits.children();
 
       $fruits.empty();
       expect($fruits.children()).to.have.length(0);
@@ -805,7 +755,6 @@ describe('$(...)', function() {
     });
 
     it('() : should destroy children\'s references to the parent', function() {
-      var $fruits = $(fruits);
       var $children = $fruits.children();
 
       $fruits.empty();
@@ -826,7 +775,6 @@ describe('$(...)', function() {
   describe('.html', function() {
 
     it('() : should get the innerHTML for an element', function() {
-      var $fruits = $(fruits);
       expect($fruits.html()).to.equal([
         '<li class="apple">Apple</li>',
         '<li class="orange">Orange</li>',
@@ -845,14 +793,13 @@ describe('$(...)', function() {
     });
 
     it('(html) : should set the html for its children', function() {
-      var $fruits = $(fruits);
       $fruits.html('<li class="durian">Durian</li>');
       var html = $fruits.html();
       expect(html).to.equal('<li class="durian">Durian</li>');
     });
 
     it('(html) : should add new elements for each element in selection', function() {
-      var $fruits = $(fruits).find('li');
+      var $fruits = $('li');
       $fruits.html('<li class="durian">Durian</li>');
       var tested = 0;
       $fruits.each(function(){
@@ -863,15 +810,13 @@ describe('$(...)', function() {
     });
 
     it('(elem) : should set the html for its children with element', function() {
-      var $fruits = $(fruits);
       $fruits.html($('<li class="durian">Durian</li>'));
       var html = $fruits.html();
       expect(html).to.equal('<li class="durian">Durian</li>');
     });
 
     it('() : should allow element reinsertion', function() {
-      var $fruits = $(fruits),
-          $children = $fruits.children();
+      var $children = $fruits.children();
 
       $fruits.html('<div></div><div></div>');
       expect($fruits.children()).to.have.length(2);
@@ -885,12 +830,10 @@ describe('$(...)', function() {
 
   describe('.toString', function() {
     it('() : should get the outerHTML for an element', function() {
-      var $fruits = $(fruits);
       expect($fruits.toString()).to.equal(fruits);
     });
 
     it('() : should return an html string for a set of elements', function() {
-      var $fruits = $(fruits);
       expect($fruits.find('li').toString()).to.equal('<li class="apple">Apple</li><li class="orange">Orange</li><li class="pear">Pear</li>');
     });
 
@@ -903,24 +846,22 @@ describe('$(...)', function() {
   describe('.text', function() {
 
     it('() : gets the text for a single element', function() {
-      expect($('.apple', fruits).text()).to.equal('Apple');
+      expect($('.apple').text()).to.equal('Apple');
     });
 
     it('() : combines all text from children text nodes', function() {
-      expect($('#fruits', fruits).text()).to.equal('AppleOrangePear');
+      expect($('#fruits').text()).to.equal('AppleOrangePear');
     });
 
     it('(text) : sets the text for the child node', function() {
-      var $fruits = $(fruits);
-      $('.apple', $fruits).text('Granny Smith Apple');
-      expect($('.apple', $fruits)[0].children[0].data).to.equal('Granny Smith Apple');
+      $('.apple').text('Granny Smith Apple');
+      expect($('.apple')[0].children[0].data).to.equal('Granny Smith Apple');
     });
 
     it('(text) : inserts separate nodes for all children', function() {
-      var $fruits = $(fruits);
-      $('li', $fruits).text('Fruits');
+      $('li').text('Fruits');
       var tested = 0;
-      $('li', $fruits).each(function(){
+      $('li').each(function(){
         expect(this.children[0].parent).to.equal(this);
         tested++;
       });
@@ -928,13 +869,12 @@ describe('$(...)', function() {
     });
 
     it('should allow functions as arguments', function() {
-      var $fruits = $(fruits);
-      $('.apple', $fruits).text(function(idx, content) {
+      $('.apple').text(function(idx, content) {
         expect(idx).to.equal(0);
         expect(content).to.equal('Apple');
         return 'whatever mate';
       });
-      expect($('.apple', $fruits)[0].children[0].data).to.equal('whatever mate');
+      expect($('.apple')[0].children[0].data).to.equal('whatever mate');
     });
 
     it('should decode special chars', function() {
@@ -967,7 +907,7 @@ describe('$(...)', function() {
     });
 
     it('(str) should encode then decode unsafe characters', function() {
-      var $apple = $('.apple', fruits);
+      var $apple = $('.apple');
 
       $apple.text('blah <script>alert("XSS!")</script> blah');
       expect($apple[0].children[0].data).to.equal('blah <script>alert("XSS!")</script> blah');

--- a/test/api.traversing.js
+++ b/test/api.traversing.js
@@ -1,5 +1,5 @@
 var expect = require('expect.js'),
-  $ = require('../'),
+  cheerio = require('..'),
   food = require('./fixtures').food,
   fruits = require('./fixtures').fruits,
   drinks = require('./fixtures').drinks,
@@ -7,18 +7,24 @@ var expect = require('expect.js'),
 
 describe('$(...)', function() {
 
+  var $;
+
+  beforeEach(function() {
+    $ = cheerio.load(fruits);
+  });
+
   describe('.find', function() {
 
     it('() : should find nothing', function() {
-      expect($('ul', fruits).find()).to.have.length(0);
+      expect($('ul').find()).to.have.length(0);
     });
 
     it('(single) : should find one descendant', function() {
-      expect($('#fruits', fruits).find('.apple')[0].attribs['class']).to.equal('apple');
+      expect($('#fruits').find('.apple')[0].attribs['class']).to.equal('apple');
     });
 
     it('(many) : should find all matching descendant', function() {
-      expect($('#fruits', fruits).find('li')).to.have.length(3);
+      expect($('#fruits').find('li')).to.have.length(3);
     });
 
     it('(many) : should merge all selected elems with matching descendants', function() {
@@ -26,23 +32,23 @@ describe('$(...)', function() {
     });
 
     it('(invalid single) : should return empty if cant find', function() {
-      expect($('ul', fruits).find('blah')).to.have.length(0);
+      expect($('ul').find('blah')).to.have.length(0);
     });
 
     it('(invalid single) : should query descendants only', function() {
-      expect($('#fruits', fruits).find('ul')).to.have.length(0);
+      expect($('#fruits').find('ul')).to.have.length(0);
     });
 
     it('should return empty if search already empty result', function() {
-      expect($('#fruits').find('li')).to.have.length(0);
+      expect($('#not-fruits').find('li')).to.have.length(0);
     });
 
     it('should lowercase selectors', function() {
-      expect($('#fruits', fruits).find('LI')).to.have.length(3);
+      expect($('#fruits').find('LI')).to.have.length(3);
     });
 
     it('should query case-sensitively when in xmlMode', function() {
-      var q = $.load('<caseSenSitive allTheWay>', {xmlMode: true});
+      var q = cheerio.load('<caseSenSitive allTheWay>', {xmlMode: true});
       expect(q('caseSenSitive')).to.have.length(1);
       expect(q('[allTheWay]')).to.have.length(1);
       expect(q('casesensitive')).to.have.length(0);
@@ -62,7 +68,7 @@ describe('$(...)', function() {
   describe('.children', function() {
 
     it('() : should get all children', function() {
-      expect($('ul', fruits).children()).to.have.length(3);
+      expect($('ul').children()).to.have.length(3);
     });
 
     it('() : should return children of all matched elements', function() {
@@ -70,12 +76,12 @@ describe('$(...)', function() {
     });
 
     it('(selector) : should return children matching selector', function() {
-      var cls = $('ul', fruits).children('.orange')[0].attribs['class'];
+      var cls = $('ul').children('.orange')[0].attribs['class'];
       expect(cls).to.equal('orange');
     });
 
     it('(invalid selector) : should return empty', function() {
-      expect($('ul', fruits).children('.lulz')).to.have.length(0);
+      expect($('ul').children('.lulz')).to.have.length(0);
     });
 
     it('should only match immediate children, not ancestors', function() {
@@ -86,16 +92,20 @@ describe('$(...)', function() {
 
   describe('.contents', function() {
 
+    beforeEach(function() {
+      $ = cheerio.load(text);
+    });
+
     it('() : should get all contents', function() {
-      expect($('p', text).contents()).to.have.length(5);
+      expect($('p').contents()).to.have.length(5);
     });
 
     it('() : should include text nodes', function() {
-      expect($('p', text).contents().first()[0].type).to.equal('text');
+      expect($('p').contents().first()[0].type).to.equal('text');
     });
 
     it('() : should include comment nodes', function() {
-      expect($('p', text).contents().last()[0].type).to.equal('comment');
+      expect($('p').contents().last()[0].type).to.equal('comment');
     });
 
   });
@@ -103,16 +113,16 @@ describe('$(...)', function() {
   describe('.next', function() {
 
     it('() : should return next element', function() {
-      var cls = $('.orange', fruits).next()[0].attribs['class'];
+      var cls = $('.orange').next()[0].attribs['class'];
       expect(cls).to.equal('pear');
     });
 
     it('(no next) : should return empty for last child', function() {
-      expect($('.pear', fruits).next()).to.have.length(0);
+      expect($('.pear').next()).to.have.length(0);
     });
 
     it('(next on empty object) : should return empty', function() {
-      expect($('.banana', fruits).next()).to.have.length(0);
+      expect($('.banana').next()).to.have.length(0);
     });
 
     it('() : should operate over all elements in the selection', function() {
@@ -121,11 +131,11 @@ describe('$(...)', function() {
 
     describe('(selector) :', function() {
       it('should reject elements that violate the filter', function() {
-        expect($('.apple', fruits).next('.non-existent')).to.have.length(0);
+        expect($('.apple').next('.non-existent')).to.have.length(0);
       });
 
       it('should accept elements that satisify the filter', function() {
-        expect($('.apple', fruits).next('.orange')).to.have.length(1);
+        expect($('.apple').next('.orange')).to.have.length(1);
       });
     });
 
@@ -134,18 +144,18 @@ describe('$(...)', function() {
   describe('.nextAll', function() {
 
     it('() : should return all following siblings', function() {
-      var elems = $('.apple', fruits).nextAll();
+      var elems = $('.apple').nextAll();
       expect(elems).to.have.length(2);
       expect(elems[0].attribs['class']).to.equal('orange');
       expect(elems[1].attribs['class']).to.equal('pear');
     });
 
     it('(no next) : should return empty for last child', function() {
-      expect($('.pear', fruits).nextAll()).to.have.length(0);
+      expect($('.pear').nextAll()).to.have.length(0);
     });
 
     it('(nextAll on empty object) : should return empty', function() {
-      expect($('.banana', fruits).nextAll()).to.have.length(0);
+      expect($('.banana').nextAll()).to.have.length(0);
     });
 
     it('() : should operate over all elements in the selection', function() {
@@ -159,7 +169,7 @@ describe('$(...)', function() {
 
     describe('(selector) :', function() {
       it('should filter according to the provided selector', function() {
-        expect($('.apple', fruits).nextAll('.pear')).to.have.length(1);
+        expect($('.apple').nextAll('.pear')).to.have.length(1);
       });
 
       it('should not consider siblings\' contents when filtering', function() {
@@ -201,7 +211,7 @@ describe('$(...)', function() {
     });
 
     it('(selector not sibling) : should return all following siblings', function() {
-      var elems = $('.apple', fruits).nextUntil('#vegetables');
+      var elems = $('.apple').nextUntil('#vegetables');
       expect(elems).to.have.length(2);
     });
 
@@ -218,15 +228,15 @@ describe('$(...)', function() {
     });
 
     it('() : should return an empty object for last child', function() {
-      expect($('.pear', fruits).nextUntil()).to.have.length(0);
+      expect($('.pear').nextUntil()).to.have.length(0);
     });
 
     it('() : should return an empty object when called on an empty object', function() {
-      expect($('.banana', fruits).nextUntil()).to.have.length(0);
+      expect($('.banana').nextUntil()).to.have.length(0);
     });
 
     it('(node) : should return all following siblings until the node', function() {
-      var $fruits = $(fruits).children();
+      var $fruits = $('#fruits').children();
       var elems = $fruits.eq(0).nextUntil($fruits[2]);
       expect(elems).to.have.length(1);
     });
@@ -243,16 +253,16 @@ describe('$(...)', function() {
   describe('.prev', function() {
 
     it('() : should return previous element', function() {
-      var cls = $('.orange', fruits).prev()[0].attribs['class'];
+      var cls = $('.orange').prev()[0].attribs['class'];
       expect(cls).to.equal('apple');
     });
 
     it('(no prev) : should return empty for first child', function() {
-      expect($('.apple', fruits).prev()).to.have.length(0);
+      expect($('.apple').prev()).to.have.length(0);
     });
 
     it('(prev on empty object) : should return empty', function() {
-      expect($('.banana', fruits).prev()).to.have.length(0);
+      expect($('.banana').prev()).to.have.length(0);
     });
 
     it('() : should operate over all elements in the selection', function() {
@@ -261,11 +271,11 @@ describe('$(...)', function() {
 
     describe('(selector) :', function() {
       it('should reject elements that violate the filter', function() {
-        expect($('.orange', fruits).prev('.non-existent')).to.have.length(0);
+        expect($('.orange').prev('.non-existent')).to.have.length(0);
       });
 
       it('should accept elements that satisify the filter', function() {
-        expect($('.orange', fruits).prev('.apple')).to.have.length(1);
+        expect($('.orange').prev('.apple')).to.have.length(1);
       });
     });
 
@@ -274,18 +284,18 @@ describe('$(...)', function() {
   describe('.prevAll', function() {
 
     it('() : should return all preceding siblings', function() {
-      var elems = $('.pear', fruits).prevAll();
+      var elems = $('.pear').prevAll();
       expect(elems).to.have.length(2);
       expect(elems[0].attribs['class']).to.equal('orange');
       expect(elems[1].attribs['class']).to.equal('apple');
     });
 
     it('(no prev) : should return empty for first child', function() {
-      expect($('.apple', fruits).prevAll()).to.have.length(0);
+      expect($('.apple').prevAll()).to.have.length(0);
     });
 
     it('(prevAll on empty object) : should return empty', function() {
-      expect($('.banana', fruits).prevAll()).to.have.length(0);
+      expect($('.banana').prevAll()).to.have.length(0);
     });
 
     it('() : should operate over all elements in the selection', function() {
@@ -299,7 +309,7 @@ describe('$(...)', function() {
 
     describe('(selector) :', function() {
       it('should filter returned elements', function() {
-        var elems = $('.pear', fruits).prevAll('.apple');
+        var elems = $('.pear').prevAll('.apple');
         expect(elems).to.have.length(1);
       });
 
@@ -314,7 +324,7 @@ describe('$(...)', function() {
   describe('.prevUntil', function() {
 
     it('() : should return all preceding siblings if no selector specified', function() {
-      var elems = $('.pear', fruits).prevUntil();
+      var elems = $('.pear').prevUntil();
       expect(elems).to.have.length(2);
       expect(elems[0].attribs['class']).to.equal('orange');
       expect(elems[1].attribs['class']).to.equal('apple');
@@ -337,7 +347,7 @@ describe('$(...)', function() {
     });
 
     it('(selector) : should return all preceding siblings until selector', function() {
-      var elems = $('.pear', fruits).prevUntil('.apple');
+      var elems = $('.pear').prevUntil('.apple');
       expect(elems).to.have.length(1);
       expect(elems[0].attribs['class']).to.equal('orange');
     });
@@ -361,15 +371,15 @@ describe('$(...)', function() {
     });
 
     it('() : should return an empty object for first child', function() {
-      expect($('.apple', fruits).prevUntil()).to.have.length(0);
+      expect($('.apple').prevUntil()).to.have.length(0);
     });
 
     it('() : should return an empty object when called on an empty object', function() {
-      expect($('.banana', fruits).prevUntil()).to.have.length(0);
+      expect($('.banana').prevUntil()).to.have.length(0);
     });
 
     it('(node) : should return all previous siblings until the node', function() {
-      var $fruits = $(fruits).children();
+      var $fruits = $('#fruits').children();
       var elems = $fruits.eq(2).prevUntil($fruits[0]);
       expect(elems).to.have.length(1);
     });
@@ -386,19 +396,19 @@ describe('$(...)', function() {
   describe('.siblings', function() {
 
     it('() : should get all the siblings', function() {
-      expect($('.orange', fruits).siblings()).to.have.length(2);
-      expect($('#fruits', fruits).siblings()).to.have.length(0);
+      expect($('.orange').siblings()).to.have.length(2);
+      expect($('#fruits').siblings()).to.have.length(0);
       expect($('.apple, .carrot', food).siblings()).to.have.length(3);
     });
 
     it('(selector) : should get all siblings that match the selector', function() {
-      expect($('.orange', fruits).siblings('.apple')).to.have.length(1);
-      expect($('.orange', fruits).siblings('.peach')).to.have.length(0);
+      expect($('.orange').siblings('.apple')).to.have.length(1);
+      expect($('.orange').siblings('.peach')).to.have.length(0);
     });
 
     it('(selector) : should throw a SyntaxError if given an invalid selector', function() {
       expect(function() {
-        $('.orange', fruits).siblings(':bah');
+        $('.orange').siblings(':bah');
       }).to.throwException(function(err) {
         expect(err).to.be.a(SyntaxError);
       });
@@ -412,59 +422,66 @@ describe('$(...)', function() {
 
   describe('.parents', function() {
 
+    beforeEach(function() {
+      $ = cheerio.load(food);
+    });
+
     it('() : should get all of the parents in logical order', function(){
-      var result = $('.orange', food).parents();
+      var result = $('.orange').parents();
       expect(result).to.have.length(2);
       expect(result[0].attribs.id).to.be('fruits');
       expect(result[1].attribs.id).to.be('food');
-      result = $('#fruits', food).parents();
+      result = $('#fruits').parents();
       expect(result).to.have.length(1);
       expect(result[0].attribs.id).to.be('food');
     });
 
     it('(selector) : should get all of the parents that match the selector in logical order', function() {
-      var result = $('.orange', food).parents('#fruits');
+      var result = $('.orange').parents('#fruits');
       expect(result).to.have.length(1);
       expect(result[0].attribs.id).to.be('fruits');
-      result = $('.orange', food).parents('ul');
+      result = $('.orange').parents('ul');
       expect(result).to.have.length(2);
       expect(result[0].attribs.id).to.be('fruits');
       expect(result[1].attribs.id).to.be('food');
     });
 
     it('() : should not break if the selector does not have any results', function() {
-      var result = $('.saladbar', food).parents();
+      var result = $('.saladbar').parents();
       expect(result).to.have.length(0);
     });
 
     it('() : should return an empty set for top-level elements', function() {
-      var result = $('#food', food).parents();
+      var result = $('#food').parents();
       expect(result).to.have.length(0);
     });
 
     it('() : should return the parents of every element in the *reveresed* collection, omitting duplicates', function() {
-      var $food = $(food);
-      var $parents = $food.find('li').parents();
+      var $parents = $('li').parents();
 
       expect($parents).to.have.length(3);
-      expect($parents[0]).to.be($food.find('#vegetables')[0]);
-      expect($parents[1]).to.be($food[0]);
-      expect($parents[2]).to.be($food.find('#fruits')[0]);
+      expect($parents[0]).to.be($('#vegetables')[0]);
+      expect($parents[1]).to.be($('#food')[0]);
+      expect($parents[2]).to.be($('#fruits')[0]);
     });
 
   });
 
   describe('.parentsUntil', function() {
 
+    beforeEach(function() {
+      $ = cheerio.load(food);
+    });
+
     it('() : should get all of the parents in logical order', function() {
-      var result = $('.orange', food).parentsUntil();
+      var result = $('.orange').parentsUntil();
       expect(result).to.have.length(2);
       expect(result[0].attribs.id).to.be('fruits');
       expect(result[1].attribs.id).to.be('food');
     });
 
     it('() : should get all of the parents in reversed order, omitting duplicates', function() {
-      var result = $('.apple, .sweetcorn', food).parentsUntil();
+      var result = $('.apple, .sweetcorn').parentsUntil();
       expect(result).to.have.length(3);
       expect(result[0].attribs.id).to.be('vegetables');
       expect(result[1].attribs.id).to.be('food');
@@ -472,40 +489,39 @@ describe('$(...)', function() {
     });
 
     it('(selector) : should get all of the parents until selector', function() {
-      var result = $('.orange', food).parentsUntil('#food');
+      var result = $('.orange').parentsUntil('#food');
       expect(result).to.have.length(1);
       expect(result[0].attribs.id).to.be('fruits');
-      result = $('.orange', food).parentsUntil('#fruits');
+      result = $('.orange').parentsUntil('#fruits');
       expect(result).to.have.length(0);
     });
 
     it('(selector not parent) : should return all parents', function() {
-      var result = $('.orange', food).parentsUntil('.apple');
+      var result = $('.orange').parentsUntil('.apple');
       expect(result).to.have.length(2);
       expect(result[0].attribs.id).to.be('fruits');
       expect(result[1].attribs.id).to.be('food');
     });
 
     it('(selector, filter) : should get all of the parents that match the filter', function() {
-      var result = $('.apple, .sweetcorn', food).parentsUntil('.saladbar', '#vegetables');
+      var result = $('.apple, .sweetcorn').parentsUntil('.saladbar', '#vegetables');
       expect(result).to.have.length(1);
       expect(result[0].attribs.id).to.be('vegetables');
     });
 
     it('() : should return empty object when called on an empty object', function() {
-      var result = $('.saladbar', food).parentsUntil();
+      var result = $('.saladbar').parentsUntil();
       expect(result).to.have.length(0);
     });
 
     it('() : should return an empty set for top-level elements', function() {
-      var result = $('#food', food).parentsUntil();
+      var result = $('#food').parentsUntil();
       expect(result).to.have.length(0);
     });
 
     it('(cheerio object) : should return all parents until any member of the cheerio object', function() {
-      var $food = $(food);
-      var $fruits = $(fruits);
-      var $until = $($food[0]);
+      var $fruits = $('#fruits');
+      var $until = $('#food');
       var result = $fruits.children().eq(1).parentsUntil($until);
       expect(result).to.have.length(1);
       expect(result[0].attribs.id).to.be('fruits');
@@ -516,7 +532,7 @@ describe('$(...)', function() {
   describe('.parent', function() {
 
     it('() : should return the parent of each matched element', function() {
-      var result = $('.orange', fruits).parent();
+      var result = $('.orange').parent();
       expect(result).to.have.length(1);
       expect(result[0].attribs.id).to.be('fruits');
       result = $('li', food).parent();
@@ -526,17 +542,17 @@ describe('$(...)', function() {
     });
 
     it('() : should return an empty object for top-level elements', function() {
-      var result = $('ul', fruits).parent();
+      var result = $('ul').parent();
       expect(result).to.have.length(0);
     });
 
     it('() : should not contain duplicate elements', function() {
-      var result = $('li', fruits).parent();
+      var result = $('li').parent();
       expect(result).to.have.length(1);
     });
 
     it('(selector) : should filter the matched parent elements by the selector', function() {
-      var result = $('.orange', fruits).parent();
+      var result = $('.orange').parent();
       expect(result).to.have.length(1);
       expect(result[0].attribs.id).to.be('fruits');
       result = $('li', food).parent('#fruits');
@@ -549,13 +565,13 @@ describe('$(...)', function() {
   describe('.closest', function() {
 
     it('() : should return an empty array', function() {
-      var result = $('.orange', fruits).closest();
+      var result = $('.orange').closest();
       expect(result).to.have.length(0);
-      expect(result).to.be.a($);
+      expect(result).to.be.a(cheerio);
     });
 
     it('(selector) : should find the closest element that matches the selector, searching through its ancestors and itself', function() {
-      expect($('.orange', fruits).closest('.apple')).to.have.length(0);
+      expect($('.orange').closest('.apple')).to.have.length(0);
       var result = $('.orange', food).closest('#food');
       expect(result[0].attribs.id).to.be('food');
       result = $('.orange', food).closest('ul');
@@ -581,7 +597,7 @@ describe('$(...)', function() {
     it('( (i, elem) -> ) : should loop selected returning fn with (i, elem)', function() {
       var items = [],
           classes = ['apple', 'orange', 'pear'];
-      $('li', fruits).each(function(idx, elem) {
+      $('li').each(function(idx, elem) {
         items[idx] = elem;
         expect(this.attribs['class']).to.equal(classes[idx]);
       });
@@ -592,7 +608,7 @@ describe('$(...)', function() {
 
     it('( (i, elem) -> ) : should break iteration when the iterator function returns false', function() {
       var iterationCount = 0;
-      $('li', fruits).each(function(idx, elem) {
+      $('li').each(function(idx, elem) {
         iterationCount++;
         return idx < 1;
       });
@@ -604,7 +620,7 @@ describe('$(...)', function() {
 
   describe('.map', function() {
     it('(fn) : should be invoked with the correct arguments and context', function() {
-      var $fruits = $('li', fruits);
+      var $fruits = $('li');
       var args = [];
       var thisVals = [];
 
@@ -626,7 +642,7 @@ describe('$(...)', function() {
     });
 
     it('(fn) : should return an Cheerio object wrapping the returned items', function() {
-      var $fruits = $('li', fruits);
+      var $fruits = $('li');
       var $mapped = $fruits.map(function(i, el) {
         return $fruits[2 - i];
       });
@@ -638,7 +654,7 @@ describe('$(...)', function() {
     });
 
     it('(fn) : should ignore `null` and `undefined` returned by iterator', function() {
-      var $fruits = $('li', fruits);
+      var $fruits = $('li');
       var retVals = [null, undefined, $fruits[1]];
 
       var $mapped = $fruits.map(function(i, el) {
@@ -650,7 +666,7 @@ describe('$(...)', function() {
     });
 
     it('(fn) : should preform a shallow merge on arrays returned by iterator', function() {
-      var $fruits = $('li', fruits);
+      var $fruits = $('li');
 
       var $mapped = $fruits.map(function(i, el) {
         return [1, [3, 4]];
@@ -664,7 +680,7 @@ describe('$(...)', function() {
     });
 
     it('(fn) : should tolerate `null` and `undefined` when flattening arrays returned by iterator', function() {
-      var $fruits = $('li', fruits);
+      var $fruits = $('li');
 
       var $mapped = $fruits.map(function(i, el) {
         return [null, undefined];
@@ -680,29 +696,29 @@ describe('$(...)', function() {
 
   describe('.filter', function() {
     it('(selector) : should reduce the set of matched elements to those that match the selector', function() {
-      var pear = $('li', fruits).filter('.pear').text();
+      var pear = $('li').filter('.pear').text();
       expect(pear).to.be('Pear');
     });
 
     it('(selector) : should not consider nested elements', function() {
-      var lis = $(fruits).filter('li');
+      var lis = $('#fruits').filter('li');
       expect(lis).to.have.length(0);
     });
 
     it('(selection) : should reduce the set of matched elements to those that are contained in the provided selection', function() {
-      var $fruits = $('li', fruits);
+      var $fruits = $('li');
       var $pear = $fruits.filter('.pear, .apple');
       expect($fruits.filter($pear)).to.have.length(2);
     });
 
     it('(element) : should reduce the set of matched elements to those that specified directly', function() {
-      var $fruits = $('li', fruits);
+      var $fruits = $('li');
       var pear = $fruits.filter('.pear')[0];
       expect($fruits.filter(pear)).to.have.length(1);
     });
 
     it('(fn) : should reduce the set of matched elements to those that pass the function\'s test', function() {
-      var orange = $('li', fruits).filter(function(i, el) {
+      var orange = $('li').filter(function(i, el) {
         expect(this).to.be(el);
         expect(el.name).to.be('li');
         expect(i).to.be.a('number');
@@ -772,11 +788,11 @@ describe('$(...)', function() {
     }
 
     it('(i) : should return the element at the specified index', function() {
-      expect(getText($('li', fruits).eq(0))).to.equal('Apple');
-      expect(getText($('li', fruits).eq(1))).to.equal('Orange');
-      expect(getText($('li', fruits).eq(2))).to.equal('Pear');
-      expect(getText($('li', fruits).eq(3))).to.equal('');
-      expect(getText($('li', fruits).eq(-1))).to.equal('Pear');
+      expect(getText($('li').eq(0))).to.equal('Apple');
+      expect(getText($('li').eq(1))).to.equal('Orange');
+      expect(getText($('li').eq(2))).to.equal('Pear');
+      expect(getText($('li').eq(3))).to.equal('');
+      expect(getText($('li').eq(-1))).to.equal('Pear');
     });
 
   });
@@ -784,21 +800,21 @@ describe('$(...)', function() {
   describe('.get', function() {
 
     it('(i) : should return the element at the specified index', function() {
-      var children = $(fruits).children();
+      var children = $('#fruits').children();
       expect(children.get(0)).to.be(children[0]);
       expect(children.get(1)).to.be(children[1]);
       expect(children.get(2)).to.be(children[2]);
     });
 
     it('(-1) : should return the element indexed from the end of the collection', function() {
-      var children = $(fruits).children();
+      var children = $('#fruits').children();
       expect(children.get(-1)).to.be(children[2]);
       expect(children.get(-2)).to.be(children[1]);
       expect(children.get(-3)).to.be(children[0]);
     });
 
     it('() : should return an array containing all of the collection', function() {
-      var children = $(fruits).children();
+      var children = $('#fruits').children();
       var all = children.get();
       expect(Array.isArray(all)).to.be.ok();
       expect(all).to.eql([
@@ -818,20 +834,20 @@ describe('$(...)', function() {
     }
 
     it('(start) : should return all elements after the given index', function() {
-      var sliced = $('li', fruits).slice(1);
+      var sliced = $('li').slice(1);
       expect(sliced).to.have.length(2);
       expect(getText(sliced.eq(0))).to.equal('Orange');
       expect(getText(sliced.eq(1))).to.equal('Pear');
     });
 
     it('(start, end) : should return all elements matching the given range', function() {
-      var sliced = $('li', fruits).slice(1, 2);
+      var sliced = $('li').slice(1, 2);
       expect(sliced).to.have.length(1);
       expect(getText(sliced.eq(0))).to.equal('Orange');
     });
 
     it('(-start) : should return element matching the offset from the end', function() {
-      var sliced = $('li', fruits).slice(-1);
+      var sliced = $('li').slice(-1);
       expect(sliced).to.have.length(1);
       expect(getText(sliced.eq(0))).to.equal('Pear');
     });
@@ -839,11 +855,15 @@ describe('$(...)', function() {
   });
 
   describe('.end() :', function() {
-    var $fruits = $(fruits).children();
+    var $fruits;
+
+    beforeEach(function() {
+      $fruits = $('#fruits').children();
+    });
 
     it('returns an empty object at the end of the chain', function() {
-      expect($fruits.end().end()).to.be.ok();
-      expect($fruits.end().end()).to.have.length(0);
+      expect($fruits.end().end().end()).to.be.ok();
+      expect($fruits.end().end().end()).to.have.length(0);
     });
     it('find', function() {
       expect($fruits.find('.apple').end()).to.be($fruits);

--- a/test/api.utils.js
+++ b/test/api.utils.js
@@ -1,37 +1,37 @@
 var expect = require('expect.js'),
     fixtures = require('./fixtures'),
-    $ = require('../');
+    cheerio = require('..');
 
 
-describe('$', function() {
+describe('cheerio', function() {
 
   describe('.html', function() {
 
     it('() : should return innerHTML; $.html(obj) should return outerHTML', function() {
-      var $div = $('div', '<div><span>foo</span><span>bar</span></div>');
+      var $div = cheerio('div', '<div><span>foo</span><span>bar</span></div>');
       var span = $div.children()[1];
-      expect($(span).html()).to.equal('bar');
-      expect($.html(span)).to.equal('<span>bar</span>');
+      expect(cheerio(span).html()).to.equal('bar');
+      expect(cheerio.html(span)).to.equal('<span>bar</span>');
     });
 
     it('(<obj>) : should accept an object, an array, or a cheerio object', function() {
-      var $span = $('<span>foo</span>');
-      expect($.html($span[0])).to.equal('<span>foo</span>');
-      expect($.html($span)).to.equal('<span>foo</span>');
+      var $span = cheerio('<span>foo</span>');
+      expect(cheerio.html($span[0])).to.equal('<span>foo</span>');
+      expect(cheerio.html($span)).to.equal('<span>foo</span>');
     });
 
     it('(<value>) : should be able to set to an empty string', function() {
-      var $elem = $('<span>foo</span>').html('');
-      expect($.html($elem)).to.equal('<span></span>');
+      var $elem = cheerio('<span>foo</span>').html('');
+      expect(cheerio.html($elem)).to.equal('<span></span>');
     });
 
     it('() : of empty cheerio object should return null', function() {
-      expect($().html()).to.be(null);
+      expect(cheerio().html()).to.be(null);
     });
 
     it('(selector) : should return the outerHTML of the selected element', function() {
-      var _$ = $.load(fixtures.fruits);
-      expect(_$.html('.pear')).to.equal('<li class="pear">Pear</li>');
+      var $ = cheerio.load(fixtures.fruits);
+      expect($.html('.pear')).to.equal('<li class="pear">Pear</li>');
     });
   });
 
@@ -40,19 +40,19 @@ describe('$', function() {
   describe('.load', function() {
 
     it('(html) : should retain original root after creating a new node', function() {
-      var $html = $.load('<body><ul id="fruits"></ul></body>');
+      var $html = cheerio.load('<body><ul id="fruits"></ul></body>');
       expect($html('body')).to.have.length(1);
       $html('<script>');
       expect($html('body')).to.have.length(1);
     });
 
     it('(html) : should handle lowercase tag options', function() {
-      var $html = $.load('<BODY><ul id="fruits"></ul></BODY>', { lowerCaseTags : true });
+      var $html = cheerio.load('<BODY><ul id="fruits"></ul></BODY>', { lowerCaseTags : true });
       expect($html.html()).to.be('<body><ul id="fruits"></ul></body>');
     });
 
     it('(html) : should handle the `normalizeWhitepace` option', function() {
-      var $html = $.load('<body><b>foo</b>  <b>bar</b></body>', { normalizeWhitespace : true });
+      var $html = cheerio.load('<body><b>foo</b>  <b>bar</b></body>', { normalizeWhitespace : true });
       expect($html.html()).to.be('<body><b>foo</b> <b>bar</b></body>');
     });
 
@@ -69,7 +69,7 @@ describe('$', function() {
   describe('.clone', function() {
 
     it('() : should return a copy', function() {
-      var $src = $('<div><span>foo</span><span>bar</span><span>baz</span></div>').children();
+      var $src = cheerio('<div><span>foo</span><span>bar</span><span>baz</span></div>').children();
       var $elem = $src.clone();
       expect($elem.length).to.equal(3);
       expect($elem.parent()).to.have.length(0);
@@ -83,20 +83,20 @@ describe('$', function() {
   describe('.parseHTML', function() {
 
     it('() : returns null', function() {
-      expect($.parseHTML()).to.equal(null);
+      expect(cheerio.parseHTML()).to.equal(null);
     });
 
     it('(null) : returns null', function() {
-      expect($.parseHTML(null)).to.equal(null);
+      expect(cheerio.parseHTML(null)).to.equal(null);
     });
 
     it('("") : returns null', function() {
-      expect($.parseHTML('')).to.equal(null);
+      expect(cheerio.parseHTML('')).to.equal(null);
     });
 
     it('(largeHtmlString) : parses large HTML strings', function() {
       var html = new Array(10).join('<div></div>');
-      var nodes = $.parseHTML(html);
+      var nodes = cheerio.parseHTML(html);
 
       expect(nodes.length).to.be.greaterThan(4);
       expect(nodes).to.be.an('array');
@@ -104,47 +104,47 @@ describe('$', function() {
 
     it('("<script>") : ignores scripts by default', function() {
       var html = '<script>undefined()</script>';
-      expect($.parseHTML(html)).to.have.length(0);
+      expect(cheerio.parseHTML(html)).to.have.length(0);
     });
 
     it('("<script>", true) : preserves scripts when requested', function() {
       var html = '<script>undefined()</script>';
-      expect($.parseHTML(html, true)[0].name).to.match(/script/i);
+      expect(cheerio.parseHTML(html, true)[0].name).to.match(/script/i);
     });
 
     it('("scriptAndNonScript) : preserves non-script nodes', function() {
       var html = '<script>undefined()</script><div></div>';
-      expect($.parseHTML(html)[0].name).to.match(/div/i);
+      expect(cheerio.parseHTML(html)[0].name).to.match(/div/i);
     });
 
     it('(scriptAndNonScript, true) : Preserves script position', function() {
       var html = '<script>undefined()</script><div></div>';
-      expect($.parseHTML(html, true)[0].name).to.match(/script/i);
+      expect(cheerio.parseHTML(html, true)[0].name).to.match(/script/i);
     });
 
     it('(text) : returns a text node', function() {
-      expect($.parseHTML('text')[0].type).to.be('text');
+      expect(cheerio.parseHTML('text')[0].type).to.be('text');
     });
 
     it('(\\ttext) : preserves leading whitespace', function() {
-      expect($.parseHTML('\t<div></div>')[0].data).to.equal('\t');
+      expect(cheerio.parseHTML('\t<div></div>')[0].data).to.equal('\t');
     });
 
     it('( text) : Leading spaces are treated as text nodes', function() {
-      expect($.parseHTML(' <div/> ')[0].type).to.be('text');
+      expect(cheerio.parseHTML(' <div/> ')[0].type).to.be('text');
     });
 
     it('(html) : should preserve content', function() {
       var html = '<div>test div</div>';
-      expect($($.parseHTML(html)[0]).html()).to.equal('test div');
+      expect(cheerio(cheerio.parseHTML(html)[0]).html()).to.equal('test div');
     });
 
     it('(malformedHtml) : should not break', function() {
-      expect($.parseHTML('<span><span>')).to.have.length(1);
+      expect(cheerio.parseHTML('<span><span>')).to.have.length(1);
     });
 
     it('(garbageInput) : should not cause an error', function() {
-      expect($.parseHTML('<#if><tr><p>This is a test.</p></tr><#/if>') || true).to.be.ok();
+      expect(cheerio.parseHTML('<#if><tr><p>This is a test.</p></tr><#/if>') || true).to.be.ok();
     });
 
   });
@@ -152,7 +152,7 @@ describe('$', function() {
   describe('.root', function() {
 
     it('() : should return a cheerio-wrapped root object', function() {
-      var $html = $.load('<div><span>foo</span><span>bar</span></div>');
+      var $html = cheerio.load('<div><span>foo</span><span>bar</span></div>');
       $html.root().append('<div id="test"></div>');
       expect($html.html()).to.equal('<div><span>foo</span><span>bar</span></div><div id="test"></div>');
     });

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -1,25 +1,30 @@
 var expect = require('expect.js'),
-    $ = require('../'),
+    cheerio = require('..'),
     food = require('./fixtures').food;
 
 describe('utility methods', function() {
 
   describe('.contains', function() {
 
+    var $;
+
+    beforeEach(function() {
+      $ = cheerio.load(food);
+    });
+
     it('(container, contained) : should correctly detect the provided element', function() {
-      var $food = $(food);
-      var $fruits = $food.find('#fruits');
-      var $apple = $fruits.find('.apple');
+      var $food = $('#food');
+      var $fruits = $('#fruits');
+      var $apple = $('.apple');
 
       expect($.contains($food[0], $fruits[0])).to.equal(true);
       expect($.contains($food[0], $apple[0])).to.equal(true);
     });
 
     it('(container, other) : should not detect elements that are not contained', function() {
-      var $food = $(food);
-      var $fruits = $food.find('#fruits');
-      var $vegetables = $food.find('#vegetables');
-      var $apple = $fruits.find('.apple');
+      var $fruits = $('#fruits');
+      var $vegetables = $('#vegetables');
+      var $apple = $('.apple');
 
       expect($.contains($vegetables[0], $apple[0])).to.equal(false);
       expect($.contains($fruits[0], $vegetables[0])).to.equal(false);

--- a/test/xml.js
+++ b/test/xml.js
@@ -1,6 +1,6 @@
 var expect = require('expect.js'),
     _ = require('lodash'),
-    cheerio = require('../lib/cheerio');
+    cheerio = require('..');
 
 var xml = function(str, options) {
   options = _.extend({ xmlMode: true }, options);


### PR DESCRIPTION
This is not going to make for fun review work, but since @davidchambers [asked for it](https://github.com/cheeriojs/cheerio/pull/502#discussion_r13399298), I nominate him! This is mostly a trivial transformation, but it did require a couple substantive changes. I'll call those out with in-line comments.

Commit message:

> This usage allows tests to be slightly more concise. In addition, it
> better reflects the real-world usage of Cheerio, promoting the unit
> tests' role as active usage examples.
