### PR TITLE
add option keep non ascii

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -269,7 +269,8 @@ of the default parsing options:
 ```js
 const $ = cheerio.load('<ul id="fruits">...</ul>', {
     normalizeWhitespace: true,
-    xmlMode: true
+    xmlMode: true,
+    keepNonAscii: true
 });
 ```
 
@@ -280,10 +281,13 @@ These parsing options are taken directly from [htmlparser2](https://github.com/f
     withDomLvl1: true,
     normalizeWhitespace: false,
     xmlMode: false,
-    decodeEntities: true
+    decodeEntities: true,
+    keepNonAscii: false
 }
 
 ```
+
+the `keepNonAscii` option controll whether output html or xml will encode non ascii character to html entities form. if false, all non character will be encode to html entities form: `☺` become `&#x263A;` . if true, character will output directly . (usually in utf8.)
 
 For a full list of options and their effects, see [this](https://github.com/fb55/DomHandler) and
 [htmlparser2's options](https://github.com/fb55/htmlparser2/wiki/Parser-options).

--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -106,7 +106,8 @@ Cheerio.prototype.options = {
   withDomLvl1: true,
   normalizeWhitespace: false,
   xmlMode: false,
-  decodeEntities: true
+  decodeEntities: true,
+  keepNonAscii: false
 };
 
 /*

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
   },
   "dependencies": {
     "css-select": "~1.2.0",
-    "dom-serializer": "~0.1.0",
-    "entities": "~1.1.1",
+    "dom-serializer": "git+https://github.com/GHolk/dom-serializer",
     "htmlparser2": "^3.9.1",
     "lodash": "^4.15.0"
   },


### PR DESCRIPTION
a few little patch include **dom-serializer** , **entities** ,
allow output keep non ascii character raw.

```
const cheerio = require('cheerio')

cheerio.load('<h1>你好 :)</h1>').html()
// <h1>&#x4F60;&#x597D; :)</h1>

cheerio.load('<h1>你好 :)</h1>', {keepNonAscii: true}).html()
// <h1>你好 :)</h1>
```