### PR TITLE
Correct rendering of root node

### DIFF
--- a/lib/static.js
+++ b/lib/static.js
@@ -87,16 +87,24 @@ function render(that, dom, options) {
     dom = select(dom, that._root, options);
   }
 
-  var useHtmlParser2 = options.xmlMode || options._useHtmlParser2;
+  if (options.xmlMode || options._useHtmlParser2) {
+    return serialize(dom, options);
+  }
 
-  return useHtmlParser2
-    ? serialize(dom, options)
-    : parse5.serialize(
-      { children: 'length' in dom ? dom : [dom] },
-      {
-        treeAdapter: parse5.treeAdapters.htmlparser2
-      }
-    );
+  // `dom-serializer` passes over the special "root" node and renders the
+  // node's children in its place. To mimic this behavior with `parse5`, an
+  // equivalent operation must be applied to the input array.
+  var nodes = 'length' in dom ? dom : [dom];
+  for (var index = 0; index < nodes.length; index += 1) {
+    if (nodes[index].type === 'root') {
+      nodes.splice.apply(nodes, [index, 1].concat(nodes[index].children));
+    }
+  }
+
+  return parse5.serialize(
+    { children: nodes },
+    { treeAdapter: parse5.treeAdapters.htmlparser2 }
+  );
 }
 
 /**

--- a/test/api/utils.js
+++ b/test/api/utils.js
@@ -21,6 +21,23 @@ describe('cheerio', function() {
       var $elem = cheerio('<span>foo</span>').html('');
       expect(cheerio.html($elem)).to.equal('<span></span>');
     });
+
+    it('(<root>) : does not render the root element', function() {
+      var $ = cheerio.load('');
+      expect(cheerio.html($.root())).to.equal(
+        '<html><head></head><body></body></html>'
+      );
+    });
+
+    it('(<elem>, <root>, <elem>) : does not render the root element', function() {
+      var $ = cheerio.load('<div>a div</div><span>a span</span>');
+      var $collection = $('div')
+        .add($.root())
+        .add('span');
+      var expected =
+        '<span>a span</span><html><head></head><body><div>a div</div><span>a span</span></body></html><div>a div</div>';
+      expect(cheerio.html($collection)).to.equal(expected);
+    });
   });
 
   describe('.text', function() {


### PR DESCRIPTION
This change normalizes rendering between trees generated by parse5 and
htmlparser2. Consistent rendering of the "root" node is especially
important given that `cheerio.render($.root())` will be the recommended
pattern for rendering entire documents in Cheerio version 1.0.