### PR TITLE
Do not expose internal `children` array

### DIFF
--- a/lib/static.js
+++ b/lib/static.js
@@ -138,7 +138,12 @@ exports.parseHTML = function(data, context, keepScripts) {
     parsed('script').remove();
   }
 
-  return parsed.root()[0].children;
+  // The `children` array is used by Cheerio internally to group elements that
+  // share the same parents. When nodes created through `parseHTML` are
+  // inserted into previously-existing DOM structures, they will be removed
+  // from the `children` array. The results of `parseHTML` should remain
+  // constant across these operations, so a shallow copy should be returned.
+  return parsed.root()[0].children.slice();
 };
 
 /**

--- a/test/api/utils.js
+++ b/test/api/utils.js
@@ -157,6 +157,14 @@ describe('cheerio', function() {
       expect(cheerio.parseHTML('<#if><tr><p>This is a test.</p></tr><#/if>') || true).to.be.ok();
     });
 
+    it('(text) : should return an array that is not effected by DOM manipulation methods', function() {
+      var $ = cheerio.load('<div>');
+      var elems = $.parseHTML('<b></b><i></i>');
+
+      $('div').append(elems);
+
+      expect(elems).to.have.length(2);
+    });
   });
 
   describe('.contains', function() {


### PR DESCRIPTION
I'll admit that this is a bit esoteric, but as noted in the commit message (below), it *is* an inconsistency with jQuery.

For additional context: the current behavior is preventing [the Backbone.Layoutmanager project](https://github.com/tbranyen/backbone.layoutmanager) from upgrading its dependency on Cheerio because [it passes the result of `$.parseHTML` to `$.fn.replaceWith`](https://github.com/tbranyen/backbone.layoutmanager/blob/a7b012f314de96b988c2217ebee2a9330c1d6953/backbone.layoutmanager.js#L105-L115). I'm a maintainer of that project, so I'm a bit biased for this solution. I'd appreciate input on whether this change is an improvement for Cheerio or whether LayoutManager ought to be changed instead.

> Whenever Cheerio inserts a node as a child of a some other node, it
> explicitly removes it from its previous `children` array. This both
> avoids memory leaks and more faithfully matches the behavior of the W3C
> DOM, where a node may only be a child of one other node.
>
> When a user creates an array of node objects from a string using
> `$.parseHTML`, she most likely intends to insert the contents into some
> previously-existing DOM structure. If supplied with the `children` array
> directly, future insertion operations will modify the contents of that
> array. This is both unintuitive from an API design perspective and
> inconsistent with jQuery's behavior.
> 
> To avoid silently changing the contents of arrays given to users, update
> `$.parseHTML` to return a shallow copy of the `children` structure.