### PR TITLE
Fix bug in `css` method

### DIFF
--- a/lib/api/css.js
+++ b/lib/api/css.js
@@ -37,7 +37,7 @@ function setCss(el, prop, val, idx) {
   if ('string' == typeof prop) {
     var styles = getCss(el);
     if (typeof val === 'function') {
-      val = val.call(el, idx, el);
+      val = val.call(el, idx, styles[prop]);
     }
 
     if (val === '') {

--- a/test/api.css.js
+++ b/test/api.css.js
@@ -44,15 +44,15 @@ describe('$(...)', function() {
 
     describe('(prop, function):', function() {
       beforeEach(function() {
-        this.$el = cheerio('<div style="margin: 0;"></div><div style="margin: 0;"></div><div style="margin: 0;">');
+        this.$el = cheerio('<div style="margin: 0px;"></div><div style="margin: 1px;"></div><div style="margin: 2px;">');
       });
 
       it('should iterate over the selection', function() {
         var count = 0;
         var $el = this.$el;
-        this.$el.css('margin', function(idx, elem) {
+        this.$el.css('margin', function(idx, value) {
           expect(idx).to.equal(count);
-          expect(elem).to.equal($el[count]);
+          expect(value).to.equal(count + 'px');
           expect(this).to.equal($el[count]);
           count++;
         });
@@ -66,7 +66,7 @@ describe('$(...)', function() {
         });
         expect(this.$el.eq(0).attr('style')).to.equal('margin: 4px;');
         expect(this.$el.eq(1).attr('style')).to.equal('');
-        expect(this.$el.eq(2).attr('style')).to.equal('margin: 0;');
+        expect(this.$el.eq(2).attr('style')).to.equal('margin: 2px;');
       });
     });
 


### PR DESCRIPTION
When a callback function is provided as the second argument to the `css`
method, it should be invoked with each element's index and the value of
the specified CSS property (not the element itself).

From the jQuery API documentation on `css`:

> # .css( propertyName, function )
> 
> **propertyName**
> Type: String
> A CSS property name.
> 
> **function**
> Type: Function( Integer index, String value ) => String or Number
> A function returning the value to set. `this` is the current element.
> Receives the index position of the element in the set and the old
> value as arguments.

http://api.jquery.com/css/#css-propertyName-function
