### PR TITLE
Fix running test on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "xyz": "~1.1.0"
   },
   "scripts": {
-    "test": "make test"
+    "test": "jshint lib/ test/ && mocha --recursive --reporter dot"
   }
 }


### PR DESCRIPTION
Moves lint and test script call from Makefile to package.json. Makes the test run on all platforms.