### PR TITLE
Ensure text nodes expose the DOM level 1 API

### DIFF
--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -412,7 +412,7 @@ exports.text = function(str) {
     // Function support
     var self = this;
     return domEach(this, function(i, el) {
-      return exports.text.call(self, str.call(el, i, $.text([el])));
+      return exports.text.call(self._make(el), str.call(el, i, $.text([el])));
     });
   }
 

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -416,22 +416,18 @@ exports.text = function(str) {
     });
   }
 
+  var opts = this.options;
+
   // Append text node to each selected elements
   domEach(this, function(i, el) {
     _.forEach(el.children, function(child) {
       child.next = child.prev = child.parent = null;
     });
 
-    var elem = {
-      data: '' + str,
-      type: 'text',
-      parent: el,
-      prev: null,
-      next: null,
-      children: []
-    };
+    var textNode =  evaluate(' ', opts)[0];
+    textNode.data = str;
 
-    updateDOM(elem, el);
+    updateDOM(textNode, el);
   });
 
   return this;

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -410,9 +410,9 @@ exports.text = function(str) {
     return $.text(this);
   } else if (typeof str === 'function') {
     // Function support
+    var self = this;
     return domEach(this, function(i, el) {
-      var $el = [el];
-      return exports.text.call($el, str.call(el, i, $.text($el)));
+      return exports.text.call(self, str.call(el, i, $.text([el])));
     });
   }
 

--- a/test/api/manipulation.js
+++ b/test/api/manipulation.js
@@ -1419,10 +1419,22 @@ describe('$(...)', function() {
       $('li').text('Fruits');
       var tested = 0;
       $('li').each(function(){
-        expect(this.childNodes[0].parent).to.equal(this);
+        expect(this.childNodes[0].parentNode).to.equal(this);
         tested++;
       });
       expect(tested).to.equal(3);
+    });
+
+    it('(text) : should create a Node with the DOM level 1 API', function() {
+      var $apple = $('.apple');
+      var textNode;
+
+      $apple.text('anything');
+      textNode = $apple[0].childNodes[0];
+
+      expect(textNode.parentNode).to.be($apple[0]);
+      expect(textNode.nodeType).to.be(3);
+      expect(textNode.data).to.be('anything');
     });
 
     it('should allow functions as arguments', function() {

--- a/test/api/manipulation.js
+++ b/test/api/manipulation.js
@@ -1446,6 +1446,15 @@ describe('$(...)', function() {
       expect($('.apple')[0].childNodes[0].data).to.equal('whatever mate');
     });
 
+    it('should allow functions as arguments for multiple elements', function() {
+      $('li').text(function(idx) {
+        return 'text' + idx;
+      });
+      $('li').each(function(idx) {
+        expect(this.childNodes[0].data).to.equal('text' + idx);
+      });
+    });
+
     it('should decode special chars', function() {
       var text = $('<p>M&amp;M</p>').text();
       expect(text).to.equal('M&M');


### PR DESCRIPTION
Rebased version of #588. We can still optimise performance later on, this works for now.