### PR TITLE
Fix #1208

### DIFF
--- a/lib/api/css.js
+++ b/lib/api/css.js
@@ -66,6 +66,10 @@ function setCss(el, prop, val, idx) {
  */
 
 function getCss(el, prop) {
+  if(!el || !el.attribs) {
+    return undefined;
+  }
+
   var styles = parse(el.attribs.style);
   if (typeof prop === 'string') {
     return styles[prop];

--- a/test/api/css.js
+++ b/test/api/css.js
@@ -42,6 +42,16 @@ describe('$(...)', function() {
       expect(el.css()).to.eql({position:'absolute'});
     });
 
+    it('(prop): should return undefined for unmatched elements', function() {
+      var $ = cheerio.load('<li style="color:;position:absolute;">');
+      expect($('ul').css('background-image')).to.eql(undefined);
+    });
+
+    it('(prop): should return undefined for unmatched styles', function() {
+      var el = cheerio('<li style="color:;position:absolute;">');
+      expect(el.css('margin')).to.eql(undefined);
+    });
+
     describe('(prop, function):', function() {
       beforeEach(function() {
         this.$el = cheerio('<div style="margin: 0px;"></div><div style="margin: 1px;"></div><div style="margin: 2px;">');


### PR DESCRIPTION
cheerio.css on empty elements set throws, jQuery returns undefined.
This PR Checks for the element before checking the styles.

Include tests

Signed-off-by: Luan <luan@luanmuniz.com.br>