### PR TITLE
Fix for issue #1175 - Update lodash for DoS/RCE vulnerability in lodash@4.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dom-serializer": "~0.1.0",
     "entities": "~1.1.1",
     "htmlparser2": "^3.9.1",
-    "lodash": "^4.15.0",
+    "lodash": "^4.17.5",
     "parse5": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
DoS/RCE vulnerability in lodash@4.15.0

After change, scanning the repo via Snyk did not reflect any issues. Test suite ran showing 598 passing tests with 1 test pending.