### PR TITLE
Update Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -366,7 +366,7 @@ $('li').slice(1, 2).length
 //=> 1
 ```
 
-#### .siblings( selector )
+#### .siblings([selector])
 Gets the first selected element's siblings, excluding itself.
 
 ```js
@@ -378,7 +378,7 @@ $('.pear').siblings('.orange').length
 
 ```
 
-#### .children( selector )
+#### .children([selector])
 Gets the children of the first selected element.
 
 ```js


### PR DESCRIPTION
`.siblings` and `.children` have a function signature like `.parents`, but the `selector` argument was not listed as being optional in the former cases. This PR fixes that, and documents the function signature like that of `.parents`.

I'll probably submit some more documentation patches later, if I run across more issues.