### PR TITLE
Update test expectation

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "css-select": "~1.2.0",
-    "dom-serializer": "~0.1.0",
+    "dom-serializer": "~0.1.1",
     "entities": "~1.1.1",
     "htmlparser2": "^3.9.1",
     "lodash": "^4.15.0",

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -368,7 +368,7 @@ describe('cheerio', function() {
       var str = '<MixedCaseTag UPPERCASEATTRIBUTE=""></MixedCaseTag>',
           // since parsing done without xml flag, all tags converted to lowercase
           expectedXml = '<html><head/><body><mixedcasetag uppercaseattribute=""/></body></html>',
-          expectedNoXml = '<html><head></head><body><mixedcasetag uppercaseattribute=""></mixedcasetag></body></html>',
+          expectedNoXml = '<html><head></head><body><mixedcasetag uppercaseattribute></mixedcasetag></body></html>',
           dom = $.load(str);
 
       expect(dom('MixedCaseTag').get(0).tagName).to.equal('mixedcasetag');


### PR DESCRIPTION
Version 0.1.1 of the dom-serializer module has corrected the way boolean
attributes are rendered when interpreted as HTML. Update this project's
expectations accordingly and explicitly rely on the release which
includes the fix.

---

@fb55 our "1.0.0-rc2" release is far behind what we're currently preparing for 1.0.0, but since the state of the tests are relevant for Node's tooling, I wanted to hot-fix this immediately. I created the base branch so we could release just the correction to the test (it's not an issue on the in-progress "v1.0.0" branch). If it looks right to you, could you merge and publish a new release candidate?