### PR TITLE
Update to css-select@1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node": ">= 0.6"
   },
   "dependencies": {
-    "css-select": "~1.0.0",
+    "css-select": "~1.1.0",
     "entities": "~1.1.1",
     "htmlparser2": "~3.8.1",
     "dom-serializer": "~0.1.0",


### PR DESCRIPTION
This release adds context support, which adds support for CSS4's `:scope` selector and fixes some issues (eg. spilling inside `.find` or the `:has` selector: Given `<a><b><c>` as a document, `$("b").find("a c")`, as well as `b:has(a c)`, won't match any elements anymore).

It's now pretty easy to implement jQuery's positional pseudo-selectors, I've started working on it in the [cheerio-select](https://github.com/cheeriojs/cheerio-select) repo (once again as a wrapper for css-select). @MatthewMueller's old wrapper included several test that I'd like to adopt, the repo seems to be deleted, though.