### PR TITLE
Added `.serialize()` support. Fixes #69

### DIFF
--- a/lib/api/forms.js
+++ b/lib/api/forms.js
@@ -2,7 +2,21 @@
 // https://github.com/jquery/jquery/blob/2.1.3/src/serialize.js
 var _ = require('lodash'),
     submittableSelector = 'input,select,textarea,keygen',
+    r20 = /%20/g,
     rCRLF = /\r?\n/g;
+
+exports.serialize = function() {
+  // Convert form elements into name/value objects
+  var arr = this.serializeArray();
+
+  // Serialize each element into a key/value string
+  var retArr = _.map(arr, function(data) {
+    return encodeURIComponent(data.name) + '=' + encodeURIComponent(data.value);
+  });
+
+  // Return the resulting serialization
+  return retArr.join('&').replace(r20, '+');
+};
 
 exports.serializeArray = function() {
   // Resolve all form elements from either forms or collections of form elements

--- a/test/api/forms.js
+++ b/test/api/forms.js
@@ -128,4 +128,28 @@ describe('$(...)', function() {
 
   });
 
+  describe('.serialize', function() {
+
+    it('() : should get form controls', function() {
+      expect($('form#simple').serialize()).to.equal('fruit=Apple');
+    });
+
+    it('() : should get nested form controls', function() {
+      expect($('form#nested').serialize()).to.equal('fruit=Apple&vegetable=Carrot');
+    });
+
+    it('() : should not get disabled form controls', function() {
+      expect($('form#disabled').serialize()).to.equal('');
+    });
+
+    it('() : should get multiple selected options', function() {
+      expect($('form#multiple').serialize()).to.equal('fruit=Apple&fruit=Orange');
+    });
+
+    it('() : should encode spaces as +\'s', function() {
+      expect($('form#spaces').serialize()).to.equal('fruit=Blood+orange');
+    });
+
+  });
+
 });

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -67,5 +67,6 @@ exports.forms = [
   '<form id="select"><select name="fruit"><option value="Apple">Apple</option><option value="Orange" selected>Orange</option></select></form>',
   '<form id="unnamed"><input type="text" name="fruit" value="Apple" /><input type="text" value="Carrot" /></form>',
   '<form id="multiple"><select name="fruit" multiple><option value="Apple" selected>Apple</option><option value="Orange" selected>Orange</option><option value="Carrot">Carrot</option></select></form>',
-  '<form id="textarea"><textarea name="fruits">Apple\nOrange</textarea></form>'
+  '<form id="textarea"><textarea name="fruits">Apple\nOrange</textarea></form>',
+  '<form id="spaces"><input type="text" name="fruit" value="Blood orange" /></form>'
 ].join('');


### PR DESCRIPTION
This was originally opened as #632 but @twolfson lost write access to the source repo and there was a merge conflict so we resolved it all in this PR

-------------------------

Now that #631 is implemented, we can add `.serialize()` support. Unfortunately, this comes with adding `$.param()`. `$.param` has a second half that `.serialize()` doesn't leverage (see its `else` statement). I am not sure whether we want to add this/test it, or drop it and make `$.param` internal only for now.

In this PR:

- Added `.serialize()` support http://api.jquery.com/serialize/
- Added tests for `.serialize()`
