### PR TITLE
fix #677: attr({foo: null}) removes attribute foo, like attr('foo', null)

### DIFF
--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -61,8 +61,8 @@ exports.attr = function(name, value) {
       if (!isTag(el)) return;
 
       if (typeof name === 'object') {
-        _.each(name, function(name, key) {
-          el.attribs[key] = name+'';
+        _.each(name, function(value, name) {
+          setAttr(el, name, value);
         });
       } else {
         setAttr(el, name, value);

--- a/test/api/attributes.js
+++ b/test/api/attributes.js
@@ -111,6 +111,22 @@ describe('$(...)', function() {
       $apple.removeAttr('data-autofocus');
       expect($apple.attr('data-autofocus')).to.be(undefined);
     });
+
+    it('(key, value) : should remove attributes when called with null value', function() {
+      var $pear = $('.pear').attr('autofocus', 'autofocus');
+      expect($pear.attr('autofocus')).to.equal('autofocus');
+      $pear.attr('autofocus', null);
+      expect($pear.attr('autofocus')).to.be(undefined);
+    });
+
+    it('(map) : should remove attributes with null values', function() {
+      var $pear = $('.pear').attr({'autofocus': 'autofocus', 'style': 'color:red'});
+      expect($pear.attr('autofocus')).to.equal('autofocus');
+      expect($pear.attr('style')).to.equal('color:red');
+      $pear.attr({'autofocus': null, 'style': 'color:blue'});
+      expect($pear.attr('autofocus')).to.be(undefined);
+      expect($pear.attr('style')).to.equal('color:blue');
+    });
   });
 
   describe('.data', function() {


### PR DESCRIPTION
also added unit tests for both attr(name, null) and attr({name: null}) cases...

Fixes #677