### PR TITLE
Improve variable names

### DIFF
--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -3,7 +3,7 @@
  *
  * @module attributes
  */
-var $ = require('../static'),
+var text = require('../static').text,
     utils = require('../utils'),
     isTag = utils.isTag,
     domEach = utils.domEach,
@@ -48,7 +48,7 @@ var getAttr = function(elem, name) {
 
   // Mimic the DOM and return text content as value for `option's`
   if (elem.name === 'option' && name === 'value') {
-    return $.text(elem.children);
+    return text(elem.children);
   }
 
   // Mimic DOM with default value for radios/checkboxes

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -4,7 +4,8 @@
  * @module manipulation
  */
 var parse = require('../parse'),
-    $ = require('../static'),
+    html = require('../static').html,
+    text = require('../static').text,
     updateDOM = parse.update,
     evaluate = parse.evaluate,
     utils = require('../utils'),
@@ -53,7 +54,7 @@ var _insert = function(concatenator) {
       var dom, domSrc;
 
       if (typeof elems[0] === 'function') {
-        domSrc = elems[0].call(el, i, $.html(el.children));
+        domSrc = elems[0].call(el, i, html(el.children));
       } else {
         domSrc = elems;
       }
@@ -366,7 +367,7 @@ exports.after = function() {
     if (index < 0) return;
 
     if (typeof elems[0] === 'function') {
-      domSrc = elems[0].call(el, i, $.html(el.children));
+      domSrc = elems[0].call(el, i, html(el.children));
     } else {
       domSrc = elems;
     }
@@ -465,7 +466,7 @@ exports.before = function() {
     if (index < 0) return;
 
     if (typeof elems[0] === 'function') {
-      domSrc = elems[0].call(el, i, $.html(el.children));
+      domSrc = elems[0].call(el, i, html(el.children));
     } else {
       domSrc = elems;
     }
@@ -666,7 +667,7 @@ exports.empty = function() {
 exports.html = function(str) {
   if (str === undefined) {
     if (!this[0] || !this[0].children) return null;
-    return $.html(this[0].children, this.options);
+    return html(this[0].children, this.options);
   }
 
   var opts = this.options;
@@ -687,7 +688,7 @@ exports.html = function(str) {
 };
 
 exports.toString = function() {
-  return $.html(this, this.options);
+  return html(this, this.options);
 };
 
 /**
@@ -712,12 +713,12 @@ exports.toString = function() {
 exports.text = function(str) {
   // If `str` is undefined, act as a "getter"
   if (str === undefined) {
-    return $.text(this);
+    return text(this);
   } else if (typeof str === 'function') {
     // Function support
     var self = this;
     return domEach(this, function(i, el) {
-      return exports.text.call(self._make(el), str.call(el, i, $.text([el])));
+      return exports.text.call(self._make(el), str.call(el, i, text([el])));
     });
   }
 

--- a/test/api/utils.js
+++ b/test/api/utils.js
@@ -85,38 +85,38 @@ describe('cheerio', function() {
 
   describe('.load', function() {
     it('(html) : should retain original root after creating a new node', function() {
-      var $html = cheerio.load('<body><ul id="fruits"></ul></body>');
-      expect($html('body')).to.have.length(1);
-      $html('<script>');
-      expect($html('body')).to.have.length(1);
+      var $ = cheerio.load('<body><ul id="fruits"></ul></body>');
+      expect($('body')).to.have.length(1);
+      $('<script>');
+      expect($('body')).to.have.length(1);
     });
 
     it('(html) : should handle lowercase tag options', function() {
-      var $html = cheerio.load('<BODY><ul id="fruits"></ul></BODY>', {
+      var $ = cheerio.load('<BODY><ul id="fruits"></ul></BODY>', {
         xml: { lowerCaseTags: true }
       });
-      expect($html.html()).to.be('<body><ul id="fruits"/></body>');
+      expect($.html()).to.be('<body><ul id="fruits"/></body>');
     });
 
     it('(html) : should handle the `normalizeWhitepace` option', function() {
-      var $html = cheerio.load('<body><b>foo</b>  <b>bar</b></body>', {
+      var $ = cheerio.load('<body><b>foo</b>  <b>bar</b></body>', {
         xml: { normalizeWhitespace: true }
       });
-      expect($html.html()).to.be('<body><b>foo</b> <b>bar</b></body>');
+      expect($.html()).to.be('<body><b>foo</b> <b>bar</b></body>');
     });
 
     // TODO:
     // it('(html) : should handle xml tag option', function() {
-    //   var $html = $.load('<body><script>oh hai</script></body>', { xml : true });
-    //   console.log($html('script')[0].type);
-    //   expect($html('script')[0].type).to.be('tag');
+    //   var $ = $.load('<body><script>oh hai</script></body>', { xml : true });
+    //   console.log($('script')[0].type);
+    //   expect($('script')[0].type).to.be('tag');
     // });
 
     it('(buffer) : should accept a buffer', function() {
-      var $html = cheerio.load(
+      var $ = cheerio.load(
         new Buffer('<html><head></head><body>foo</body></html>')
       );
-      expect($html.html()).to.be('<html><head></head><body>foo</body></html>');
+      expect($.html()).to.be('<html><head></head><body>foo</body></html>');
     });
   });
 
@@ -263,9 +263,9 @@ describe('cheerio', function() {
 
   describe('.root', function() {
     it('() : should return a cheerio-wrapped root object', function() {
-      var $html = cheerio.load('<html><head></head><body>foo</body></html>');
-      $html.root().append('<div id="test"></div>');
-      expect($html.html()).to.equal(
+      var $ = cheerio.load('<html><head></head><body>foo</body></html>');
+      $.root().append('<div id="test"></div>');
+      expect($.html()).to.equal(
         '<html><head></head><body>foo</body></html><div id="test"></div>'
       );
     });

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -1,6 +1,6 @@
 var expect = require('expect.js'),
     htmlparser2 = require('htmlparser2'),
-    $ = require('../'),
+    cheerio = require('../'),
     fixtures = require('./fixtures'),
     fruits = fixtures.fruits,
     food = fixtures.food,
@@ -14,42 +14,42 @@ var script = '<script src="script.js" type="text/javascript"></script>',
 
 describe('cheerio', function() {
   it('should get the version', function() {
-    expect(/\d+\.\d+\.\d+/.test($.version)).to.be.ok();
+    expect(/\d+\.\d+\.\d+/.test(cheerio.version)).to.be.ok();
   });
 
-  it('$(null) should return be empty', function() {
-    expect($(null)).to.be.empty();
+  it('cheerio(null) should return be empty', function() {
+    expect(cheerio(null)).to.be.empty();
   });
 
-  it('$(undefined) should be empty', function() {
-    expect($(undefined)).to.be.empty();
+  it('cheerio(undefined) should be empty', function() {
+    expect(cheerio(undefined)).to.be.empty();
   });
 
-  it('$(null) should be empty', function() {
-    expect($('')).to.be.empty();
+  it('cheerio(null) should be empty', function() {
+    expect(cheerio('')).to.be.empty();
   });
 
-  it('$(selector) with no context or root should be empty', function() {
-    expect($('.h2')).to.be.empty();
-    expect($('#fruits')).to.be.empty();
+  it('cheerio(selector) with no context or root should be empty', function() {
+    expect(cheerio('.h2')).to.be.empty();
+    expect(cheerio('#fruits')).to.be.empty();
   });
 
-  it('$(node) : should override previously-loaded nodes', function() {
-    var C = $.load('<div><span></span></div>');
-    var spanNode = C('span')[0];
-    var $span = C(spanNode);
+  it('cheerio(node) : should override previously-loaded nodes', function() {
+    var $ = cheerio.load('<div><span></span></div>');
+    var spanNode = $('span')[0];
+    var $span = $(spanNode);
     expect($span[0]).to.equal(spanNode);
   });
 
   it('should be able to create html without a root or context', function() {
-    var $h2 = $('<h2>');
+    var $h2 = cheerio('<h2>');
     expect($h2).to.not.be.empty();
     expect($h2).to.have.length(1);
     expect($h2[0].tagName).to.equal('h2');
   });
 
   it('should be able to create complicated html', function() {
-    var $script = $(script);
+    var $script = cheerio(script);
     expect($script).to.not.be.empty();
     expect($script).to.have.length(1);
     expect($script[0].attribs.src).to.equal('script.js');
@@ -68,52 +68,52 @@ describe('cheerio', function() {
   };
 
   it('should be able to select .apple with only a context', function() {
-    var $apple = $('.apple', fruits);
+    var $apple = cheerio('.apple', fruits);
     testAppleSelect($apple);
   });
 
   it('should be able to select .apple with a node as context', function() {
-    var $apple = $('.apple', $(fruits)[0]);
+    var $apple = cheerio('.apple', cheerio(fruits)[0]);
     testAppleSelect($apple);
   });
 
   it('should be able to select .apple with only a root', function() {
-    var $apple = $('.apple', null, fruits);
+    var $apple = cheerio('.apple', null, fruits);
     testAppleSelect($apple);
   });
 
   it('should be able to select an id', function() {
-    var $fruits = $('#fruits', null, fruits);
+    var $fruits = cheerio('#fruits', null, fruits);
     expect($fruits).to.have.length(1);
     expect($fruits[0].attribs.id).to.equal('fruits');
   });
 
   it('should be able to select a tag', function() {
-    var $ul = $('ul', fruits);
+    var $ul = cheerio('ul', fruits);
     expect($ul).to.have.length(1);
     expect($ul[0].tagName).to.equal('ul');
   });
 
   it('should accept a node reference as a context', function() {
-    var $elems = $('<div><span></span></div>');
-    expect($('span', $elems[0])).to.have.length(1);
+    var $elems = cheerio('<div><span></span></div>');
+    expect(cheerio('span', $elems[0])).to.have.length(1);
   });
 
   it('should accept an array of node references as a context', function() {
-    var $elems = $('<div><span></span></div>');
-    expect($('span', $elems.toArray())).to.have.length(1);
+    var $elems = cheerio('<div><span></span></div>');
+    expect(cheerio('span', $elems.toArray())).to.have.length(1);
   });
 
   it('should select only elements inside given context (Issue #193)', function() {
-    var q = $.load(food),
-        $fruits = q('#fruits'),
-        fruitElements = q('li', $fruits);
+    var $ = cheerio.load(food),
+        $fruits = $('#fruits'),
+        fruitElements = $('li', $fruits);
 
     expect(fruitElements).to.have.length(3);
   });
 
   it('should be able to select multiple tags', function() {
-    var $fruits = $('li', null, fruits);
+    var $fruits = cheerio('li', null, fruits);
     expect($fruits).to.have.length(3);
     var classes = ['apple', 'orange', 'pear'];
     $fruits.each(function(idx, $fruit) {
@@ -121,34 +121,34 @@ describe('cheerio', function() {
     });
   });
 
-  it('should be able to do: $("#fruits .apple")', function() {
-    var $apple = $('#fruits .apple', fruits);
+  it('should be able to do: cheerio("#fruits .apple")', function() {
+    var $apple = cheerio('#fruits .apple', fruits);
     testAppleSelect($apple);
   });
 
-  it('should be able to do: $("li.apple")', function() {
-    var $apple = $('li.apple', fruits);
+  it('should be able to do: cheerio("li.apple")', function() {
+    var $apple = cheerio('li.apple', fruits);
     testAppleSelect($apple);
   });
 
   it('should be able to select by attributes', function() {
-    var $apple = $('li[class=apple]', fruits);
+    var $apple = cheerio('li[class=apple]', fruits);
     testAppleSelect($apple);
   });
 
-  it('should be able to select multiple classes: $(".btn.primary")', function() {
-    var $a = $('.btn.primary', multiclass);
+  it('should be able to select multiple classes: cheerio(".btn.primary")', function() {
+    var $a = cheerio('.btn.primary', multiclass);
     expect($a).to.have.length(1);
     expect($a[0].childNodes[0].data).to.equal('Save');
   });
 
   it('should not create a top-level node', function() {
-    var $elem = $('* div', '<div>');
+    var $elem = cheerio('* div', '<div>');
     expect($elem).to.have.length(0);
   });
 
-  it('should be able to select multiple elements: $(".apple, #fruits")', function() {
-    var $elems = $('.apple, #fruits', fruits);
+  it('should be able to select multiple elements: cheerio(".apple, #fruits")', function() {
+    var $elems = cheerio('.apple, #fruits', fruits);
     expect($elems).to.have.length(2);
 
     var $apple = _.filter($elems, function(elem) {
@@ -161,81 +161,81 @@ describe('cheerio', function() {
     expect($fruits[0].attribs.id).to.equal('fruits');
   });
 
-  it('should select first element $(:first)');
-  // var $elem = $(':first', fruits);
-  // var $h2 = $('<h2>fruits</h2>');
+  it('should select first element cheerio(:first)');
+  // var $elem = cheerio(':first', fruits);
+  // var $h2 = cheerio('<h2>fruits</h2>');
   // console.log($elem.before('hi'));
   // console.log($elem.before($h2));
 
-  it('should be able to select immediate children: $("#fruits > .pear")', function() {
-    var $food = $(food);
-    $('.pear', $food).append('<li class="pear">Another Pear!</li>');
-    expect($('#fruits .pear', $food)).to.have.length(2);
-    var $elem = $('#fruits > .pear', $food);
+  it('should be able to select immediate children: cheerio("#fruits > .pear")', function() {
+    var $food = cheerio(food);
+    cheerio('.pear', $food).append('<li class="pear">Another Pear!</li>');
+    expect(cheerio('#fruits .pear', $food)).to.have.length(2);
+    var $elem = cheerio('#fruits > .pear', $food);
     expect($elem).to.have.length(1);
     expect($elem.attr('class')).to.equal('pear');
   });
 
-  it('should be able to select immediate children: $(".apple + .pear")', function() {
-    var $elem = $('.apple + li', fruits);
+  it('should be able to select immediate children: cheerio(".apple + .pear")', function() {
+    var $elem = cheerio('.apple + li', fruits);
     expect($elem).to.have.length(1);
-    $elem = $('.apple + .pear', fruits);
+    $elem = cheerio('.apple + .pear', fruits);
     expect($elem).to.have.length(0);
-    $elem = $('.apple + .orange', fruits);
+    $elem = cheerio('.apple + .orange', fruits);
     expect($elem).to.have.length(1);
     expect($elem.attr('class')).to.equal('orange');
   });
 
-  it('should be able to select immediate children: $(".apple ~ .pear")', function() {
-    var $elem = $('.apple ~ li', fruits);
+  it('should be able to select immediate children: cheerio(".apple ~ .pear")', function() {
+    var $elem = cheerio('.apple ~ li', fruits);
     expect($elem).to.have.length(2);
-    $elem = $('.apple ~ .pear', fruits);
+    $elem = cheerio('.apple ~ .pear', fruits);
     expect($elem.attr('class')).to.equal('pear');
   });
 
-  it('should handle wildcards on attributes: $("li[class*=r]")', function() {
-    var $elem = $('li[class*=r]', fruits);
+  it('should handle wildcards on attributes: cheerio("li[class*=r]")', function() {
+    var $elem = cheerio('li[class*=r]', fruits);
     expect($elem).to.have.length(2);
     expect($elem.eq(0).attr('class')).to.equal('orange');
     expect($elem.eq(1).attr('class')).to.equal('pear');
   });
 
-  it('should handle beginning of attr selectors: $("li[class^=o]")', function() {
-    var $elem = $('li[class^=o]', fruits);
+  it('should handle beginning of attr selectors: cheerio("li[class^=o]")', function() {
+    var $elem = cheerio('li[class^=o]', fruits);
     expect($elem).to.have.length(1);
     expect($elem.eq(0).attr('class')).to.equal('orange');
   });
 
-  it('should handle beginning of attr selectors: $("li[class$=e]")', function() {
-    var $elem = $('li[class$=e]', fruits);
+  it('should handle beginning of attr selectors: cheerio("li[class$=e]")', function() {
+    var $elem = cheerio('li[class$=e]', fruits);
     expect($elem).to.have.length(2);
     expect($elem.eq(0).attr('class')).to.equal('apple');
     expect($elem.eq(1).attr('class')).to.equal('orange');
   });
 
   it('should gracefully degrade on complex, unmatched queries', function() {
-    var $elem = $('Eastern States Cup #8-fin&nbsp;<br>Downhill&nbsp;');
+    var $elem = cheerio('Eastern States Cup #8-fin&nbsp;<br>Downhill&nbsp;');
     expect($elem).to.have.length(0); // []
   });
 
   it('(extended Array) should not interfere with prototype methods (issue #119)', function() {
     var extended = [];
     extended.find = extended.children = extended.each = function() {};
-    var $empty = $(extended);
+    var $empty = cheerio(extended);
 
-    expect($empty.find).to.be($.prototype.find);
-    expect($empty.children).to.be($.prototype.children);
-    expect($empty.each).to.be($.prototype.each);
+    expect($empty.find).to.be(cheerio.prototype.find);
+    expect($empty.children).to.be(cheerio.prototype.children);
+    expect($empty.each).to.be(cheerio.prototype.each);
   });
 
   it('should set html(number) as a string', function() {
-    var $elem = $('<div>');
+    var $elem = cheerio('<div>');
     $elem.html(123);
     expect(typeof $elem.text()).to.equal('string');
   });
 
   it('should set text(number) as a string', function() {
-    var $elem = $('<div>');
+    var $elem = cheerio('<div>');
     $elem.text(123);
     expect(typeof $elem.text()).to.equal('string');
   });
@@ -248,22 +248,22 @@ describe('cheerio', function() {
     });
 
     it('should be a function', function() {
-      expect(typeof $.merge).to.equal('function');
+      expect(typeof cheerio.merge).to.equal('function');
     });
 
     it('(arraylike, arraylike) : should return an array', function() {
-      var ret = $.merge(arr1, arr2);
+      var ret = cheerio.merge(arr1, arr2);
       expect(typeof ret).to.equal('object');
       expect(ret instanceof Array).to.be.ok();
     });
 
     it('(arraylike, arraylike) : should modify the first array', function() {
-      $.merge(arr1, arr2);
+      cheerio.merge(arr1, arr2);
       expect(arr1).to.have.length(6);
     });
 
     it('(arraylike, arraylike) : should not modify the second array', function() {
-      $.merge(arr1, arr2);
+      cheerio.merge(arr1, arr2);
       expect(arr2).to.have.length(3);
     });
 
@@ -278,7 +278,7 @@ describe('cheerio', function() {
       arr2[0] = 'd';
       arr2[1] = 'e';
       arr2[2] = 'f';
-      $.merge(arr1, arr2);
+      cheerio.merge(arr1, arr2);
       expect(arr1).to.have.length(6);
       expect(arr1[3]).to.equal('d');
       expect(arr1[4]).to.equal('e');
@@ -287,28 +287,28 @@ describe('cheerio', function() {
     });
 
     it('(?, ?) : should gracefully reject invalid inputs', function() {
-      var ret = $.merge([4], 3);
+      var ret = cheerio.merge([4], 3);
       expect(ret).to.not.be.ok();
-      ret = $.merge({}, {});
+      ret = cheerio.merge({}, {});
       expect(ret).to.not.be.ok();
-      ret = $.merge([], {});
+      ret = cheerio.merge([], {});
       expect(ret).to.not.be.ok();
-      ret = $.merge({}, []);
+      ret = cheerio.merge({}, []);
       expect(ret).to.not.be.ok();
       var fakeArray1 = { length: 3 };
       fakeArray1[0] = 'a';
       fakeArray1[1] = 'b';
       fakeArray1[3] = 'd';
-      ret = $.merge(fakeArray1, []);
+      ret = cheerio.merge(fakeArray1, []);
       expect(ret).to.not.be.ok();
-      ret = $.merge([], fakeArray1);
+      ret = cheerio.merge([], fakeArray1);
       expect(ret).to.not.be.ok();
       fakeArray1 = {};
       fakeArray1.length = '7';
-      ret = $.merge(fakeArray1, []);
+      ret = cheerio.merge(fakeArray1, []);
       expect(ret).to.not.be.ok();
       fakeArray1.length = -1;
-      ret = $.merge(fakeArray1, []);
+      ret = cheerio.merge(fakeArray1, []);
       expect(ret).to.not.be.ok();
     });
 
@@ -317,12 +317,12 @@ describe('cheerio', function() {
       fakeArray1[0] = 'a';
       fakeArray1[1] = 'b';
       fakeArray1[3] = 'd';
-      $.merge(fakeArray1, []);
+      cheerio.merge(fakeArray1, []);
       expect(fakeArray1).to.have.length(3);
       expect(fakeArray1[0]).to.equal('a');
       expect(fakeArray1[1]).to.equal('b');
       expect(fakeArray1[3]).to.equal('d');
-      $.merge([], fakeArray1);
+      cheerio.merge([], fakeArray1);
       expect(fakeArray1).to.have.length(3);
       expect(fakeArray1[0]).to.equal('a');
       expect(fakeArray1[1]).to.equal('b');
@@ -332,15 +332,15 @@ describe('cheerio', function() {
 
   describe('.load', function() {
     it('should generate selections as proper instances', function() {
-      var q = $.load(fruits);
+      var $ = cheerio.load(fruits);
 
-      expect(q('.apple')).to.be.a(q);
+      expect($('.apple')).to.be.a($);
     });
 
     it('should be able to filter down using the context', function() {
-      var q = $.load(fruits),
-          apple = q('.apple', 'ul'),
-          lis = q('li', 'ul');
+      var $ = cheerio.load(fruits),
+          apple = $('.apple', 'ul'),
+          lis = $('li', 'ul');
 
       expect(apple).to.have.length(1);
       expect(lis).to.have.length(3);
@@ -348,18 +348,18 @@ describe('cheerio', function() {
 
     it('should allow loading a pre-parsed DOM', function() {
       var dom = htmlparser2.parseDOM(food),
-          q = $.load(dom);
+          $ = cheerio.load(dom);
 
-      expect(q('ul')).to.have.length(3);
+      expect($('ul')).to.have.length(3);
     });
 
     it('should render xml in html() when options.xml = true', function() {
       var str = '<MixedCaseTag UPPERCASEATTRIBUTE=""></MixedCaseTag>',
           expected = '<MixedCaseTag UPPERCASEATTRIBUTE=""/>',
-          dom = $.load(str, { xml: true });
+          $ = cheerio.load(str, { xml: true });
 
-      expect(dom('MixedCaseTag').get(0).tagName).to.equal('MixedCaseTag');
-      expect(dom.html()).to.be(expected);
+      expect($('MixedCaseTag').get(0).tagName).to.equal('MixedCaseTag');
+      expect($.html()).to.be(expected);
     });
 
     it('should render xml in html() when options.xml = true passed to html()', function() {
@@ -369,11 +369,11 @@ describe('cheerio', function() {
           '<html><head/><body><mixedcasetag uppercaseattribute=""/></body></html>',
           expectedNoXml =
           '<html><head></head><body><mixedcasetag uppercaseattribute=""></mixedcasetag></body></html>',
-          dom = $.load(str);
+          $ = cheerio.load(str);
 
-      expect(dom('MixedCaseTag').get(0).tagName).to.equal('mixedcasetag');
-      expect(dom.html()).to.be(expectedNoXml);
-      expect(dom.html({ xml: true })).to.be(expectedXml);
+      expect($('MixedCaseTag').get(0).tagName).to.equal('mixedcasetag');
+      expect($.html()).to.be(expectedNoXml);
+      expect($.html({ xml: true })).to.be(expectedXml);
     });
 
     it('should respect options on the element level', function() {
@@ -381,8 +381,8 @@ describe('cheerio', function() {
           '<!doctype html><html><head><title>Some test</title></head><body><footer><p>Copyright &copy; 2003-2014</p></footer></body></html>',
           expectedHtml = '<p>Copyright &copy; 2003-2014</p>',
           expectedXml = '<p>Copyright © 2003-2014</p>',
-          domNotEncoded = $.load(str, { xml: { decodeEntities: false } }),
-          domEncoded = $.load(str);
+          domNotEncoded = cheerio.load(str, { xml: { decodeEntities: false } }),
+          domEncoded = cheerio.load(str);
 
       expect(domNotEncoded('footer').html()).to.be(expectedHtml);
       // TODO: Make it more html friendly, maybe with custom encode tables
@@ -390,23 +390,23 @@ describe('cheerio', function() {
     });
 
     it('should return a fully-qualified Function', function() {
-      var $c = $.load('<div>');
+      var $ = cheerio.load('<div>');
 
-      expect($c).to.be.a(Function);
+      expect($).to.be.a(Function);
     });
 
     describe('prototype extensions', function() {
       it('should honor extensions defined on `prototype` property', function() {
-        var $c = $.load('<div>');
+        var $ = cheerio.load('<div>');
         var $div;
-        $c.prototype.myPlugin = function() {
+        $.prototype.myPlugin = function() {
           return {
             context: this,
             args: arguments
           };
         };
 
-        $div = $c('div');
+        $div = $('div');
 
         expect($div.myPlugin).to.be.a('function');
         expect($div.myPlugin().context).to.be($div);
@@ -418,16 +418,16 @@ describe('cheerio', function() {
       });
 
       it('should honor extensions defined on `fn` property', function() {
-        var $c = $.load('<div>');
+        var $ = cheerio.load('<div>');
         var $div;
-        $c.fn.myPlugin = function() {
+        $.fn.myPlugin = function() {
           return {
             context: this,
             args: arguments
           };
         };
 
-        $div = $c('div');
+        $div = $('div');
 
         expect($div.myPlugin).to.be.a('function');
         expect($div.myPlugin().context).to.be($div);
@@ -439,8 +439,8 @@ describe('cheerio', function() {
       });
 
       it('should isolate extensions between loaded functions', function() {
-        var $a = $.load('<div>');
-        var $b = $.load('<div>');
+        var $a = cheerio.load('<div>');
+        var $b = cheerio.load('<div>');
 
         $a.prototype.foo = function() {};
 

--- a/test/xml.js
+++ b/test/xml.js
@@ -6,8 +6,8 @@ var expect = require('expect.js'),
 
 var xml = function(str, options) {
   options = _.extend({ xml: true }, options);
-  var dom = cheerio.load(str, options);
-  return dom.xml();
+  var $ = cheerio.load(str, options);
+  return $.xml();
 };
 
 var dom = function(str, options) {
@@ -53,9 +53,9 @@ describe('render', function() {
 
     it('should maintain the parsing options of distinct contexts independently', function() {
       var str = '<g><someElem someAttribute="something">hello</someElem></g>';
-      var $x = cheerio.load('', { xml: false });
+      var $ = cheerio.load('', { xml: false });
 
-      expect($x(str).html()).to.equal(
+      expect($(str).html()).to.equal(
         '<someelem someattribute="something">hello</someelem>'
       );
     });


### PR DESCRIPTION
Promote consistency in variable names within the project's source and
unit tests. This helps to highlight the distinction between the object
exported by the module and the function produced by the `load` method.
The latter value is expected to mimic the jQuery API, while the former
value generally should only be used for a small set of methods specific
to Cheerio:

- `load`
- `html`
- `xml`
- `text`

Other usages of the exported object are discouraged, and a future patch
will update the unit tests to reflect the usages that are endorsed for
long-term stability.

---

Hey @fb55.

My plan to accomodate gh-1122 in version 1.0 is to document the irregular API as "deprecated" but also to improve test coverage. Currently, our coverage is incomplete, and that's particularly hard to see given the irregular use of `$` internally. This patch is the first step towards fixing things. I'm hoping that by being more precise with variable names, my future work will be easier to review.