### PR TITLE
Ensure text nodes expose the DOM level 1 API

### DIFF
--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -275,22 +275,18 @@ exports.text = function(str) {
     });
   }
 
+  var opts = this.options;
+
   // Append text node to each selected elements
   domEach(this, function(i, el) {
     _.each(el.children, function(el) {
       el.next = el.prev = el.parent = null;
     });
 
-    var elem = {
-      data: str,
-      type: 'text',
-      parent: el,
-      prev: null,
-      next: null,
-      children: []
-    };
+    var textNode =  evaluate(' ', opts)[0];
+    textNode.data = str;
 
-    updateDOM(elem, el);
+    updateDOM(textNode, el);
   });
 
   return this;

--- a/test/api.manipulation.js
+++ b/test/api.manipulation.js
@@ -886,10 +886,22 @@ describe('$(...)', function() {
       $('li').text('Fruits');
       var tested = 0;
       $('li').each(function(){
-        expect(this.childNodes[0].parent).to.equal(this);
+        expect(this.childNodes[0].parentNode).to.equal(this);
         tested++;
       });
       expect(tested).to.equal(3);
+    });
+
+    it('(text) : should create a Node with the DOM level 1 API', function() {
+      var $apple = $('.apple');
+      var textNode;
+
+      $apple.text('anything');
+      textNode = $apple[0].childNodes[0];
+
+      expect(textNode.parentNode).to.be($apple[0]);
+      expect(textNode.nodeType).to.be(3);
+      expect(textNode.data).to.be('anything');
     });
 
     it('should allow functions as arguments', function() {


### PR DESCRIPTION
Since enabling the `withDomLvl1` parsing option, nodes cannot be created
with an object literal. Create new text nodes using the `evaluate`
function to ensure they expose the correct attributes.
