### PR TITLE
Reinstate `$.fn.toArray`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -786,6 +786,14 @@ $.xml()
 ### Miscellaneous
 DOM element methods that don't fit anywhere else
 
+#### .toArray()
+Retrieve all the DOM elements contained in the jQuery set as an array.
+
+```js
+$('li').toArray()
+//=> [ {...}, {...}, {...} ]
+```
+
 #### .clone() ####
 Clone the cheerio object.
 

--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -125,8 +125,6 @@ Cheerio.prototype._make = function(dom, context) {
 
 /**
  * Turn a cheerio object into an array
- *
- * @deprecated
  */
 
 Cheerio.prototype.toArray = function() {


### PR DESCRIPTION
jQuery defines the `$.fn.toArray` method, and it is *not* deprecated, so
Cheerio should document and maintain it for the foreseeable future.