### PR TITLE
Enable setting data on all elements in selection

### DIFF
--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -74,6 +74,10 @@ exports.attr = function(name, value) {
 };
 
 var setData = function(el, name, value) {
+  if (!el.data) {
+    el.data = {};
+  }
+
   if (typeof name === 'object') return _.extend(el.data, name);
   if (typeof name === 'string' && value !== undefined) {
     el.data[name] = value;

--- a/test/api/attributes.js
+++ b/test/api/attributes.js
@@ -232,6 +232,14 @@ describe('$(...)', function() {
       expect(b.data('snack')).to.eql('chocoletti');
     });
 
+    it('(key, value) : should set data for all elements in the selection', function() {
+      $('li').data('foo', 'bar');
+
+      expect($('li').eq(0).data('foo')).to.eql('bar');
+      expect($('li').eq(1).data('foo')).to.eql('bar');
+      expect($('li').eq(2).data('foo')).to.eql('bar');
+    });
+
     it('(map) : object map should set multiple data attributes', function() {
       var data = $('.linth').data({
         id: 'Cailler',


### PR DESCRIPTION
According to the description of `$.fn.data` (below), the method should
set the data for *all* elements in the selection. Ensure this does not
generate an error in those cases where any elements in the selection do
not yet define a `data` property.

> Store arbitrary data associated with the matched elements or return
> the value at the named data store for the first element in the set of
> matched elements.

Source: https://api.jquery.com/data/

This resolves gh-733