### PR TITLE
interpret null in objects passed to attr() consistently

### DIFF
--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -61,8 +61,8 @@ exports.attr = function(name, value) {
       if (!isTag(el)) return;
 
       if (typeof name === 'object') {
-        _.each(name, function(name, key) {
-          el.attribs[key] = name+'';
+        _.each(name, function(objectValue, objectKey) {
+          setAttr(el, objectKey, objectValue !== null ? objectValue+'' : null);
         });
       } else {
         setAttr(el, name, value);
@@ -404,4 +404,3 @@ exports.is = function (selector) {
   }
   return false;
 };
-

--- a/test/api/attributes.js
+++ b/test/api/attributes.js
@@ -69,6 +69,16 @@ describe('$(...)', function() {
       expect(attrs['data-url']).to.equal('http://apple.com');
     });
 
+    it('(map) : should remove attributes when null is passed in the object', function () {
+      var $apple = $('.apple');
+      $apple.attr({
+        'class': null,
+        'id':'newId'
+      });
+      expect($apple.attr('class')).to.equal(undefined);
+      expect($apple.attr('id')).to.equal('newId');
+    });
+
     it('(key, function) : should call the function and update the attribute with the return value', function() {
       var $fruits = $('#fruits');
       $fruits.attr('id', function(index, value) {


### PR DESCRIPTION
… that is by removing the attribute in question rather than setting
it to the string "null".

Also add a test for this and avoid overwriting variables in the
implementation.

This should solve #677.