### PR TITLE
Updates Readme.md: .not(function (index, elem))

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -441,7 +441,7 @@ $('li').not('.apple').length;
 Function:
 
 ```js
-$('li').filter(function(i, el) {
+$('li').not(function(i, el) {
   // this === el
   return $(this).attr('class') === 'orange';
 }).length;


### PR DESCRIPTION
Updates the Readme.md example given for the .not(function (index, elem))
function to correctly call .not(function (index, elem)).

Fixes #650.