### PR TITLE
Allow failures in Node.js v0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ node_js:
 script: make travis-test
 matrix:
   fast_finish: true
+  allow_failures:
+    - node_js: 0.11


### PR DESCRIPTION
I think allowing failures here is the correct policy in principle, but we now have a practical reason to do so. From https://github.com/tmpvar/jsdom/issues/984 (Dec 20, 2014):

> I am not interested in taking on the support burden of working with unstable Node versions. Wait for iojs.

Commit message:

> Node.js version 0.11 is an unstable platform, meaning it may introduce
> breaking changes at any time. It is useful for the project maintainers
> to be aware of such failures (because they represent potential problems
> with the next stable release of Node.js), they should not block ongoing
> work.