### PR TITLE
Add baseHref option to cheerio.load, and have prop() resolve urls

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -160,7 +160,8 @@ of the default parsing options:
 ```js
 $ = cheerio.load('<ul id="fruits">...</ul>', {
     normalizeWhitespace: true,
-    xmlMode: true
+    xmlMode: true,
+    baseHref: 'http://example.com/'
 });
 ```
 
@@ -217,6 +218,8 @@ $('.apple').attr('id', 'favorite').html()
 
 #### .prop( name, value )
 Method for getting and setting properties. Gets the property value for only the first element in the matched set.
+Use the `baseHref` option with `cheerio.load` to control how `src` and `href` properties are resolved. To imitate
+what jQuery and the browser does.
 
 ```js
 $('input[type="checkbox"]').prop('checked')

--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -1,5 +1,6 @@
 var $ = require('../static'),
     utils = require('../utils'),
+    url = require('url'),
     isTag = utils.isTag,
     domEach = utils.domEach,
     hasOwn = Object.prototype.hasOwnProperty,
@@ -124,6 +125,13 @@ exports.prop = function (name, value) {
       case 'tagName':
       case 'nodeName':
         property = this[0].name.toUpperCase();
+        break;
+      case 'src':
+      case 'href':
+        property = getProp(this[0], name);
+        if (this.options.baseHref && property != null) {
+          property = url.resolve(this.options.baseHref, property);
+        }
         break;
       default:
         property = getProp(this[0], name);

--- a/test/api/attributes.js
+++ b/test/api/attributes.js
@@ -133,6 +133,24 @@ describe('$(...)', function() {
     var $,
         checkbox;
 
+    describe('with baseHref option', function() {
+      beforeEach(function() {
+        $ = cheerio.load(
+          '<img src="/hello.png"><a href="foobar/">test</a>',
+          { baseHref: 'http://example.com/a/' }
+        );
+      });
+
+      it('should have correct url', function() {
+        expect($('img').prop('src')).to.equal('http://example.com/hello.png');
+        expect($('a').prop('href')).to.equal('http://example.com/a/foobar/');
+      });
+
+      it('should not error on missing prop', function() {
+        expect($('img').prop('href')).to.equal(undefined);
+      });
+    });
+
     beforeEach(function () {
       $ = cheerio.load(inputs);
       checkbox = $('input[name=checkbox_on]');


### PR DESCRIPTION
This pull request adds a baseHref option to cheerio.load. When this option is set, .`prop(attrName)` will resolve `src` and `href` attributes as jQuery would relative to the baseHref.
