### PR TITLE
Return a fully-qualified Function from `$.load`

### DIFF
--- a/lib/static.js
+++ b/lib/static.js
@@ -28,7 +28,7 @@ exports.load = function(content, options) {
   initialize.prototype = Cheerio.prototype;
 
   // Add in the static methods
-  initialize.__proto__ = exports;
+  _.merge(initialize, exports);
 
   // Add in the root
   initialize._root = root;

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -284,5 +284,11 @@ describe('cheerio', function() {
       expect(domEncoded('footer').html()).to.be(expectedXml);
     });
 
+    it('should return a fully-qualified Function', function() {
+      var $c = $.load('<div>');
+
+      expect($c).to.be.a(Function);
+    });
+
   });
 });


### PR DESCRIPTION
This should resolve #550.

An alternative implementation would involve defining `module.exports` as a no-op function in `lib/static.js`. If the static methods were attached to this function (i.e. `module.exports.html`), then when the `__proto__` attribute of the new function was re-set, the resulting object would have `Function.prototype` in its prototype chain. I opted for this approach because, while slower (the call to `_.merge` requires more work than simply setting an attribute), I've never been comfortable using `__proto__`, and I don't think we need to heavily optimize `$.load`.

Commit message:

> The function generated by `$.load` should inherit from the `Function`
> prototype so that methods like `call`, `apply`, and `bind` are available
> to users.
