### PR TITLE
Clone nodes according to original parsing options

### DIFF
--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -299,5 +299,5 @@ exports.text = function(str) {
 exports.clone = function() {
   // Turn it into HTML, then recreate it,
   // Seems to be the easiest way to reconnect everything correctly
-  return this._make($.html(this));
+  return this._make($.html(this, this.options));
 };

--- a/test/api.utils.js
+++ b/test/api.utils.js
@@ -83,6 +83,12 @@ describe('cheerio', function() {
       expect($elem.text()).to.not.equal($src.text());
     });
 
+    it('() : should preserve parsing options', function() {
+      var $ = cheerio.load('<div>π</div>', { decodeEntities: false });
+      var $div = $('div');
+
+      expect($div.text()).to.equal($div.clone().text());
+    });
   });
 
   describe('.parseHTML', function() {


### PR DESCRIPTION
Internally, Cheerio clones node structures by rendering them to a string
of HTML and subsequently parsing that string. Ensure that the
intermediary string is parsed according to the same options used to
create the target Cheerio object.

This should resolve gh-551.
