### PR TITLE
Disallow variable shadowing

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -6,5 +6,6 @@
   "undef": true,
   "unused": true,
   "node": true,
-  "quotmark": "single"
+  "quotmark": "single",
+  "shadow": "outer"
 }

--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -78,8 +78,8 @@ exports.attr = function(name, value) {
       if (!isTag(el)) return;
 
       if (typeof name === 'object') {
-        _.forEach(name, function(value, name) {
-          setAttr(el, name, value);
+        _.forEach(name, function(objValue, objName) {
+          setAttr(el, objName, objValue);
         });
       } else {
         setAttr(el, name, value);
@@ -135,18 +135,18 @@ exports.prop = function (name, value) {
   if (typeof name === 'object' || value !== undefined) {
 
     if (typeof value === 'function') {
-      return domEach(this, function(i, el) {
-        setProp(el, name, value.call(el, i, getProp(el, name)));
+      return domEach(this, function(j, el) {
+        setProp(el, name, value.call(el, j, getProp(el, name)));
       });
     }
 
-    return domEach(this, function(i, el) {
+    return domEach(this, function(__, el) {
       if (!isTag(el)) return;
 
       if (typeof name === 'object') {
 
-        _.forEach(name, function(val, name) {
-          setProp(el, name, val);
+        _.forEach(name, function(val, key) {
+          setProp(el, key, val);
         });
 
       } else {
@@ -182,8 +182,8 @@ var readData = function(el, name) {
     domNames = Object.keys(el.attribs).filter(function(attrName) {
       return attrName.slice(0, dataAttrPrefix.length) === dataAttrPrefix;
     });
-    jsNames = domNames.map(function(domName) {
-      return camelCase(domName.slice(dataAttrPrefix.length));
+    jsNames = domNames.map(function(_domName) {
+      return camelCase(_domName.slice(dataAttrPrefix.length));
     });
   } else {
     domNames = [dataAttrPrefix + cssCase(name)];
@@ -287,7 +287,7 @@ exports.val = function(value) {
       returnValue = option.attr('value');
       if (this.attr().hasOwnProperty('multiple')) {
         returnValue = [];
-        domEach(option, function(i, el) {
+        domEach(option, function(__, el) {
           returnValue.push(getAttr(el, 'value'));
         });
       }

--- a/lib/api/forms.js
+++ b/lib/api/forms.js
@@ -42,22 +42,22 @@ exports.serializeArray = function() {
     ).map(function(i, elem) {
       var $elem = Cheerio(elem);
       var name = $elem.attr('name');
-      var val = $elem.val();
+      var value = $elem.val();
 
       // If there is no value set (e.g. `undefined`, `null`), then return nothing
-      if (val == null) {
+      if (value == null) {
         return null;
       } else {
         // If we have an array of values (e.g. `<select multiple>`), return an array of key/value pairs
-        if (Array.isArray(val)) {
-          return _.map(val, function(val) {
+        if (Array.isArray(value)) {
+          return _.map(value, function(val) {
             // We trim replace any line endings (e.g. `\r` or `\r\n` with `\r\n`) to guarantee consistency across platforms
             //   These can occur inside of `<textarea>'s`
             return {name: name, value: val.replace( rCRLF, '\r\n' )};
           });
         // Otherwise (e.g. `<input type="text">`, return only one key/value pair
         } else {
-          return {name: name, value: val.replace( rCRLF, '\r\n' )};
+          return {name: name, value: value.replace( rCRLF, '\r\n' )};
         }
       }
     // Convert our result to an array

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -350,8 +350,8 @@ exports.replaceWith = function(content) {
 
 exports.empty = function() {
   domEach(this, function(i, el) {
-    _.forEach(el.children, function(el) {
-      el.next = el.prev = el.parent = null;
+    _.forEach(el.children, function(child) {
+      child.next = child.prev = child.parent = null;
     });
 
     el.children.length = 0;
@@ -371,8 +371,8 @@ exports.html = function(str) {
   var opts = this.options;
 
   domEach(this, function(i, el) {
-    _.forEach(el.children, function(el) {
-      el.next = el.prev = el.parent = null;
+    _.forEach(el.children, function(child) {
+      child.next = child.prev = child.parent = null;
     });
 
     var content = str.cheerio ? str.clone().get() : evaluate('' + str, opts);
@@ -401,8 +401,8 @@ exports.text = function(str) {
 
   // Append text node to each selected elements
   domEach(this, function(i, el) {
-    _.forEach(el.children, function(el) {
-      el.next = el.prev = el.parent = null;
+    _.forEach(el.children, function(child) {
+      child.next = child.prev = child.parent = null;
     });
 
     var elem = {

--- a/test/api/attributes.js
+++ b/test/api/attributes.js
@@ -130,8 +130,7 @@ describe('$(...)', function() {
   });
 
   describe('.prop', function () {
-    var $,
-        checkbox;
+    var checkbox;
 
     beforeEach(function () {
       $ = cheerio.load(inputs);

--- a/test/api/manipulation.js
+++ b/test/api/manipulation.js
@@ -1330,7 +1330,7 @@ describe('$(...)', function() {
     });
 
     it('(html) : should add new elements for each element in selection', function() {
-      var $fruits = $('li');
+      $fruits = $('li');
       $fruits.html('<li class="durian">Durian</li>');
       var tested = 0;
       $fruits.each(function(){

--- a/test/api/traversing.js
+++ b/test/api/traversing.js
@@ -48,8 +48,8 @@ describe('$(...)', function() {
     });
 
     it('should query immediate descendant only', function() {
-      var $ = cheerio.load('<foo><bar><bar></bar><bar></bar></bar></foo>');
-      expect($('foo').find('> bar')).to.have.length(1);
+      var q = cheerio.load('<foo><bar><bar></bar><bar></bar></bar></foo>');
+      expect(q('foo').find('> bar')).to.have.length(1);
     });
 
     it('should query case-sensitively when in xmlMode', function() {
@@ -70,42 +70,42 @@ describe('$(...)', function() {
 
     describe('(cheerio object) :', function() {
       it('returns only those nodes contained within the current selection', function() {
-        var $ = cheerio.load(food);
-        var $selection = $('#fruits').find($('li'));
+        var q = cheerio.load(food);
+        var $selection = q('#fruits').find(q('li'));
 
         expect($selection).to.have.length(3);
-        expect($selection[0]).to.be($('.apple')[0]);
-        expect($selection[1]).to.be($('.orange')[0]);
-        expect($selection[2]).to.be($('.pear')[0]);
+        expect($selection[0]).to.be(q('.apple')[0]);
+        expect($selection[1]).to.be(q('.orange')[0]);
+        expect($selection[2]).to.be(q('.pear')[0]);
       });
       it('returns only those nodes contained within any element in the current selection', function() {
-        var $ = cheerio.load(food);
-        var $selection = $('.apple, #vegetables').find($('li'));
+        var q = cheerio.load(food);
+        var $selection = q('.apple, #vegetables').find(q('li'));
 
         expect($selection).to.have.length(2);
-        expect($selection[0]).to.be($('.carrot')[0]);
-        expect($selection[1]).to.be($('.sweetcorn')[0]);
+        expect($selection[0]).to.be(q('.carrot')[0]);
+        expect($selection[1]).to.be(q('.sweetcorn')[0]);
       });
     });
 
     describe('(node) :', function() {
       it('returns node when contained within the current selection', function() {
-        var $ = cheerio.load(food);
-        var $selection = $('#fruits').find($('.apple')[0]);
+        var q = cheerio.load(food);
+        var $selection = q('#fruits').find(q('.apple')[0]);
 
         expect($selection).to.have.length(1);
-        expect($selection[0]).to.be($('.apple')[0]);
+        expect($selection[0]).to.be(q('.apple')[0]);
       });
       it('returns node when contained within any element the current selection', function() {
-        var $ = cheerio.load(food);
-        var $selection = $('#fruits, #vegetables').find($('.carrot')[0]);
+        var q = cheerio.load(food);
+        var $selection = q('#fruits, #vegetables').find(q('.carrot')[0]);
 
         expect($selection).to.have.length(1);
-        expect($selection[0]).to.be($('.carrot')[0]);
+        expect($selection[0]).to.be(q('.carrot')[0]);
       });
       it('does not return node that is not contained within the current selection', function() {
-        var $ = cheerio.load(food);
-        var $selection = $('#fruits').find($('.carrot')[0]);
+        var q = cheerio.load(food);
+        var $selection = q('#fruits').find(q('.carrot')[0]);
 
         expect($selection).to.have.length(0);
       });
@@ -855,8 +855,8 @@ describe('$(...)', function() {
 
     it('(element) : should only consider nested elements', function() {
       var $fruits = $('#fruits');
-      var fruits = $fruits[0];
-      var $empty = $fruits.has(fruits);
+      var fruitsEl = $fruits[0];
+      var $empty = $fruits.has(fruitsEl);
 
       expect($empty).to.have.length(0);
     });
@@ -1109,13 +1109,17 @@ describe('$(...)', function() {
   });
 
   describe('.add', function() {
-    var $ = cheerio.load(food);
-    var $fruits = $('#fruits');
-    var $apple = $('.apple');
-    var $orange = $('.orange');
-    var $pear = $('.pear');
-    var $carrot = $('.carrot');
-    var $sweetcorn = $('.sweetcorn');
+    var $fruits, $apple, $orange, $pear, $carrot, $sweetcorn;
+
+    beforeEach(function() {
+      $ = cheerio.load(food);
+      $fruits = $('#fruits');
+      $apple = $('.apple');
+      $orange = $('.orange');
+      $pear = $('.pear');
+      $carrot = $('.carrot');
+      $sweetcorn = $('.sweetcorn');
+    });
 
     describe('(selector', function() {
       describe(') :', function() {
@@ -1393,13 +1397,13 @@ describe('$(...)', function() {
         expect($selection[1]).to.be($('.apple')[0]);
       });
       it('includes parents and self', function() {
-        var $ = cheerio.load(food);
-        var $selection = $('.apple').parents().addBack();
+        var q = cheerio.load(food);
+        var $selection = q('.apple').parents().addBack();
 
         expect($selection).to.have.length(3);
-        expect($selection[0]).to.be($('#food')[0]);
-        expect($selection[1]).to.be($('#fruits')[0]);
-        expect($selection[2]).to.be($('.apple')[0]);
+        expect($selection[0]).to.be(q('#food')[0]);
+        expect($selection[1]).to.be(q('#fruits')[0]);
+        expect($selection[2]).to.be(q('.apple')[0]);
       });
     });
     it('(filter) : filters the previous selection', function() {

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -107,8 +107,8 @@ describe('cheerio', function() {
 
   it('should select only elements inside given context (Issue #193)', function() {
     var q = $.load(food),
-        fruits = q('#fruits'),
-        fruitElements = q('li', fruits);
+        $fruits = q('#fruits'),
+        fruitElements = q('li', $fruits);
 
     expect(fruitElements).to.have.length(3);
   });


### PR DESCRIPTION
@ssp raised this concern during the review of gh-718. I'm inclined to agree that shadowing is a hazardous practice that ought to be avoided, but I don't know where the rest of @cheeriojs/owners stand. Do you folks care to weigh in on this?

Commit message:

> When variable binding identifies are re-used in nested scopes
> ("shadowing"), code readability suffers. The same identifier may
> describe many distinct values in memory, and the process of
> disambiguating requires explicit attention from the reader. Mistakes
> made in this process can trigger bugs which, unlike unresolvable
> references, are not immediately apparent.
> 
> Configure JSHint to warn on occurrences of nested reuse of variable
> binding identifiers in order to promote code clarity. Update the
> codebase to satisfy this new constraint.
