### PR TITLE
createWriteStream method

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -83,4 +83,8 @@ exports.update = function(arr, parent) {
   return parent;
 };
 
+exports.createWriteStream = function (options, cb) {
+  return htmlparser.createDomStream(cb, options);
+};
+
 // module.exports = $.extend(exports);

--- a/lib/static.js
+++ b/lib/static.js
@@ -26,7 +26,7 @@ exports.load = function(content, options) {
   // Ensure that selections created by the "loaded" `initialize` function are
   // true Cheerio instances.
   initialize.prototype = Cheerio.prototype;
-  // Keep a reference to the top-level scope so we can chain methods that implicitly 
+  // Keep a reference to the top-level scope so we can chain methods that implicitly
   // resolve selectors; e.g. $("<span>").(".bar"), which otherwise loses ._root
   initialize.prototype._originalRoot = root;
 
@@ -39,6 +39,23 @@ exports.load = function(content, options) {
   initialize._options = options;
 
   return initialize;
+};
+
+/**
+* $.createWriteStream()
+*/
+
+exports.createWriteStream = function(options) {
+
+  var stream = parse.createWriteStream(options, function done(err, dom) {
+    if (err) {
+      stream.emit('error', err);
+    } else {
+      stream.emit('finish', exports.load(dom));
+    }
+  });
+
+  return stream;
 };
 
 /**

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -291,4 +291,22 @@ describe('cheerio', function() {
     });
 
   });
+
+  describe('.createWriteStream', function() {
+
+    it('should parse a stream', function(done) {
+      var s = $.createWriteStream();
+
+      s.on('finish', function (q) {
+        expect(q('.apple')).to.be.a(q);
+        done();
+      });
+
+      s.write(fruits.substring(0, 24));
+      s.write(fruits.substring(24, 48));
+      s.end(fruits.substring(48));
+
+    });
+
+  });
 });


### PR DESCRIPTION
Exposes `.createWriteStream(options)` which takes the same options as `.load(..., options)` and returns a writeable stream.

A `finish` event is emitted when the dom is ready.
