### PR TITLE
xyz@0.4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 REPORTER = dot
-XYZ = node_modules/.bin/xyz --message 'Release X.Y.Z' --tag X.Y.Z --script scripts/prepublish
+XYZ = node_modules/.bin/xyz --message 'Release X.Y.Z' --tag X.Y.Z --repo git@github.com:cheeriojs/cheerio.git --script scripts/prepublish
 
 lint:
 	@./node_modules/.bin/jshint lib/ test/

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jsdom": "~0.8.9",
     "jshint": "~2.3.0",
     "mocha": "*",
-    "xyz": "~0.3.0"
+    "xyz": "~0.4.0"
   },
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
This [upgrade](https://github.com/davidchambers/xyz/compare/v0.3.0...v0.4.0) brings two improvements:
- we now specify the repository URL, so we no longer rely on `origin` pointing to **cheeriojs/cheerio** (in my case, at least, it doesn't); and
- xyz now aborts if the working directory contains unstaged changes.
