### PR TITLE
V1 release notes 2

### DIFF
--- a/History.md
+++ b/History.md
@@ -31,7 +31,12 @@ With this release of Cheerio, strings provided to the `load` method are
 interpreted as documents. The same example will produce a `$` function that
 operates on a full HTML document, including an `<html>` document element with
 nested `<head>` and `<body>` tags. This mimics web browser behavior much more
-closely, but may require alterations to existing code.
+closely, but may require alterations to existing code. To work with fragments,
+first load an empty document, and then use the resulting `$` to parse the
+input:
+
+    var $ = cheerio.load('');
+    var $fragment = $('<p>Hello, <b>world</b>!</p>');
 
  * Document advanced usage with htmlparser2 (Mike Pennisi)
  * Correct errors in Readme.md (Mike Pennisi)

--- a/History.md
+++ b/History.md
@@ -1,3 +1,65 @@
+1.0.0-rc.2 / 2017-06-10
+==================
+
+This release changes Cheerio's default parser to [the Parse5 HTML
+parser](https://github.com/inikulin/parse5). Parse5 is an excellent project
+that rigorously conforms to the HTML standard. It does not support XML, so
+Cheerio continues to use [`htmlparser2`](https://github.com/fb55/htmlparser2/)
+when working with XML documents.
+
+This switch addresses many long-standing bugs in Cheerio, but some users may
+experience slower behavior in performance-critical applications. In addition,
+`htmlparser2` is more forgiving of invalid markup which can be useful when
+input sourced from a third party and cannot be corrected. For these reasons,
+the `load` method also accepts a DOM structure as produced by the `htmlparser2`
+library. See the project's "readme" file for more details on this usage
+pattern.
+
+### Migrating from version 0.x
+
+`cheerio.load( html[, options ] )`` This method continues to produce
+jQuery-like functions, bound to the provided input text. In prior releases, the
+provided string was interpreted as a document fragment. This meant that in a
+statement such as:
+
+    var $ = cheerio.load('<p>Hello, <b>world</b>!</p>');
+
+The resulting `$` function would operate on a tree whose root element was a
+paragraph tag.
+
+With this release of Cheerio, strings provided to the `load` method are
+interpreted as documents. The same example will produce a `$` function that
+operates on a full HTML document, including an `<html>` document element with
+nested `<head>` and `<body>` tags. This mimics web browser behavior much more
+closely, but may require alterations to existing code.
+
+ * Document advanced usage with htmlparser2 (Mike Pennisi)
+ * Correct errors in Readme.md (Mike Pennisi)
+ * Improve release process (Mike Pennisi)
+ * 1.0.0-rc.1 (Mike Pennisi)
+ * Update unit test (Mike Pennisi)
+ * Normalize code style (Mike Pennisi)
+ * Added support for nested wrapping. (Diane Looney)
+ * Add nested wrapping test (Toni Helenius)
+ * Added $.merge following the specification at https://api.jquery.com/jquery.merge/ Added test cases for $.merge (Diane Looney)
+ * Clarify project scope in README file (Mike Pennisi)
+ * .text() ignores script and style tags (#1018) (Haleem Assal)
+ * Test suite housekeeping (#1016) (DianeLooney)
+ * experiment with a job board (Matthew)
+ * Change options format (inikulin)
+ * Add test for #997 (inikulin)
+ * Update .filter function docs. (Konstantin)
+ * Standardise readme on ES6 variable declarations (Dekatron)
+ * Use documents via $.load (inikulin)
+ * Use parse5 as a default parser (closes #863) (inikulin)
+ * Fix small typo in Readme (Darren Scerri)
+ * Report test failures in CI (Mike Pennisi)
+ * serializeArray should not ignore input elements without value attributes (Ricardo Gladwell)
+ * Disallow variable shadowing (Mike Pennisi)
+ * Update hasClass method (sufisaid)
+ * Added MIT License fixes #902 (Prasanth Vaaheeswaran)
+ * chore(package): update dependencies (greenkeeper[bot])
+ * Use modular lodash package (#913) (Billy Janitsch)
 
 0.22.0 / 2016-08-23
 ==================

--- a/Readme.md
+++ b/Readme.md
@@ -908,7 +908,7 @@ Checks to see if the `contained` DOM element is a descendant of the `container` 
 Parses a string into an array of DOM nodes. The `context` argument has no meaning for Cheerio, but it is maintained for API compatability.
 
 #### $.load( html[, options ] )
-Create a jQuery-like function, bound to a document created from the provided markup. Note that similar to web browser contexts, this operation may introduce `<html>`, `<head>`, and `<body>` elements. See the previous section titled "Loading" for usage information.
+Create a querying function, bound to a document created from the provided markup. Note that similar to web browser contexts, this operation may introduce `<html>`, `<head>`, and `<body>` elements. See the previous section titled "Loading" for usage information.
 
 ### Plugins
 

--- a/Readme.md
+++ b/Readme.md
@@ -121,6 +121,23 @@ These parsing options are taken directly from [htmlparser2](https://github.com/f
 For a full list of options and their effects, see [this](https://github.com/fb55/DomHandler) and
 [htmlparser2's options](https://github.com/fb55/htmlparser2/wiki/Parser-options).
 
+Some users may wish to parse markup with the `htmlparser2` library, and
+traverse/manipulate the resulting structure with Cheerio. This may be the case
+for those upgrading from pre-1.0 releases of Cheerio (which relied on
+`htmlparser2`), for those dealing with invalid markup (because `htmlparser2` is
+more forgiving), or for those operating in performance-critical situations
+(because `htmlparser2` may be faster in some cases).
+
+To support these cases, `load` also accepts a `htmlparser2`-compatible data
+structure as its first argument. Users may install `htmlparser2`, use it to
+parse input, and pass the result to `load`:
+
+```js
+const htmlParser2 = require('htmlparser2');
+const dom = { /* See htmlParser2's documentation for usage instructions. */ };
+const $ = cheerio.load(dom);
+```
+
 ### Selectors
 
 Cheerio's selector implementation is nearly identical to jQuery's, so the API is very similar.

--- a/Readme.md
+++ b/Readme.md
@@ -127,8 +127,9 @@ for those upgrading from pre-1.0 releases of Cheerio (which relied on
 `htmlparser2`), for those dealing with invalid markup (because `htmlparser2` is
 more forgiving), or for those operating in performance-critical situations
 (because `htmlparser2` may be faster in some cases). Note that "more forgiving"
-is not necessarily an advantage; `htmlparser2` will recover from some invalid
-markup differently than web browsers, and this may or may not be helpful.
+means `htmlparser2` has error-correcting mechanisms that aren't always a match
+for the standards observed by web browsers. This behavior may be useful when
+parsing non-HTML content.
 
 To support these cases, `load` also accepts a `htmlparser2`-compatible data
 structure as its first argument. Users may install `htmlparser2`, use it to
@@ -136,7 +137,7 @@ parse input, and pass the result to `load`:
 
 ```js
 // Usage as of htmlparser2 version 3:
-const htmlParser2 = require('htmlparser2');
+const htmlparser2 = require('htmlparser2');
 const dom = htmlparser2.parseDOM(document, options);
 
 const $ = cheerio.load(dom);

--- a/Readme.md
+++ b/Readme.md
@@ -126,15 +126,19 @@ traverse/manipulate the resulting structure with Cheerio. This may be the case
 for those upgrading from pre-1.0 releases of Cheerio (which relied on
 `htmlparser2`), for those dealing with invalid markup (because `htmlparser2` is
 more forgiving), or for those operating in performance-critical situations
-(because `htmlparser2` may be faster in some cases).
+(because `htmlparser2` may be faster in some cases). Note that "more forgiving"
+is not necessarily an advantage; `htmlparser2` will recover from some invalid
+markup differently than web browsers, and this may or may not be helpful.
 
 To support these cases, `load` also accepts a `htmlparser2`-compatible data
 structure as its first argument. Users may install `htmlparser2`, use it to
 parse input, and pass the result to `load`:
 
 ```js
+// Usage as of htmlparser2 version 3:
 const htmlParser2 = require('htmlparser2');
-const dom = { /* See htmlParser2's documentation for usage instructions. */ };
+const dom = htmlparser2.parseDOM(document, options);
+
 const $ = cheerio.load(dom);
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -96,26 +96,26 @@ const $ = require('cheerio');
 $('li', 'ul', '<ul id="fruits">...</ul>');
 ```
 
-You can also pass an extra object to `.load()` if you need to modify any
-of the default parsing options:
+If you need to modify parsing options for XML input, you may pass an extra
+object to `.load()`:
 
 ```js
 const $ = cheerio.load('<ul id="fruits">...</ul>', {
-    normalizeWhitespace: true,
-    xmlMode: true
+    xml: {
+      normalizeWhitespace: true,
+    }
 });
 ```
 
-These parsing options are taken directly from [htmlparser2](https://github.com/fb55/htmlparser2/wiki/Parser-options), therefore any options that can be used in `htmlparser2` are valid in cheerio as well. The default options are:
+The options in the `xml` object are taken directly from [htmlparser2](https://github.com/fb55/htmlparser2/wiki/Parser-options), therefore any options that can be used in `htmlparser2` are valid in cheerio as well. The default options are:
 
 ```js
 {
     withDomLvl1: true,
     normalizeWhitespace: false,
-    xmlMode: false,
+    xmlMode: true,
     decodeEntities: true
 }
-
 ```
 
 For a full list of options and their effects, see [this](https://github.com/fb55/DomHandler) and

--- a/Readme.md
+++ b/Readme.md
@@ -30,7 +30,7 @@ $('h2.title').text('Hello there!')
 $('h2').addClass('welcome')
 
 $.html()
-//=> <h2 class="title welcome">Hello there!</h2>
+//=> <html><head></head><body><h2 class="title welcome">Hello there!</h2></body></html>
 ```
 
 ## Installation
@@ -106,15 +106,14 @@ const $ = cheerio.load('<ul id="fruits">...</ul>', {
 });
 ```
 
-These parsing options are taken directly from [htmlparser2](https://github.com/fb55/htmlparser2/wiki/Parser-options), therefore any options that can be used in `htmlparser2` are valid in cheerio as well. If any of these options is set to non-default value cheerio will implicitly use `htmlparser2` as an underlying parser. In addition, you can use `useHtmlParser2` option to force cheerio use `htmlparser2` instead of `parse5`. The default options are:
+These parsing options are taken directly from [htmlparser2](https://github.com/fb55/htmlparser2/wiki/Parser-options), therefore any options that can be used in `htmlparser2` are valid in cheerio as well. The default options are:
 
 ```js
 {
     withDomLvl1: true,
     normalizeWhitespace: false,
     xmlMode: false,
-    decodeEntities: true,
-    useHtmlParser2: false
+    decodeEntities: true
 }
 
 ```
@@ -888,7 +887,7 @@ Checks to see if the `contained` DOM element is a descendant of the `container` 
 Parses a string into an array of DOM nodes. The `context` argument has no meaning for Cheerio, but it is maintained for API compatability.
 
 #### $.load( html[, options ] )
-Load in the HTML. (See the previous section titled "Loading" for more information.)
+Create a jQuery-like function, bound to a document created from the provided markup. Note that similar to web browser contexts, this operation may introduce `<html>`, `<head>`, and `<body>` elements. See the previous section titled "Loading" for usage information.
 
 ### Plugins
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -7,7 +7,7 @@ var assign = require('lodash/assign');
 exports.default = {
   withDomLvl1: true,
   normalizeWhitespace: false,
-  xmlMode: false,
+  xml: false,
   decodeEntities: true
 };
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -37,7 +37,7 @@ exports.evaluate = function(content, options, isDocument) {
     content = content.toString();
 
   if (typeof content === 'string') {
-    var useHtmlParser2 = options.xmlMode || options.useHtmlParser2;
+    var useHtmlParser2 = options.xmlMode || options._useHtmlParser2;
 
     dom = useHtmlParser2 ? htmlparser.parseDOM(content, options) : parseWithParse5(content, isDocument);
   } else {

--- a/lib/static.js
+++ b/lib/static.js
@@ -102,7 +102,7 @@ exports.html = function(dom, options) {
  */
 
 exports.xml = function(dom) {
-  var options = _.defaults({xmlMode: true}, this._options);
+  var options = _.defaults({xml: true}, this._options);
 
   return render(this, dom, options);
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -62,7 +62,7 @@ exports.domEach = function(cheerio, fn) {
  * @argument {Object} options - The parsing/rendering options
  */
 exports.cloneDom = function(dom, options) {
-  options = assign({}, options, { useHtmlParser2: true });
+  options = assign({}, options, { _useHtmlParser2: true });
 
   return parse(render(dom, options), options, false).children;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cheerio",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "description": "Tiny, fast, and elegant implementation of core jQuery designed specifically for the server",
   "author": "Matt Mueller <mattmuelle@gmail.com> (mat.io)",
   "license": "MIT",

--- a/test/api/traversing.js
+++ b/test/api/traversing.js
@@ -52,8 +52,8 @@ describe('$(...)', function() {
       expect(q('foo').find('> bar')).to.have.length(1);
     });
 
-    it('should query case-sensitively when in xmlMode', function() {
-      var q = cheerio.load('<caseSenSitive allTheWay>', {xmlMode: true});
+    it('should query case-sensitively when in xml', function() {
+      var q = cheerio.load('<caseSenSitive allTheWay>', {xml: true});
       expect(q('caseSenSitive')).to.have.length(1);
       expect(q('[allTheWay]')).to.have.length(1);
       expect(q('casesensitive')).to.have.length(0);

--- a/test/api/traversing.js
+++ b/test/api/traversing.js
@@ -52,7 +52,7 @@ describe('$(...)', function() {
       expect(q('foo').find('> bar')).to.have.length(1);
     });
 
-    it('should query case-sensitively when in xml', function() {
+    it('should query case-sensitively when in xml mode', function() {
       var q = cheerio.load('<caseSenSitive allTheWay>', {xml: true});
       expect(q('caseSenSitive')).to.have.length(1);
       expect(q('[allTheWay]')).to.have.length(1);

--- a/test/api/utils.js
+++ b/test/api/utils.js
@@ -95,7 +95,7 @@ describe('cheerio', function() {
 
     // TODO:
     // it('(html) : should handle xml tag option', function() {
-    //   var $html = $.load('<body><script>oh hai</script></body>', { xmlMode : true });
+    //   var $html = $.load('<body><script>oh hai</script></body>', { xml : true });
     //   console.log($html('script')[0].type);
     //   expect($html('script')[0].type).to.be('tag');
     // });

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -355,25 +355,25 @@ describe('cheerio', function() {
       expect(q('ul')).to.have.length(3);
     });
 
-    it('should render xml in html() when options.xmlMode = true', function() {
+    it('should render xml in html() when options.xml = true', function() {
       var str = '<MixedCaseTag UPPERCASEATTRIBUTE=""></MixedCaseTag>',
           expected = '<MixedCaseTag UPPERCASEATTRIBUTE=""/>',
-          dom = $.load(str, {xmlMode: true});
+          dom = $.load(str, {xml: true});
 
       expect(dom('MixedCaseTag').get(0).tagName).to.equal('MixedCaseTag');
       expect(dom.html()).to.be(expected);
     });
 
-    it('should render xml in html() when options.xmlMode = true passed to html()', function() {
+    it('should render xml in html() when options.xml = true passed to html()', function() {
       var str = '<MixedCaseTag UPPERCASEATTRIBUTE=""></MixedCaseTag>',
-          // since parsing done without xmlMode flag, all tags converted to lowercase
+          // since parsing done without xml flag, all tags converted to lowercase
           expectedXml = '<html><head/><body><mixedcasetag uppercaseattribute=""/></body></html>',
           expectedNoXml = '<html><head></head><body><mixedcasetag uppercaseattribute=""></mixedcasetag></body></html>',
           dom = $.load(str);
 
       expect(dom('MixedCaseTag').get(0).tagName).to.equal('mixedcasetag');
       expect(dom.html()).to.be(expectedNoXml);
-      expect(dom.html({xmlMode: true})).to.be(expectedXml);
+      expect(dom.html({xml: true})).to.be(expectedXml);
     });
 
     it('should respect options on the element level', function() {

--- a/test/xml.js
+++ b/test/xml.js
@@ -50,7 +50,7 @@ describe('render', function() {
 
     it('should maintain the parsing options of distinct contexts independently', function() {
       var str = '<g><someElem someAttribute="something">hello</someElem></g>';
-      var $x = cheerio.load('', { xmlMode: false });
+      var $x = cheerio.load('', { xml: false });
 
       expect($x(str).html()).to.equal('<someelem someattribute="something">hello</someelem>');
     });


### PR DESCRIPTION
@fb55 @inikulin here's a second attempt, hopefully more in-line with reality. Note the changes to the "pre-release" script; I thought this was the best way to promote safety while allowing us to make manual modifications to the project's release history document.

Also, because the lack of documentation has already caused confusion for early adopters, I'm recommending we publish this as a new release candidate. Following that, I'd like to update the `Readme.md` file in `master` to let folks know that we're currently vetting a release candidate, and pointing them to the `v1.0.0` branch.