### PR TITLE
Prevent data-uri splitting at css parsing

### DIFF
--- a/lib/api/css.js
+++ b/lib/api/css.js
@@ -110,7 +110,7 @@ function parse(styles) {
   if (!styles) return {};
 
   return styles
-    .split(';')
+    .split(/;(?!base64)/)
     .reduce(function(obj, str){
       var n = str.indexOf(':');
       // skip if there is no :, or if it is the first/last character

--- a/test/api/css.js
+++ b/test/api/css.js
@@ -32,6 +32,11 @@ describe('$(...)', function() {
       expect(el.css('background-image')).to.equal('url(http://example.com/img.png)');
     });
 
+    it('(prop): should not mangle embedded data-uris', function() {
+      var el = cheerio('<li style="background-image:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAC4AAA);">');
+      expect(el.css('background-image')).to.equal('url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAC4AAA)');
+    });
+
     it('(prop): should ignore blank properties', function() {
       var el = cheerio('<li style=":#ccc;color:#aaa;">');
       expect(el.css()).to.eql({color:'#aaa'});


### PR DESCRIPTION
This fix prevent `url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAC4AAA)`
properties to be split in two properties, due to the semi-colon it contains.

It does not introduce any regression.
It may slow a bit the process as it relies on Regexp now.

It does not handle every data-uri types.
As of RFC2397[1] and RFC2396[2], other fields such as `mediatype` may
contain semi-colon.

It is thus still not perfect, but fix at least some cases.

[1] https://tools.ietf.org/html/rfc2397
[2] https://tools.ietf.org/html/rfc2396