### PR TITLE
Few optimizations

### DIFF
--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -192,7 +192,7 @@ var readData = function(el, name) {
 
       if (hasOwn.call(primitives, value)) {
         value = primitives[value];
-      } else if (value === String(Number(value))) {
+      } else if (value === Number(value)+'') {
         value = Number(value);
       } else if (rbrace.test(value)) {
         try {

--- a/lib/api/css.js
+++ b/lib/api/css.js
@@ -14,7 +14,7 @@ var toString = Object.prototype.toString;
 exports.css = function(prop, val) {
   if (arguments.length === 2 ||
     // When `prop` is a "plain" object
-    (toString.call(prop) === '[object Object]')) {
+    (prop instanceof Object || toString.call(prop) === '[object Object]')) {
     return domEach(this, function(idx, el) {
       setCss(el, prop, val, idx);
     });

--- a/lib/static.js
+++ b/lib/static.js
@@ -78,7 +78,7 @@ exports.html = function(dom, options) {
   // with options as only parameter
   // check dom argument for dom element specific properties
   // assume there is no 'length' or 'type' properties in the options object
-  if (Object.prototype.toString.call(dom) === '[object Object]' && !options && !('length' in dom) && !('type' in dom))
+  if ((dom instanceof Object || Object.prototype.toString.call(dom) === '[object Object]') && !options && !('length' in dom) && !('type' in dom))
   {
     options = dom;
     dom = undefined;


### PR DESCRIPTION
Hi,

I suggest the following two optimizations:

1) It is performance wise to use instanceof instead of toString class comparison, at least in the first place (it is implemented in almost all environments). I have made simple jsperf test to illustrate this: http://jsperf.com/instanceof-vs-tostring-2

2) String conversion with String constructor is more expensive than using the implicit string conversion. Since the input to String constructor in attributes.js, line 195 is always the number, it is safe to implicitly convert it to string. jsperf test: http://jsperf.com/implicitvsstringconstructor

