### PR TITLE
Use explicit extension for require package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,4 +8,4 @@ exports = module.exports = require('./lib/cheerio');
   Export the version
 */
 
-exports.version = require('./package').version;
+exports.version = require('./package.json').version;


### PR DESCRIPTION
I got an error Error: Cannot find module "./package" when using webpack and setting `resolve.extensions = ['', '.js', '.jsx']`. As package here is not going to have another extension than .json I see no downside in this change.