### PR TITLE
Update JSDom

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "coveralls": "~2.10",
     "expect.js": "~0.3.1",
     "istanbul": "~0.2",
-    "jsdom": "~0.8.9",
+    "jsdom": "~3.0.2",
     "jshint": "~2.5.1",
     "mocha": "*",
     "xyz": "~0.5.0"


### PR DESCRIPTION
The version of JSDom used in this project's benchmark suite has a
dependency ("contextify") that is is no longer compatible with Node.js
version 0.11. This causes build failures when installing
`devDependencies` in Node.js v0.11. Update to the latest version of
JSDom (which, despite being a different major release, exposes the same
API necessary for the benchmarks) because it uses a Node.js
v0.11-compatible version of "contextify".