### PR TITLE
.prop now returns undefined if given an invalid element or tag (#875)

### DIFF
--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -91,6 +91,8 @@ exports.attr = function(name, value) {
 };
 
 var getProp = function (el, name) {
+  if (!el || !isTag(el)) return;
+  
   return el.hasOwnProperty(name)
       ? el[name]
       : rboolean.test(name)

--- a/test/api/attributes.js
+++ b/test/api/attributes.js
@@ -182,6 +182,11 @@ describe('$(...)', function() {
     it('(key, value) : should support chaining after setting props', function() {
       expect(checkbox.prop('checked', false)).to.equal(checkbox);
     });
+    
+    it('(invalid element/tag) : prop should return undefined', function() {
+      expect($(undefined).prop('prop')).to.be(undefined);
+      expect($(null).prop('prop')).to.be(undefined);
+    });
   });
 
   describe('.data', function() {


### PR DESCRIPTION
Fix for issue https://github.com/cheeriojs/cheerio/issues/875.