### PR TITLE
Document, test, and extend static `$.text` method

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -821,6 +821,13 @@ $.xml()
 //=>  <media:thumbnail url="http://www.foo.com/keyframe.jpg" width="75" height="50" time="12:05:01.123"/>
 ```
 
+You may also render the text content of a Cheerio object using the `text` static method:
+
+```js
+$ = cheerio.load('<div>This is <em>content</em>.</div>')
+$.text($('div'))
+//=> This is content.
+```
 
 ### Miscellaneous
 DOM element methods that don't fit anywhere else

--- a/Readme.md
+++ b/Readme.md
@@ -824,8 +824,16 @@ $.xml()
 You may also render the text content of a Cheerio object using the `text` static method:
 
 ```js
+$ = cheerio.load('This is <em>content</em>.')
+$.text()
+//=> This is content.
+```
+
+The method may be called on the Cheerio module itself--be sure to pass a collection of nodes!
+
+```js
 $ = cheerio.load('<div>This is <em>content</em>.</div>')
-$.text($('div'))
+cheerio.text($('div'))
 //=> This is content.
 ```
 

--- a/lib/static.js
+++ b/lib/static.js
@@ -106,7 +106,9 @@ exports.xml = function(dom) {
  */
 
 exports.text = function(elems) {
-  if (!elems) return '';
+  if (!elems) {
+    elems = this.root();
+  }
 
   var ret = '',
       len = elems.length,

--- a/test/api/utils.js
+++ b/test/api/utils.js
@@ -35,6 +35,23 @@ describe('cheerio', function() {
   });
 
 
+  describe('.text', function() {
+    it('(cheerio object) : should return the text contents of the specified elements', function() {
+      var $ = cheerio.load('<a>This is <em>content</em>.</a>');
+      expect($.text($('a'))).to.equal('This is content.');
+    });
+
+    it('(cheerio object) : should omit comment nodes', function() {
+      var $ = cheerio.load('<a>This is <!-- a comment --> not a comment.</a>');
+      expect($.text($('a'))).to.equal('This is  not a comment.');
+    });
+
+    it('(cheerio object) : should include text contents of children recursively', function() {
+      var $ = cheerio.load('<a>This is <div>a child with <span>another child and <!-- a comment --> not a comment</span> followed by <em>one last child</em> and some final</div> text.</a>');
+      expect($.text($('a'))).to.equal('This is a child with another child and  not a comment followed by one last child and some final text.');
+    });
+  });
+
 
   describe('.load', function() {
 

--- a/test/api/utils.js
+++ b/test/api/utils.js
@@ -50,6 +50,11 @@ describe('cheerio', function() {
       var $ = cheerio.load('<a>This is <div>a child with <span>another child and <!-- a comment --> not a comment</span> followed by <em>one last child</em> and some final</div> text.</a>');
       expect($.text($('a'))).to.equal('This is a child with another child and  not a comment followed by one last child and some final text.');
     });
+
+    it('() : should return the rendered text content of the root', function() {
+      var $ = cheerio.load('<a>This is <div>a child with <span>another child and <!-- a comment --> not a comment</span> followed by <em>one last child</em> and some final</div> text.</a>');
+      expect($.text()).to.equal('This is a child with another child and  not a comment followed by one last child and some final text.');
+    });
   });
 
 


### PR DESCRIPTION
As noted in the commit messages, this method was previously undocumented and untested. Add tests, and implement a change that, while technically backwards-incompatible, promotes parity between this method and the static methods `$.html` and `$.xml`.