### PR TITLE
Update to css-select@1.0.0

### DIFF
--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -1,5 +1,5 @@
 var _ = require('lodash'),
-    select = require('CSSselect'),
+    select = require('css-select'),
     utils = require('../utils'),
     domEach = utils.domEach,
     uniqueSort = require('htmlparser2').DomUtils.uniqueSort,

--- a/lib/static.js
+++ b/lib/static.js
@@ -2,7 +2,7 @@
  * Module dependencies
  */
 
-var select = require('CSSselect'),
+var select = require('css-select'),
     parse = require('./parse'),
     render = require('dom-serializer'),
     _ = require('lodash');

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node": ">= 0.6"
   },
   "dependencies": {
-    "CSSselect": "~0.4.0",
+    "css-select": "~1.0.0",
     "entities": "~1.1.1",
     "htmlparser2": "~3.8.1",
     "dom-serializer": "~0.0.0",


### PR DESCRIPTION
The new version supports `:matches` and includes a number of other improvements. I had to change the name due to a npm bug (upper case package names aren't supported anymore).

Fixes #644.