### PR TITLE
Fix typo on calling _.extend

### DIFF
--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -160,7 +160,7 @@ var setData = function(el, name, value) {
   if (typeof name === 'string' && value !== undefined) {
     el.data[name] = value;
   } else if (typeof name === 'object') {
-    _.exend(el.data, name);
+    _.extend(el.data, name);
   }
 };
 


### PR DESCRIPTION
Typo on extending objects, as it missed a t.