### PR TITLE
Inline runnable examples with RunKit

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,7 +163,7 @@ are valid in cheerio as well. The default options are:</p>
 <span class="nx">$</span><span class="p">(</span><span class="s1">'ul .pear'</span><span class="p">).</span><span class="nx">attr</span><span class="p">(</span><span class="s1">'class'</span><span class="p">)</span>
 <span class="c1">//=&gt; pear</span>
 
-<span class="nx">$</span><span class="p">(</span><span class="s1">'li[class=orange]'</span><span class="p">).</span><span class="nx">html</span><span class="p">()</span>
+<span class="nx">$</span><span class="p">(</span><span class="s1">'li[class=orange]'</span><span class="p">).</span><span class="nx">toString</span><span class="p">()</span>
 <span class="c1">//=&gt; &lt;li class = "orange"&gt;Orange&lt;/li&gt;</span>
 </pre></div>
 
@@ -180,7 +180,7 @@ are valid in cheerio as well. The default options are:</p>
 <div class="highlight"><pre><span class="nx">$</span><span class="p">(</span><span class="s1">'ul'</span><span class="p">).</span><span class="nx">attr</span><span class="p">(</span><span class="s1">'id'</span><span class="p">)</span>
 <span class="c1">//=&gt; fruits</span>
 
-<span class="nx">$</span><span class="p">(</span><span class="s1">'.apple'</span><span class="p">).</span><span class="nx">attr</span><span class="p">(</span><span class="s1">'id'</span><span class="p">,</span> <span class="s1">'favorite'</span><span class="p">).</span><span class="nx">html</span><span class="p">()</span>
+<span class="nx">$</span><span class="p">(</span><span class="s1">'.apple'</span><span class="p">).</span><span class="nx">attr</span><span class="p">(</span><span class="s1">'id'</span><span class="p">,</span> <span class="s1">'favorite'</span><span class="p">).</span><span class="nx">toString</span><span class="p">()</span>
 <span class="c1">//=&gt; &lt;li class = "apple" id = "favorite"&gt;Apple&lt;/li&gt;</span>
 </pre></div>
 
@@ -193,7 +193,7 @@ are valid in cheerio as well. The default options are:</p>
 
 <p>Method for removing attributes by <code>name</code>.</p>
 
-<div class="highlight"><pre><span class="nx">$</span><span class="p">(</span><span class="s1">'.pear'</span><span class="p">).</span><span class="nx">removeAttr</span><span class="p">(</span><span class="s1">'class'</span><span class="p">).</span><span class="nx">html</span><span class="p">()</span>
+<div class="highlight"><pre><span class="nx">$</span><span class="p">(</span><span class="s1">'.pear'</span><span class="p">).</span><span class="nx">removeAttr</span><span class="p">(</span><span class="s1">'class'</span><span class="p">).</span><span class="nx">toString</span><span class="p">()</span>
 <span class="c1">//=&gt; &lt;li&gt;Pear&lt;/li&gt;</span>
 </pre></div>
 
@@ -217,10 +217,10 @@ are valid in cheerio as well. The default options are:</p>
 
 <p>Adds class(es) to all of the matched elements. Also accepts a <code>function</code> like jQuery.</p>
 
-<div class="highlight"><pre><span class="nx">$</span><span class="p">(</span><span class="s1">'.pear'</span><span class="p">).</span><span class="nx">addClass</span><span class="p">(</span><span class="s1">'fruit'</span><span class="p">).</span><span class="nx">html</span><span class="p">()</span>
+<div class="highlight"><pre><span class="nx">$</span><span class="p">(</span><span class="s1">'.pear'</span><span class="p">).</span><span class="nx">addClass</span><span class="p">(</span><span class="s1">'fruit'</span><span class="p">).</span><span class="nx">toString</span><span class="p">()</span>
 <span class="c1">//=&gt; &lt;li class = "pear fruit"&gt;Pear&lt;/li&gt;</span>
 
-<span class="nx">$</span><span class="p">(</span><span class="s1">'.apple'</span><span class="p">).</span><span class="nx">addClass</span><span class="p">(</span><span class="s1">'fruit red'</span><span class="p">).</span><span class="nx">html</span><span class="p">()</span>
+<span class="nx">$</span><span class="p">(</span><span class="s1">'.apple'</span><span class="p">).</span><span class="nx">addClass</span><span class="p">(</span><span class="s1">'fruit red'</span><span class="p">).</span><span class="nx">toString</span><span class="p">()</span>
 <span class="c1">//=&gt; &lt;li class = "apple fruit red"&gt;Apple&lt;/li&gt;</span>
 </pre></div>
 
@@ -233,10 +233,10 @@ are valid in cheerio as well. The default options are:</p>
 
 <p>Removes one or more space-separated classes from the selected elements. If no <code>className</code> is defined, all classes will be removed. Also accepts a <code>function</code> like jQuery.</p>
 
-<div class="highlight"><pre><span class="nx">$</span><span class="p">(</span><span class="s1">'.pear'</span><span class="p">).</span><span class="nx">removeClass</span><span class="p">(</span><span class="s1">'pear'</span><span class="p">).</span><span class="nx">html</span><span class="p">()</span>
+<div class="highlight"><pre><span class="nx">$</span><span class="p">(</span><span class="s1">'.pear'</span><span class="p">).</span><span class="nx">removeClass</span><span class="p">(</span><span class="s1">'pear'</span><span class="p">).</span><span class="nx">toString</span><span class="p">()</span>
 <span class="c1">//=&gt; &lt;li class = ""&gt;Pear&lt;/li&gt;</span>
 
-<span class="nx">$</span><span class="p">(</span><span class="s1">'.apple'</span><span class="p">).</span><span class="nx">addClass</span><span class="p">(</span><span class="s1">'red'</span><span class="p">).</span><span class="nx">removeClass</span><span class="p">().</span><span class="nx">html</span><span class="p">()</span>
+<span class="nx">$</span><span class="p">(</span><span class="s1">'.apple'</span><span class="p">).</span><span class="nx">addClass</span><span class="p">(</span><span class="s1">'red'</span><span class="p">).</span><span class="nx">removeClass</span><span class="p">().</span><span class="nx">toString</span><span class="p">()</span>
 <span class="c1">//=&gt; &lt;li class = ""&gt;Apple&lt;/li&gt;</span>
 </pre></div>
 

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
 
 <p>Teach your server HTML.</p>
 
-<div class="highlight"><pre><span class="kd">var</span> <span class="nx">cheerio</span> <span class="o">=</span> <span class="nx">require</span><span class="p">(</span><span class="s1">'cheerio'</span><span class="p">),</span>
+<div class="highlight"><pre data-runkit-embed="no-premble"><span class="kd">var</span> <span class="nx">cheerio</span> <span class="o">=</span> <span class="nx">require</span><span class="p">(</span><span class="s1">'cheerio'</span><span class="p">),</span>
     <span class="nx">$</span> <span class="o">=</span> <span class="nx">cheerio</span><span class="p">.</span><span class="nx">load</span><span class="p">(</span><span class="s1">'&lt;h2 class = "title"&gt;Hello world&lt;/h2&gt;'</span><span class="p">);</span>
 
 <span class="nx">$</span><span class="p">(</span><span class="s1">'h2.title'</span><span class="p">).</span><span class="nx">text</span><span class="p">(</span><span class="s1">'Hello there!'</span><span class="p">);</span>
@@ -91,7 +91,7 @@ The goal of JSDOM is to provide an identical DOM environment as what we see in t
 <h3>
 <a name="markup-example-well-be-using" class="anchor" href="#markup-example-well-be-using"><span class="octicon octicon-link"></span></a>Markup example we'll be using:</h3>
 
-<div class="highlight"><pre><span class="nt">&lt;ul</span> <span class="na">id=</span><span class="s">"fruits"</span><span class="nt">&gt;</span>
+<div class="highlight"><pre data-runkit-embed="disable" id="htmlExample"><span class="nt">&lt;ul</span> <span class="na">id=</span><span class="s">"fruits"</span><span class="nt">&gt;</span>
   <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"apple"</span><span class="nt">&gt;</span>Apple<span class="nt">&lt;/li&gt;</span>
   <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"orange"</span><span class="nt">&gt;</span>Orange<span class="nt">&lt;/li&gt;</span>
   <span class="nt">&lt;li</span> <span class="na">class=</span><span class="s">"pear"</span><span class="nt">&gt;</span>Pear<span class="nt">&lt;/li&gt;</span>
@@ -107,26 +107,26 @@ The goal of JSDOM is to provide an identical DOM environment as what we see in t
 
 <p>This is the <em>preferred</em> method:</p>
 
-<div class="highlight"><pre><span class="kd">var</span> <span class="nx">cheerio</span> <span class="o">=</span> <span class="nx">require</span><span class="p">(</span><span class="s1">'cheerio'</span><span class="p">),</span>
+<div class="highlight"><pre data-runkit-embed="disable"><span class="kd">var</span> <span class="nx">cheerio</span> <span class="o">=</span> <span class="nx">require</span><span class="p">(</span><span class="s1">'cheerio'</span><span class="p">),</span>
     <span class="nx">$</span> <span class="o">=</span> <span class="nx">cheerio</span><span class="p">.</span><span class="nx">load</span><span class="p">(</span><span class="s1">'&lt;ul id = "fruits"&gt;...&lt;/ul&gt;'</span><span class="p">);</span>
 </pre></div>
 
 <p>Optionally, you can also load in the HTML by passing the string as the context:</p>
 
-<div class="highlight"><pre><span class="nx">$</span> <span class="o">=</span> <span class="nx">require</span><span class="p">(</span><span class="s1">'cheerio'</span><span class="p">);</span>
+<div class="highlight"><pre data-runkit-embed="disable"><span class="nx">$</span> <span class="o">=</span> <span class="nx">require</span><span class="p">(</span><span class="s1">'cheerio'</span><span class="p">);</span>
 <span class="nx">$</span><span class="p">(</span><span class="s1">'ul'</span><span class="p">,</span> <span class="s1">'&lt;ul id = "fruits"&gt;...&lt;/ul&gt;'</span><span class="p">);</span>
 </pre></div>
 
 <p>Or as the root:</p>
 
-<div class="highlight"><pre><span class="nx">$</span> <span class="o">=</span> <span class="nx">require</span><span class="p">(</span><span class="s1">'cheerio'</span><span class="p">);</span>
+<div class="highlight"><pre data-runkit-embed="disable"><span class="nx">$</span> <span class="o">=</span> <span class="nx">require</span><span class="p">(</span><span class="s1">'cheerio'</span><span class="p">);</span>
 <span class="nx">$</span><span class="p">(</span><span class="s1">'li'</span><span class="p">,</span> <span class="s1">'ul'</span><span class="p">,</span> <span class="s1">'&lt;ul id = "fruits"&gt;...&lt;/ul&gt;'</span><span class="p">);</span>
 </pre></div>
 
 <p>You can also pass an extra object to <code>.load()</code> if you need to modify any
 of the default parsing options:</p>
 
-<div class="highlight"><pre><span class="nx">$</span> <span class="o">=</span> <span class="nx">cheerio</span><span class="p">.</span><span class="nx">load</span><span class="p">(</span><span class="s1">'&lt;ul id = "fruits"&gt;...&lt;/ul&gt;'</span><span class="p">,</span> <span class="p">{</span>
+<div class="highlight"><pre data-runkit-embed="disable"><span class="nx">$</span> <span class="o">=</span> <span class="nx">cheerio</span><span class="p">.</span><span class="nx">load</span><span class="p">(</span><span class="s1">'&lt;ul id = "fruits"&gt;...&lt;/ul&gt;'</span><span class="p">,</span> <span class="p">{</span>
     <span class="nx">ignoreWhitespace</span><span class="o">:</span> <span class="kc">true</span><span class="p">,</span>
     <span class="nx">xmlMode</span><span class="o">:</span> <span class="kc">true</span>
 <span class="p">});</span>
@@ -135,7 +135,7 @@ of the default parsing options:</p>
 <p>These parsing options are taken directly from htmlparser2, therefore any options that can be used in htmlparser2
 are valid in cheerio as well. The default options are:</p>
 
-<div class="highlight"><pre><span class="p">{</span>
+<div class="highlight"><pre data-runkit-embed="disable"><span class="p">{</span>
     <span class="nx">ignoreWhitespace</span><span class="o">:</span> <span class="kc">false</span><span class="p">,</span>
     <span class="nx">xmlMode</span><span class="o">:</span> <span class="kc">false</span><span class="p">,</span>
     <span class="nx">lowerCaseTags</span><span class="o">:</span> <span class="kc">false</span>
@@ -667,17 +667,62 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
         <p><small>Hosted on GitHub Pages &mdash; Theme by <a href="https://github.com/orderedlist">orderedlist</a></small></p>
       </footer>
     </div>
+
     <script src="javascripts/scale.fix.js"></script>
-              <script type="text/javascript">
-            var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
-            document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-          </script>
-          <script type="text/javascript">
-            try {
-              var pageTracker = _gat._getTracker("UA-10351690-10");
-            pageTracker._trackPageview();
-            } catch(err) {}
-          </script>
+    <script src = "https://embed.runkit.com" async defer></script>
+
+    <script type="text/javascript">
+      var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+      document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
+
+      try {
+        var pageTracker = _gat._getTracker("UA-10351690-10");
+      pageTracker._trackPageview();
+      } catch(err) {}
+
+      var htmlExample = document.getElementById("htmlExample").textContent.replace(/\n/g, "\\\n");
+      var runkitPreamble = "var cheerio = require('cheerio'),\
+                                $ = cheerio.load('" + htmlExample + "');";
+
+      var allJS = document.querySelectorAll(".highlight pre");
+
+      allJS.forEach(function(codeElement) {
+        var embedConfig = codeElement.dataset.runkitEmbed;
+
+        if (embedConfig === "disable")
+          return;
+
+        var code = codeElement.textContent;
+        var preamble = embedConfig === "no-premble" ? "" : runkitPreamble;
+
+        var runItButton = document.createElement("a");
+        runItButton.className = "run-it";
+        runItButton.innerText = "Run It";
+        codeElement.appendChild(runItButton);
+
+        runItButton.addEventListener("click", function(anEvent) {
+          if (!window.RunKit)
+            return;
+
+          var container = document.createElement("div");
+          var parent = codeElement.parentNode;
+
+          parent.insertBefore(container, codeElement);
+          parent.removeChild(codeElement);
+          codeElement.removeChild(runItButton);
+
+          RunKit.createNotebook({
+            element: container,
+            preamble: preamble,
+            source: code,
+            minHeight: "52px",
+            onLoad: function(notebook) {
+              notebook.evaluate();
+            }
+          });
+        }, false);
+      });
+    </script>
 
   </body>
 </html>

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -65,7 +65,7 @@ code, pre {
 
 pre {
   padding:8px 15px;
-  background: #f8f8f8;  
+  background: #f8f8f8;
   border-radius:5px;
   border:1px solid #e5e5e5;
   overflow-x: auto;
@@ -104,9 +104,9 @@ header {
 header ul {
   list-style:none;
   height:40px;
-  
+
   padding:0;
-  
+
   background: #eee;
   background: -moz-linear-gradient(top, #f8f8f8 0%, #dddddd 100%);
   background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#f8f8f8), color-stop(100%,#dddddd));
@@ -114,7 +114,7 @@ header ul {
   background: -o-linear-gradient(top, #f8f8f8 0%,#dddddd 100%);
   background: -ms-linear-gradient(top, #f8f8f8 0%,#dddddd 100%);
   background: linear-gradient(top, #f8f8f8 0%,#dddddd 100%);
-  
+
   border-radius:5px;
   border:1px solid #d2d2d2;
   box-shadow:inset #fff 0 1px 0, inset rgba(0,0,0,0.03) 0 -1px 0;
@@ -183,34 +183,50 @@ footer {
   bottom:50px;
 }
 
+div.highlight pre
+{
+  position: relative;
+}
+
+a.run-it
+{
+    position: absolute;
+    cursor: pointer;
+    right: .5em;
+    bottom:  .1em;
+    border: 0;
+    background: transparent;
+    color: rgba(49, 50, 137, 1.0);
+}
+
 @media print, screen and (max-width: 960px) {
-  
+
   div.wrapper {
     width:auto;
     margin:0;
   }
-  
+
   header, section, footer {
     float:none;
     position:static;
     width:auto;
   }
-  
+
   header {
     padding-right:320px;
   }
-  
+
   section {
     border:1px solid #e5e5e5;
     border-width:1px 0;
     padding:20px 0;
     margin:0 0 20px;
   }
-  
+
   header a small {
     display:inline;
   }
-  
+
   header ul {
     position:absolute;
     right:50px;
@@ -222,15 +238,15 @@ footer {
   body {
     word-wrap:break-word;
   }
-  
+
   header {
     padding:0;
   }
-  
+
   header ul, header p.view {
     position:static;
   }
-  
+
   pre, code {
     word-wrap:normal;
   }
@@ -240,7 +256,7 @@ footer {
   body {
     padding:15px;
   }
-  
+
   header ul {
     display:none;
   }


### PR DESCRIPTION
I'd like to propose using RunKit embeds for the examples in Cheerio's documentation. The way I've implemented it, the existing examples remain as is, but also have a "run it" button on the bottom right. When clicked, a RunKit embed is swapped in and the example becomes runnable and editable:

![out](https://user-images.githubusercontent.com/90050/27936885-151c2bd6-6268-11e7-963b-e936ad18539e.gif)

Since all the examples are runnable inline, it allows users to stay on the main documentation page and see the documentation, etc which makes it easier to understand the API as you play with it.

The results are also presented with our nice object viewers. In the above example we're rendering the HTML, but you can also switch to see the raw string. If a non-primitive is returned we show the object explorer (very similar to what you'd find in Chrome). 

The basic goal we're trying to accomplish is to make code immediately usable in docs, to shorten the time it takes to get familiar with a library. Lodash has been using RunKit on their documentation for about a year now (https://lodash.com/docs/), and Express recently incorporated RunKit into their Getting Started example as well. 
https://expressjs.com/en/starter/hello-world.html 

Would love to see the same here, and I am happy to make any changes as necessary.