### PR TITLE
Do not lint files excluded from version control

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ REPORTER = dot
 XYZ = node_modules/.bin/xyz --message 'Release X.Y.Z' --tag X.Y.Z --repo git@github.com:cheeriojs/cheerio.git --script scripts/prepublish
 
 lint:
-	@./node_modules/.bin/eslint .
+	@./node_modules/.bin/eslint --ignore-path .gitignore .
 
 test: lint
 	@./node_modules/.bin/mocha --recursive --reporter $(REPORTER)


### PR DESCRIPTION
This includes code coverage reports as generated by the command `make
test-cov`.