### PR TITLE
Recognize options in $.xml()

### DIFF
--- a/lib/static.js
+++ b/lib/static.js
@@ -4,7 +4,7 @@
 
 var select = require('CSSselect'),
     parse = require('./parse'),
-    render = require('dom-serializer'),
+    serialize = require('dom-serializer'),
     _ = require('lodash');
 
 /**
@@ -49,8 +49,26 @@ exports.load = function(content, options) {
   return initialize;
 };
 
+/*
+* Helper function
+*/
+
+function render(that, dom, options) {
+  if (!dom) {
+    if (that._root && that._root.children) {
+      dom = that._root.children;
+    } else {
+      return '';
+    }
+  } else if (typeof dom === 'string') {
+    dom = select(dom, that._root, options);
+  }
+
+  return serialize(dom, options);
+}
+
 /**
- * $.html([selector | dom])
+ * $.html([selector | dom], [options])
  */
 
 exports.html = function(dom, options) {
@@ -70,14 +88,7 @@ exports.html = function(dom, options) {
   // so fallback non existing options to the default ones
   options = _.defaults(options || {}, this._options, Cheerio.prototype.options);
 
-  if (dom) {
-    dom = (typeof dom === 'string') ? select(dom, this._root, options) : dom;
-    return render(dom, options);
-  } else if (this._root && this._root.children) {
-    return render(this._root.children, options);
-  } else {
-    return '';
-  }
+  return render(this, dom, options);
 };
 
 /**
@@ -85,14 +96,9 @@ exports.html = function(dom, options) {
  */
 
 exports.xml = function(dom) {
-  if (dom) {
-    dom = (typeof dom === 'string') ? select(dom, this._root, this.options) : dom;
-    return render(dom, { xmlMode: true });
-  } else if (this._root && this._root.children) {
-    return render(this._root.children, { xmlMode: true });
-  } else {
-    return '';
-  }
+  var options = _.defaults({xmlMode: true}, this._options);
+
+  return render(this, dom, options);
 };
 
 /**

--- a/test/xml.js
+++ b/test/xml.js
@@ -27,6 +27,11 @@ describe('render', function() {
       expect(xml(str)).to.equal('<link>http://www.github.com/</link>');
     });
 
+    it('should escape entities', function(){
+      var str = '<tag attr="foo &amp; bar"/>';
+      expect(xml(str)).to.equal(str);
+    });
+
   });
 
   describe('(dom)', function () {


### PR DESCRIPTION
Also moved shared logic with `.html()` to a function.

fixes #645