### PR TITLE
Fixed map function so it returns array

### DIFF
--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -302,10 +302,12 @@ exports.each = function(fn) {
 };
 
 exports.map = function(fn) {
-  return this._make(_.reduce(this, function(memo, el, i) {
-    var val = fn.call(el, i, el);
-    return val == null ? memo : memo.concat(val);
-  }, []));
+  var len = this.length, arr = [];
+  for (var i = 0; i < len; i++){
+    var val = fn.call(this[i], i, this[i]);
+    if (val != false) arr.push(val);
+  }
+  return arr;
 };
 
 var makeFilterMethod = function(filterFn) {


### PR DESCRIPTION
Map unexpectedly returns an object with the expected array as well as a bunch of other properties in [this example](http://stackoverflow.com/questions/39044690/cheerio-map-strange-behaviour/41028339#41028339):
```
let ids = $('[data-profileid]').map(function() {
    return $(this).attr('data-profileid')
})

console.log(ids)
```
Output:
```
...
'69': '234234234,
'70': '9328402397432',
'71': '1324235234',
  options:
   { withDomLvl1: true,
     normalizeWhitespace: false,
     xmlMode: false,
     decodeEntities: true },
  _root:
   { '0':
      { type: 'root',
        name: 'root',
        attribs: {},
...
```
I'm not sure what the purpose of the `_make` and `reduce` functions are, but this change returns an array for the case above.