### PR TITLE
update css-select dependency to ~1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node": ">= 0.6"
   },
   "dependencies": {
-    "css-select": "~1.0.0",
+    "css-select": "~1.1.0",
     "entities": "~1.1.1",
     "htmlparser2": "~3.8.1",
     "dom-serializer": "~0.1.0",


### PR DESCRIPTION
Hey Cheerio,

I updated css-select to the most up to date 1.1.0 because prior versions of css-select used prior versions of css-what which uses not fully supported `trimLeft`. (see https://github.com/fb55/css-what/pull/10).

Thanks!