### PR TITLE
Adds failing testcase for .html() result.

### DIFF
--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -276,5 +276,10 @@ describe('cheerio', function() {
     expect(domEncoded('footer').html()).to.be(expectedXml);
   });
 
+  it('should handle nested quoting properly', function() {
+    var str = '<label><input id="setbtn" type="button" value="set" ng-click="myVar=\'my-class\'"></label>',
+        domEncoded = $.load(str);
 
+    expect(domEncoded.html()).to.be.equal(str);
+  });
 });


### PR DESCRIPTION
**Issue title:** Nested quotes get substituted with ampersand code.

**Issue description**: when parsing html code with nested quotes, the `.html()` replaces the inner quotes with their ampersend code. Had' just a bit time to dig, so not sure if its an issue of 'htmlparser2' or simply just the excepted behavior. Please correct me if i'm wrong there.

Created a failing test case, which results:

```
Error: expected
'<label><input id="setbtn" type="button" value="set" ng-click="myVar=&apos;my-class&apos;"></label>'
to equal
'<label><input id="setbtn" type="button" value="set" ng-click="myVar=\'my-class\'"></label>'
```

I know the resulting HTML is legit, still  it should've been modified IMHO.
