### PR TITLE
Change to latest release of `dom-serializer`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1125,12 +1125,24 @@
       }
     },
     "dom-serializer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
-      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+      "version": "0.2.1",
+      "resolved": "https://artifactory.roving.com/artifactory/api/npm/npm-virtual/dom-serializer/-/dom-serializer-0.2.1.tgz",
+      "integrity": "sha1-E2UMhQ2v/qNdi2JqTPxNOhdkP9s=",
       "requires": {
-        "domelementtype": "^1.3.0",
-        "entities": "^1.1.1"
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.roving.com/artifactory/api/npm/npm-virtual/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha1-H4vf6R9aeAYydOgDtL3O326U+U0="
+        },
+        "entities": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.roving.com/artifactory/api/npm/npm-virtual/entities/-/entities-2.0.0.tgz",
+          "integrity": "sha1-aNYITKsbB5dnVA2A5Wo5tCPkq/Q="
+        }
       }
     },
     "domelementtype": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "css-select": "~2.0.0",
-    "dom-serializer": "~0.1.1",
+    "dom-serializer": "~0.2.1",
     "entities": "~1.1.1",
     "htmlparser2": "^3.9.1",
     "lodash": "^4.17.11",


### PR DESCRIPTION
`dom-serializer` at version 0.1.1 contains the use of `const`. This is causing my project to release code that is not es5 compatible. Please upgrade to a fixed version of `dom-serializer`.

The commit where they fixed the issue: https://github.com/cheeriojs/dom-serializer/commit/67806ca7316710c78d7b159d0c769bd436bc0de9#diff-168726dbe96b3ce427e7fedce31bb0bcL108