### PR TITLE
Updated parse5 to 4.0.0 (fixes #1245).

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "entities": "~1.1.1",
     "htmlparser2": "^3.9.1",
     "lodash": "^4.17.5",
-    "parse5": "^3.0.1"
+    "parse5": "^4.0.0"
   },
   "devDependencies": {
     "benchmark": "^2.1.0",


### PR DESCRIPTION
Tests run successfully.  This is specifically to fix projects including cheerio failing to compile as ES3 TypeScript (see #1245), which [seems to be what 3.0.1->4.0.0 addresses](https://github.com/inikulin/parse5/blob/master/docs/version-history.md#400).