### PR TITLE
Correct error in documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -401,9 +401,9 @@ Pass each element in the current matched set through a function, producing a new
 ```js
 $('li').map(function(i, el) {
   // this === el
-  return $('<div>').text($(this).text());
-}).html();
-//=> <div>apple</div><div>orange</div><div>pear</div>
+  return $(this).text();
+}).get().join(' ');
+//=> "apple orange pear"
 ```
 
 #### .filter( selector ) <br /> .filter( selection ) <br /> .filter( element ) <br /> .filter( function(index) )


### PR DESCRIPTION
This should resolve #555.

Commit message:

> The current documentation of the `map` method demonstrates an incorrect
> usage. Because the function creates a Cheerio object containing the
> values returned by the iterator function, the current example
> demonstrates creating a Cheerio object whose members are themselves
> Cheerio objects. The behavior of the `html` method invoked on such an
> object is not defined.
> 
> Update the example to demonstrate a simpler, more tradition use of the
> `map` method.
