### PR TITLE
Added support for options without a `value` attribute. Fixes #633

### DIFF
--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -1,4 +1,5 @@
 var _ = require('lodash'),
+  $ = require('../static'),
   utils = require('../utils'),
   isTag = utils.isTag,
   domEach = utils.domEach,
@@ -37,6 +38,11 @@ var getAttr = function(elem, name) {
   if (hasOwn.call(elem.attribs, name)) {
     // Get the (decoded) attribute
     return rboolean.test(name) ? name : elem.attribs[name];
+  }
+
+  // Mimic the DOM and return text content as value for `option's`
+  if (elem.name === 'option' && name === 'value') {
+    return $.text(elem.children);
   }
 };
 
@@ -198,7 +204,7 @@ exports.val = function(value) {
       if (this.attr().hasOwnProperty('multiple')) {
         returnValue = [];
         domEach(option, function(i, el) {
-          returnValue.push(el.attribs.value);
+          returnValue.push(getAttr(el, 'value'));
         });
       }
       return returnValue;

--- a/test/api/attributes.js
+++ b/test/api/attributes.js
@@ -286,6 +286,18 @@ describe('$(...)', function() {
       var val = $('select#one').val();
       expect(val).to.equal('option_selected');
     });
+    it('.val(): on select with no value should get text', function() {
+      var val = $('select#one-valueless').val();
+      expect(val).to.equal('Option selected');
+    });
+    it('.val(): on select with no value should get converted HTML', function() {
+      var val = $('select#one-html-entity').val();
+      expect(val).to.equal('Option <selected>');
+    });
+    it('.val(): on select with no value should get text content', function() {
+      var val = $('select#one-nested').val();
+      expect(val).to.equal('Option selected');
+    });
     it('.val(): on option should get value', function() {
       var val = $('select#one option').eq(0).val();
       expect(val).to.equal('option_not_selected');
@@ -308,7 +320,11 @@ describe('$(...)', function() {
     });
     it('.val(): on multiple select should get an array of values', function() {
       var val = $('select#multi').val();
-      expect(val).to.have.length(2);
+      expect(val).to.eql(['2', '3']);
+    });
+    it('.val(): on multiple select with no value attribute should get an array of text content', function() {
+      var val = $('select#multi-valueless').val();
+      expect(val).to.eql(['2', '3']);
     });
     it('.val(value): on input text should set value', function() {
       var element = $('input[type="text"]').val('test');

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -41,11 +41,15 @@ exports.food = [
 
 exports.inputs = [
   '<select id="one"><option value="option_not_selected">Option not selected</option><option value="option_selected" selected>Option selected</option></select>',
+  '<select id="one-valueless"><option>Option not selected</option><option selected>Option selected</option></select>',
+  '<select id="one-html-entity"><option>Option not selected</option><option selected>Option &lt;selected&gt;</option></select>',
+  '<select id="one-nested"><option>Option not selected</option><option selected>Option <span>selected</span></option></select>',
   '<input type="text" value="input_text" />',
   '<input type="checkbox" name="checkbox_off" value="off" /><input type="checkbox" name="checkbox_on" value="on" checked />',
   '<input type="radio" value="off" name="radio" /><input type="radio" name="radio" value="on" checked />',
   '<input type="radio" value="off" name="radio[brackets]" /><input type="radio" name="radio[brackets]" value="on" checked />',
-  '<select id="multi" multiple><option value="1">1</option><option value="2" selected>2</option><option value="3" selected>3</option><option value="4">4</option></select>'
+  '<select id="multi" multiple><option value="1">1</option><option value="2" selected>2</option><option value="3" selected>3</option><option value="4">4</option></select>',
+  '<select id="multi-valueless" multiple><option>1</option><option selected>2</option><option selected>3</option><option>4</option></select>'
 ].join('');
 
 exports.text = [


### PR DESCRIPTION
As noted in #633, we are not properly treating `option's` without a `value` attribute. This PR adds back functionality that emulates the DOM and thus jQuery behavior. In this PR:

- Added tests for value-less options (e.g. normal, with HTML entities, with HTML elements)
    - Correct expectations can be found at http://codepen.io/twolfson/pen/WbymMK
- Added patches for `attr` and `val`
