### PR TITLE
serializeArray should not ignore input elements without value attributes

### DIFF
--- a/lib/api/forms.js
+++ b/lib/api/forms.js
@@ -28,21 +28,21 @@ exports.serializeArray = function() {
       var name = $elem.attr('name');
       var val = $elem.val();
 
-      // If there is no value set (e.g. `undefined`, `null`), then return nothing
+      // If there is no value set (e.g. `undefined`, `null`), then default value to empty
       if (val == null) {
-        return null;
-      } else {
-        // If we have an array of values (e.g. `<select multiple>`), return an array of key/value pairs
-        if (Array.isArray(val)) {
-          return _.map(val, function(val) {
-            // We trim replace any line endings (e.g. `\r` or `\r\n` with `\r\n`) to guarantee consistency across platforms
-            //   These can occur inside of `<textarea>'s`
-            return {name: name, value: val.replace( rCRLF, '\r\n' )};
-          });
-        // Otherwise (e.g. `<input type="text">`, return only one key/value pair
-        } else {
+        val = '';
+      }
+
+      // If we have an array of values (e.g. `<select multiple>`), return an array of key/value pairs
+      if (Array.isArray(val)) {
+        return _.map(val, function(val) {
+          // We trim replace any line endings (e.g. `\r` or `\r\n` with `\r\n`) to guarantee consistency across platforms
+          //   These can occur inside of `<textarea>'s`
           return {name: name, value: val.replace( rCRLF, '\r\n' )};
-        }
+        });
+      // Otherwise (e.g. `<input type="text">`, return only one key/value pair
+      } else {
+        return {name: name, value: val.replace( rCRLF, '\r\n' )};
       }
     // Convert our result to an array
     }).get();

--- a/test/api/forms.js
+++ b/test/api/forms.js
@@ -126,6 +126,15 @@ describe('$(...)', function() {
         ]);
     });
 
+    it('() : should serialize inputs without value attributes', function() {
+        expect($('<input name="fruit">').serializeArray()).to.eql([
+            {
+                name: 'fruit',
+                value: ''
+            }
+        ]);
+    });
+
   });
 
 });


### PR DESCRIPTION
`serializeArray` ignores input elements without value attributes. The value attribute is optional for most types of input elements, however:

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-value

In this case, input elements without a value attribute should be parsed by this function, and default to an empty string value.
