### PR TITLE
load from url

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -83,4 +83,8 @@ exports.update = function(arr, parent) {
   return parent;
 };
 
+exports.createWriteStream = function (options, cb) {
+  return htmlparser.createDomStream(cb, options);
+};
+
 // module.exports = $.extend(exports);

--- a/lib/static.js
+++ b/lib/static.js
@@ -26,7 +26,7 @@ exports.load = function(content, options) {
   // Ensure that selections created by the "loaded" `initialize` function are
   // true Cheerio instances.
   initialize.prototype = Cheerio.prototype;
-  // Keep a reference to the top-level scope so we can chain methods that implicitly 
+  // Keep a reference to the top-level scope so we can chain methods that implicitly
   // resolve selectors; e.g. $("<span>").(".bar"), which otherwise loses ._root
   initialize.prototype._originalRoot = root;
 
@@ -39,6 +39,23 @@ exports.load = function(content, options) {
   initialize._options = options;
 
   return initialize;
+};
+
+/**
+* $.createWriteStream()
+*/
+
+exports.createWriteStream = function(options) {
+
+  var stream = parse.createWriteStream(options, function done(err, dom) {
+    if (err) {
+      stream.emit('error', err);
+    } else {
+      stream.emit('finish', exports.load(dom));
+    }
+  });
+
+  return stream;
 };
 
 /**

--- a/lib/static.js
+++ b/lib/static.js
@@ -5,13 +5,45 @@
 var select = require('CSSselect'),
     parse = require('./parse'),
     render = require('dom-serializer'),
+    get = require('simple-get'),
     _ = require('lodash');
+
+function looksLikeRequest(opt) {
+
+  if (typeof opt === 'string' && opt.substring(0, 4) === 'http') {
+    return true;
+  }
+
+  if (typeof opt === 'object' && (opt.host || opt.hostname || opt.path)) {
+    return true;
+  }
+
+  return false;
+}
 
 /**
  * $.load(str)
+ * $.load(url, cb)
  */
 
 exports.load = function(content, options) {
+  if (typeof options === 'function' && looksLikeRequest(content)) {
+    var stream = exports.createWriteStream();
+    var emitError = stream.emit.bind(stream, 'error');
+
+    get(content, function (err, res) {
+      if (err) { return emitError(err); }
+
+      res.on('error', emitError);
+      res.pipe(stream);
+    });
+
+    stream.on('error', options);
+    stream.on('finish', options.bind(null, null));
+
+    return stream;
+  }
+
   var Cheerio = require('./cheerio');
 
   options = _.defaults(options || {}, Cheerio.prototype.options);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "entities": "~1.1.1",
     "htmlparser2": "~3.8.1",
     "dom-serializer": "~0.0.0",
-    "lodash": "~2.4.1"
+    "lodash": "~2.4.1",
+    "simple-get": "~1.2.0"
   },
   "devDependencies": {
     "benchmark": "~1.0.0",

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -2,6 +2,7 @@ var expect = require('expect.js'),
     _ = require('lodash'),
     htmlparser2 = require('htmlparser2'),
     $ = require('../'),
+    http = require('http'),
     fixtures = require('./fixtures'),
     fruits = fixtures.fruits,
     food = fixtures.food;
@@ -288,6 +289,20 @@ describe('cheerio', function() {
       var $c = $.load('<div>');
 
       expect($c).to.be.a(Function);
+    });
+
+    it('should load a url', function (done) {
+
+      var server = http.createServer(function (req, res) {
+        res.end(fruits);
+      }).listen(23000);
+
+      $.load('http://localhost:23000/', function (err, q) {
+        expect(err).not.to.an(Error);
+        expect(q('.apple').text()).to.be('Apple');
+        server.close(done);
+      });
+
     });
 
   });

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -291,4 +291,22 @@ describe('cheerio', function() {
     });
 
   });
+
+  describe('.createWriteStream', function() {
+
+    it('should parse a stream', function(done) {
+      var s = $.createWriteStream();
+
+      s.on('finish', function (q) {
+        expect(q('.apple')).to.be.a(q);
+        done();
+      });
+
+      s.write(fruits.substring(0, 24));
+      s.write(fruits.substring(24, 48));
+      s.end(fruits.substring(48));
+
+    });
+
+  });
 });


### PR DESCRIPTION
*Depends on #619, pull it first.*

Adds support for `.load(url, cb)` which streams an html document from the web into the parser. The callback receives `(err, $)`.

Sample program:
```js
var cheerio = require('./');

cheerio.load('http://example.com/', function (err, $) {
  if (err) { throw err; }

  console.log($('h1').text());
});
```