### PR TITLE
Change lodash dependencies to ^3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "entities": "~1.1.1",
     "htmlparser2": "~3.8.1",
     "dom-serializer": "~0.0.0",
-    "lodash": "~3.1.0"
+    "lodash": "^3.2.0"
   },
   "devDependencies": {
     "benchmark": "~1.0.0",


### PR DESCRIPTION
I know I made a PR for this a few days ago (#653). But I think `~3.1.0` is too strict considering what cheerio is using from lodash (core methods): `_.each`, `_.forEach`, `_.map`, `_.defaults` and `_.merge`; these methods are not planned to change in the `3.x.x`  or anytime soon.

Being less strict is better for people using it with something like browserify (reduce bundle size by avoiding having 2 versions of lodash).

For example, from `3.1.0` to `3.2.0`, jdalton fixed some "important" issues in non-core methods (chaining): https://github.com/lodash/lodash/issues/955 and https://github.com/lodash/lodash/issues/958.

Another, maybe better and even less strict, solution can be: `3.x.x || 2.4.x`

Let me know what you think.
