### PR TITLE
Added an optional argument for last()

### DIFF
--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -345,8 +345,13 @@ exports.first = function() {
   return this.length > 1 ? this._make(this[0]) : this;
 };
 
-exports.last = function() {
-  return this.length > 1 ? this._make(this[this.length - 1]) : this;
+// takes an optional argument for arg-to-last item
+// not passing an optional argument returns last item
+exports.last = function(from) {
+  if (from === 'undefined'){
+    return this.length > 1 ? this._make(this[this.length - 1]) : this;
+  }
+  return this.length > from - 1 ? this._make(this[this.length - from]) : this;
 };
 
 // Reduce the set of matched elements to the one at the specified index.


### PR DESCRIPTION
Addressed https://github.com/cheeriojs/cheerio/issues/936

Last takes an optional argument so that something like last(2) will return the second-to-last item