### PR TITLE
If null is passed to html, empty the element rather than throwing. 

### DIFF
--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -367,6 +367,10 @@ exports.html = function(str) {
     if (!this[0] || !this[0].children) return null;
     return $.html(this[0].children, this.options);
   }
+  
+  if(str === null){
+    str = '';
+  }
 
   var opts = this.options;
 

--- a/test/api/manipulation.js
+++ b/test/api/manipulation.js
@@ -1345,6 +1345,18 @@ describe('$(...)', function() {
       var html = $fruits.html();
       expect(html).to.equal('<li class="durian">Durian</li>');
     });
+    
+    it('(null) : should empty the element', function() {
+      $fruits.html(null);
+      var html = $fruits.html();
+      expect(html).to.equal('');
+    });
+    
+    it('(\'\') : should empty the element', function() {
+      $fruits.html('');
+      var html = $fruits.html();
+      expect(html).to.equal('');
+    });
 
     it('() : should allow element reinsertion', function() {
       var $children = $fruits.children();


### PR DESCRIPTION
Fixes #897
