### PR TITLE
let apple = $('#apple');$('#fruits').add(apple);

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ lib-cov
 cover_html
 .c9revisions
 coverage
+.idea

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -418,7 +418,7 @@ exports.add = function (other, context) {
     }
     this.length = contents.length;
     return selection;
-}
+};
 
 // Add the previous set of elements on the stack to the current set, optionally
 // filtered by a selector.

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -408,17 +408,17 @@ exports.end = function() {
   return this.prevObject || this._make([]);
 };
 
-exports.add = function(other, context) {
-  var selection = this._make(other, context);
-  var contents = uniqueSort(selection.get().concat(this.get()));
+exports.add = function (other, context) {
+    var _other = other.clone();
+    var selection = this._make(_other, context);
+    var contents = uniqueSort(selection.get().concat(this.get()));
 
-  for (var i = 0; i < contents.length; ++i) {
-    selection[i] = contents[i];
-  }
-  selection.length = contents.length;
-
-  return selection;
-};
+    for (var i = 0; i < contents.length; ++i) {
+        this[i] = contents[i];
+    }
+    this.length = contents.length;
+    return selection;
+}
 
 // Add the previous set of elements on the stack to the current set, optionally
 // filtered by a selector.


### PR DESCRIPTION
the right result is #fruits has apple
but I found apple has fruits

I don't need $('#fruits') = $('#fruits').add(apple);//and apple is wrong
I need $('#fruits).add(apple); then that fruits is changed;
I changed this bug