### PR TITLE
Fixed grammatical error

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -114,7 +114,7 @@ For a full list of options and their effects, see [this](https://github.com/fb55
 Cheerio's selector implementation is nearly identical to jQuery's, so the API is very similar.
 
 #### $( selector, [context], [root] )
-`selector` searches within the `context` scope which searches within the `root` scope. `selector` and `context` can be an string expression, DOM Element, array of DOM elements, or cheerio object. `root` is typically the HTML document string.
+`selector` searches within the `context` scope which searches within the `root` scope. `selector` and `context` can be a string expression, DOM Element, array of DOM elements, or cheerio object. `root` is typically the HTML document string.
 
 This selector method is the starting point for traversing and manipulating the document. Like jQuery, it's the primary method for selecting elements in the document, but unlike jQuery it's built on top of the CSSSelect library, which implements most of the Sizzle selectors.
 


### PR DESCRIPTION
Changed a part of line 117 of the Readme.MD from "an string expression" to "a string expression".
close #775 