### PR TITLE
make readme examples for ES2015 friendly

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -415,8 +415,8 @@ Iterates over a cheerio object, executing a function for each matched element. W
 ```js
 var fruits = [];
 
-$('li').each(function(i, elem) {
-  fruits[i] = $(this).text();
+$('li').each(function(i, el) {
+  fruits[i] = $(el).text();
 });
 
 fruits.join(', ');
@@ -428,8 +428,7 @@ Pass each element in the current matched set through a function, producing a new
 
 ```js
 $('li').map(function(i, el) {
-  // this === el
-  return $(this).text();
+  return $(el).text();
 }).get().join(' ');
 //=> "apple orange pear"
 ```
@@ -449,8 +448,7 @@ Function:
 
 ```js
 $('li').filter(function(i, el) {
-  // this === el
-  return $(this).attr('class') === 'orange';
+  return $(el).attr('class') === 'orange';
 }).attr('class')
 //=> orange
 ```
@@ -470,8 +468,7 @@ Function:
 
 ```js
 $('li').not(function(i, el) {
-  // this === el
-  return $(this).attr('class') === 'orange';
+  return $(el).attr('class') === 'orange';
 }).length;
 //=> 2
 ```


### PR DESCRIPTION
`$(this)` will not work within "arrow" functions, where `this` refers to the lexical `this` value in the scope of the declaration.

This PR updates removes `$(this)` from the README in favor of `$(el)`, so the code examples can be rewritten in ES2015 and will still work.

cc @gajus, https://github.com/cheeriojs/cheerio/issues/762
