### PR TITLE
Isolate prototypes of functions created via `load`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -763,6 +763,19 @@ Checks to see if the `contained` DOM element is a descendent of the `container` 
 #### $.parseHTML( data [, context ] [, keepScripts ] )
 Parses a string into an array of DOM nodes. The `context` argument has no meaning for Cheerio, but it is maintained for API compatability.
 
+### Plugins
+
+Once you have loaded a document, you may extend the prototype or the equivalent `fn` property with custom plugin methods:
+
+```js
+var $ = cheerio.load('<html><body>Hello, <b>world</b>!</body></html>');
+$.prototype.logHtml = function() {
+  console.log(this.html());
+};
+
+$('body').logHtml(); // logs "Hello, <b>world</b>!" to the console
+```
+
 ### The "DOM Node" object
 
 Cheerio collections are made up of objects that bear some resemblence to [browser-based DOM nodes](https://developer.mozilla.org/en-US/docs/Web/API/Node). You can expect them to define the following properties:

--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -134,7 +134,7 @@ var isHtml = function(str) {
  */
 
 Cheerio.prototype._make = function(dom, context) {
-  var cheerio = new Cheerio(dom, context, this._root, this.options);
+  var cheerio = new this.constructor(dom, context, this._root, this.options);
   cheerio.prevObject = this;
   return cheerio;
 };

--- a/lib/static.js
+++ b/lib/static.js
@@ -19,13 +19,21 @@ exports.load = function(content, options) {
   var root = parse(content, options);
 
   var initialize = function(selector, context, r, opts) {
+    if (!(this instanceof initialize)) {
+      return new initialize(selector, context, r, opts);
+    }
     opts = _.defaults(opts || {}, options);
     return Cheerio.call(this, selector, context, r || root, opts);
   };
 
   // Ensure that selections created by the "loaded" `initialize` function are
   // true Cheerio instances.
-  initialize.prototype = Cheerio.prototype;
+  initialize.prototype = Object.create(Cheerio.prototype);
+  initialize.prototype.constructor = initialize;
+
+  // Mimic jQuery's prototype alias for plugin authors.
+  initialize.fn = initialize.prototype;
+
   // Keep a reference to the top-level scope so we can chain methods that implicitly 
   // resolve selectors; e.g. $("<span>").(".bar"), which otherwise loses ._root
   initialize.prototype._originalRoot = root;

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -290,5 +290,51 @@ describe('cheerio', function() {
       expect($c).to.be.a(Function);
     });
 
+    describe('prototype extensions', function() {
+      it('should honor extensions defined on `prototype` property', function() {
+        var $c = $.load('<div>');
+        var $div;
+        $c.prototype.myPlugin = function() {
+          return {
+            context: this,
+            args: arguments
+          };
+        };
+
+        $div = $c('div');
+
+        expect($div.myPlugin).to.be.a('function');
+        expect($div.myPlugin().context).to.be($div);
+        expect(Array.prototype.slice.call($div.myPlugin(1, 2, 3).args))
+          .to.eql([1, 2, 3]);
+      });
+
+      it('should honor extensions defined on `fn` property', function() {
+        var $c = $.load('<div>');
+        var $div;
+        $c.fn.myPlugin = function() {
+          return {
+            context: this,
+            args: arguments
+          };
+        };
+
+        $div = $c('div');
+
+        expect($div.myPlugin).to.be.a('function');
+        expect($div.myPlugin().context).to.be($div);
+        expect(Array.prototype.slice.call($div.myPlugin(1, 2, 3).args))
+          .to.eql([1, 2, 3]);
+      });
+
+      it('should isolate extensions between loaded functions', function() {
+        var $a = $.load('<div>');
+        var $b = $.load('<div>');
+
+        $a.prototype.foo = function() {};
+
+        expect($b('div').foo).to.be(undefined);
+      });
+    });
   });
 });


### PR DESCRIPTION
I wanted to shore up the project's recommendation for extending Cheerio and back it with documentation and tests. This will allow us to be more confident in recommending this pattern in the future. Related issues: gh-621 & gh-589

Commit message:

> Ensure that each Cheerio function created with the `load` static method
> has a dedicated object in its prototype chain. This allows for
> conflict-free extension of the generated prototype.
>
> Additionally, expose the `fn` prototype alias as defined by jQuery and
> used by many jQuery plugins.