### PR TITLE
Pass options to parse5 to enable location info

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2,7 +2,8 @@
   Module Dependencies
 */
 var htmlparser = require('htmlparser2'),
-    parse5 = require('parse5');
+    parse5 = require('parse5'),
+    assign = require('lodash/assign');
 
 /*
   Parser
@@ -21,9 +22,9 @@ exports = module.exports = function(content, options, isDocument) {
   return root;
 };
 
-function parseWithParse5 (content, isDocument) {
+function parseWithParse5 (content, options, isDocument) {
   var parse = isDocument ? parse5.parse : parse5.parseFragment,
-      root = parse(content, { treeAdapter: parse5.treeAdapters.htmlparser2 });
+      root = parse(content, assign({}, options, { treeAdapter: parse5.treeAdapters.htmlparser2 }));
 
   return root.children;
 }
@@ -39,7 +40,7 @@ exports.evaluate = function(content, options, isDocument) {
   if (typeof content === 'string') {
     var useHtmlParser2 = options.xmlMode || options._useHtmlParser2;
 
-    dom = useHtmlParser2 ? htmlparser.parseDOM(content, options) : parseWithParse5(content, isDocument);
+    dom = useHtmlParser2 ? htmlparser.parseDOM(content, options) : parseWithParse5(content, options, isDocument);
   } else {
     dom = content;
   }

--- a/test/parse.js
+++ b/test/parse.js
@@ -1,4 +1,5 @@
 var expect = require('expect.js'),
+    assign = require('lodash/assign'),
     parse = require('../lib/parse'),
     defaultOpts = require('../lib/options').default;
 
@@ -352,6 +353,14 @@ describe('parse', function() {
       expect(childNodes[0].tagName).to.be('pre');
       expect(childNodes[0].childNodes[0].data).to.be('A <- factor(A, levels = c("c","a","b"))\n');
     });
+  });
+
+  it('should pass the options for including the location info to parse5', function() {
+    var root = parse('<p>Hello</p>', assign({}, defaultOpts, { _useHtmlParser2: false, locationInfo: true }), false);
+    var location = root.children[0].__location;
+
+    expect(location).to.be.an('object');
+    expect(location.endOffset).to.be(12);
   });
 
 });


### PR DESCRIPTION
Hello! :raised_hands: 

This PR attempts to bring back options passing to parse5.

Addresses(and closes) #1296 

- Introduces a way to pass options to parse5 if cheerio ends up using it
- Adds a test for checking whether it's possible to get the location info

I didn't know which base to use for this PR, so I made it on top of `v1.0.0-rc.3`

Please let me know if anything needs to be changed!