### PR TITLE
Fix buffer deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,11 @@
     "coveralls": "^2.11.9",
     "expect.js": "~0.3.1",
     "istanbul": "^0.4.3",
-    "jsdom": "^9.2.1",
     "jquery": "^3.0.0",
+    "jsdom": "^9.2.1",
     "jshint": "^2.9.2",
     "mocha": "^3.1.2",
+    "safe-buffer": "^5.1.2",
     "xyz": "~1.1.0"
   },
   "scripts": {

--- a/test/api/utils.js
+++ b/test/api/utils.js
@@ -1,6 +1,7 @@
 var expect = require('expect.js'),
     fixtures = require('../fixtures'),
-    cheerio = require('../..');
+    cheerio = require('../..'),
+    Buffer = require('safe-buffer').Buffer;
 
 describe('cheerio', function() {
 
@@ -101,7 +102,7 @@ describe('cheerio', function() {
     // });
 
     it('(buffer) : should accept a buffer', function() {
-      var $html = cheerio.load(new Buffer('<div>foo</div>'));
+      var $html = cheerio.load(Buffer.from('<div>foo</div>'));
       expect($html.html()).to.be('<div>foo</div>');
     });
 


### PR DESCRIPTION
This makes sure the test uses `Buffer.from` instead of `new Buffer`
to prevent the deprecation warning. It will work with all Node.js
versions due to using the `safe-buffer` module.