### PR TITLE
Correct bug in implementation of `Cheerio#val`

### DIFF
--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -166,21 +166,10 @@ exports.val = function(value) {
     case 'input':
       switch (this.attr('type')) {
         case 'radio':
-          var queryString = 'input[type=radio][name="' + this.attr('name') + '"]:checked';
-          var parentEl, root;
-
-          // Go up until we hit a form or root
-          parentEl = this.closest('form');
-          if (parentEl.length === 0) {
-            root = (this.parents().last()[0] || this[0]).root;
-            parentEl = this._make(root);
-          }
-
           if (querying) {
-            return parentEl.find(queryString).attr('value');
+            return this.attr('value');
           } else {
-            parentEl.find(':checked').removeAttr('checked');
-            parentEl.find('input[type=radio][value="' + value + '"]').attr('checked', '');
+            this.attr('value', value);
             return this;
           }
           break;

--- a/test/api.attributes.js
+++ b/test/api.attributes.js
@@ -299,7 +299,7 @@ describe('$(...)', function() {
     });
     it('.val(): on radio should get value', function() {
       var val = $('input[type="radio"]').val();
-      expect(val).to.equal('on');
+      expect(val).to.equal('off');
     });
     it('.val(): on multiple select should get an array of values', function() {
       var val = $('select#multi').val();


### PR DESCRIPTION
jQuery does not attempt to calculate the value of a `radio` input group.
Instead, when the value of such an element is queries, that element's
`value` attribute is returned directly.

Although slightly less convenient in some cases, this allows for direct
manipulation of `radio` input element values (which is otherwise
impossible).
