### PR TITLE
Use modular lodash package

### DIFF
--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -8,9 +8,9 @@ var $ = require('../static'),
     rspace = /\s+/,
     dataAttrPrefix = 'data-',
     _ = {
-      forEach: require('lodash.foreach'),
-      extend: require('lodash.assignin'),
-      some: require('lodash.some')
+      forEach: require('lodash/forEach'),
+      extend: require('lodash/assignIn'),
+      some: require('lodash/some')
     },
 
   // Lookup table for coercing string data-* attributes to their corresponding
@@ -92,7 +92,7 @@ exports.attr = function(name, value) {
 
 var getProp = function (el, name) {
   if (!el || !isTag(el)) return;
-  
+
   return el.hasOwnProperty(name)
       ? el[name]
       : rboolean.test(name)
@@ -492,4 +492,3 @@ exports.is = function (selector) {
   }
   return false;
 };
-

--- a/lib/api/css.js
+++ b/lib/api/css.js
@@ -1,6 +1,6 @@
 var domEach = require('../utils').domEach,
     _ = {
-      pick: require('lodash.pick'),
+      pick: require('lodash/pick'),
     };
 
 var toString = Object.prototype.toString;

--- a/lib/api/forms.js
+++ b/lib/api/forms.js
@@ -4,7 +4,7 @@ var submittableSelector = 'input,select,textarea,keygen',
     r20 = /%20/g,
     rCRLF = /\r?\n/g,
     _ = {
-      map: require('lodash.map')
+      map: require('lodash/map')
     };
 
 exports.serialize = function() {

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -8,9 +8,9 @@ var parse = require('../parse'),
     isHtml = utils.isHtml,
     slice = Array.prototype.slice,
     _ = {
-      flatten: require('lodash.flatten'),
-      bind: require('lodash.bind'),
-      forEach: require('lodash.foreach')
+      flatten: require('lodash/flatten'),
+      bind: require('lodash/bind'),
+      forEach: require('lodash/forEach')
     };
 
 // Create an array of nodes, recursing into arrays and parsing strings if

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -4,11 +4,11 @@ var select = require('css-select'),
     uniqueSort = require('htmlparser2').DomUtils.uniqueSort,
     isTag = utils.isTag,
     _ = {
-      bind: require('lodash.bind'),
-      forEach: require('lodash.foreach'),
-      reject: require('lodash.reject'),
-      filter: require('lodash.filter'),
-      reduce: require('lodash.reduce')
+      bind: require('lodash/bind'),
+      forEach: require('lodash/forEach'),
+      reject: require('lodash/reject'),
+      filter: require('lodash/filter'),
+      reduce: require('lodash/reduce')
     };
 
 exports.find = function(selectorOrHaystack) {

--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -5,10 +5,10 @@
 var parse = require('./parse'),
     isHtml = require('./utils').isHtml,
     _ = {
-      extend: require('lodash.assignin'),
-      bind: require('lodash.bind'),
-      forEach: require('lodash.foreach'),
-      defaults: require('lodash.defaults')
+      extend: require('lodash/assignIn'),
+      bind: require('lodash/bind'),
+      forEach: require('lodash/forEach'),
+      defaults: require('lodash/defaults')
     };
 
 /*

--- a/lib/static.js
+++ b/lib/static.js
@@ -6,8 +6,8 @@ var serialize = require('dom-serializer'),
     select = require('css-select'),
     parse = require('./parse'),
     _ = {
-      merge: require('lodash.merge'),
-      defaults: require('lodash.defaults')
+      merge: require('lodash/merge'),
+      defaults: require('lodash/defaults')
     };
 
 /**

--- a/package.json
+++ b/package.json
@@ -29,18 +29,7 @@
     "dom-serializer": "~0.1.0",
     "entities": "~1.1.1",
     "htmlparser2": "^3.9.1",
-    "lodash.assignin": "^4.0.9",
-    "lodash.bind": "^4.1.4",
-    "lodash.defaults": "^4.0.1",
-    "lodash.filter": "^4.4.0",
-    "lodash.flatten": "^4.2.0",
-    "lodash.foreach": "^4.3.0",
-    "lodash.map": "^4.4.0",
-    "lodash.merge": "^4.4.0",
-    "lodash.pick": "^4.2.1",
-    "lodash.reduce": "^4.4.0",
-    "lodash.reject": "^4.4.0",
-    "lodash.some": "^4.4.0"
+    "lodash": "^4.15.0"
   },
   "devDependencies": {
     "benchmark": "^2.1.0",

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -5,7 +5,7 @@ var expect = require('expect.js'),
     fruits = fixtures.fruits,
     food = fixtures.food,
     _ = {
-      filter: require('lodash.filter')
+      filter: require('lodash/filter')
     };
 
 // HTML

--- a/test/xml.js
+++ b/test/xml.js
@@ -1,7 +1,7 @@
 var expect = require('expect.js'),
     cheerio = require('..'),
     _ = {
-      extend: require('lodash.assignin')
+      extend: require('lodash/assignIn')
     };
 
 var xml = function(str, options) {


### PR DESCRIPTION
As of lodash 4.14.0, individual packages (e.g. `lodash.foreach`) are zero-dependency modules (see the [changelog](https://github.com/lodash/lodash/wiki/Changelog#v4140)), meaning that if you install several of them, they do not share any code.

This completely negates (and actually worsens) the bundle size savings introduced in #864, since cheerio now depends on so many individual method packages. The solution is to use the modular version of lodash (installing lodash and importing from `lodash/method` rather than from the `lodash` monolith) as mentioned [here](https://github.com/cheeriojs/cheerio/pull/864#issuecomment-234014347).