### PR TITLE
Add nested wrapping test

### DIFF
--- a/test/api/manipulation.js
+++ b/test/api/manipulation.js
@@ -47,6 +47,16 @@ describe('$(...)', function() {
       expect($('p')).to.have.length(0);
     });
 
+    it('(html) : wraps with nested elements', function() {
+      var $orangeFruits = $('<div class="orange-fruits"><div class="and-stuff"></div></div>');
+      $('.orange').wrap($orangeFruits);
+
+      expect($fruits.children().eq(1).hasClass('orange-fruits')).to.be.ok();
+      expect($('.orange-fruits').children().eq(0).hasClass('and-stuff')).to.be.ok();
+      expect($fruits.children().eq(2).hasClass('pear')).to.be.ok();
+      expect($('.orange-fruits').children()).to.have.length(1);
+    });
+
     it('(selector) : wraps the content with a copy of the first matched element', function() {
       var $oranges;
 


### PR DESCRIPTION
Not sure if this is correct but I think cheerio is still missing the nested wrapping feature from jQuery:

```
<html>
<body>
<img src="image.gif">
</body>
</html>

$('img').wrap('<div class="figure-wrapper"><figure></figure></div>');
=>

<html>
<body>
<div class="figure-wrapper">
  <figure>
    <img src="image.gif">
  </figure>
</div>
</body>
</html>