### PR TITLE
Allow Webpack support

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,4 +8,4 @@ exports = module.exports = require('./lib/cheerio');
   Export the version
 */
 
-exports.version = require('./package').version;
+exports.version = require('./package.json').version;


### PR DESCRIPTION
When requiring cheerio in a webpack bundle, two issues arise:
- Firstly, the `entities` module loads JSON files, which trips up webpack. This is easily circumvented by using [json-loader](http://npmjs.org/package/json-loader).
- Secondly, in `index.js` where `package.json` is required. The lack of explicit file extension here prevents webpack from detecting that this is a JSON file, not a JS module; without this it cannot discern the correct loader to use.
