### PR TITLE
#944 fixing missing prop(‘outerHTML’) implementation.

### DIFF
--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -125,6 +125,9 @@ exports.prop = function (name, value) {
       case 'nodeName':
         property = this[0].name.toUpperCase();
         break;
+      case 'outerHTML':
+        property = this.clone().wrap('<container />').parent().html();
+        break;
       default:
         property = getProp(this[0], name);
     }

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -350,5 +350,14 @@ describe('cheerio', function() {
         expect($b('div').foo).to.be(undefined);
       });
     });
+
+    describe('.prop', function () {
+      describe('("outerHTML")', function () {
+        var outerHtml = '<div><a></a></div>';
+        var $a = $(outerHtml);
+
+        expect($a.prop('outerHTML')).to.be(outerHtml);
+      });
+    });
   });
 });


### PR DESCRIPTION
fixes #944
Added an ‘outerHTML’ case to the switch in the prop function, which wraps a clone of `this` in a container element, and sets `property` to that container's HTML