### PR TITLE
Avoid lodash where possible

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,14 +6,6 @@
   "extends": ["eslint:recommended", "prettier"],
   "globals": {},
   "rules": {
-    "indent": [
-      2,
-      2,
-      {
-        "SwitchCase": 1,
-        "VariableDeclarator": 2
-      }
-    ],
     "no-eq-null": 0,
     "no-proto": 2,
 

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,14 @@
   "extends": ["eslint:recommended", "prettier"],
   "globals": {},
   "rules": {
+    "indent": [
+      2,
+      2,
+      {
+        "SwitchCase": 1,
+        "VariableDeclarator": 2
+      }
+    ],
     "no-eq-null": 0,
     "no-proto": 2,
 

--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -8,25 +8,25 @@ exports = exports; // eslint-disable-line no-self-assign
 // The preceeding statement is necessary for proper documentation generation.
 
 var text = require('../static').text,
-  utils = require('../utils'),
-  isTag = utils.isTag,
-  domEach = utils.domEach,
-  hasOwn = Object.prototype.hasOwnProperty,
-  camelCase = utils.camelCase,
-  cssCase = utils.cssCase,
-  rspace = /\s+/,
-  dataAttrPrefix = 'data-',
-  // Lookup table for coercing string data-* attributes to their corresponding
-  // JavaScript primitives
-  primitives = {
-    null: null,
-    true: true,
-    false: false,
-  },
-  // Attributes that are booleans
-  rboolean = /^(?:autofocus|autoplay|async|checked|controls|defer|disabled|hidden|loop|multiple|open|readonly|required|scoped|selected)$/i,
-  // Matches strings that look like JSON objects or arrays
-  rbrace = /^(?:\{[\w\W]*\}|\[[\w\W]*\])$/;
+    utils = require('../utils'),
+    isTag = utils.isTag,
+    domEach = utils.domEach,
+    hasOwn = Object.prototype.hasOwnProperty,
+    camelCase = utils.camelCase,
+    cssCase = utils.cssCase,
+    rspace = /\s+/,
+    dataAttrPrefix = 'data-',
+    // Lookup table for coercing string data-* attributes to their corresponding
+    // JavaScript primitives
+    primitives = {
+      null: null,
+      true: true,
+      false: false,
+    },
+    // Attributes that are booleans
+    rboolean = /^(?:autofocus|autoplay|async|checked|controls|defer|disabled|hidden|loop|multiple|open|readonly|required|scoped|selected)$/i,
+    // Matches strings that look like JSON objects or arrays
+    rbrace = /^(?:\{[\w\W]*\}|\[[\w\W]*\])$/;
 
 var getAttr = function (elem, name) {
   if (!elem || !isTag(elem)) return;
@@ -118,8 +118,8 @@ var getProp = function (el, name) {
   return name in el
     ? el[name]
     : rboolean.test(name)
-    ? getAttr(el, name) !== undefined
-    : getAttr(el, name);
+      ? getAttr(el, name) !== undefined
+      : getAttr(el, name);
 };
 
 var setProp = function (el, name, value) {
@@ -145,7 +145,7 @@ var setProp = function (el, name, value) {
  */
 exports.prop = function (name, value) {
   var i = 0,
-    property;
+      property;
 
   if (typeof name === 'string' && value === undefined) {
     switch (name) {
@@ -317,7 +317,7 @@ exports.data = function (name, value) {
  */
 exports.val = function (value) {
   var querying = arguments.length === 0,
-    element = this[0];
+      element = this[0];
 
   if (!element) return;
 
@@ -337,7 +337,7 @@ exports.val = function (value) {
       return this.attr('value', value);
     case 'select':
       var option = this.find('option:selected'),
-        returnValue;
+          returnValue;
       if (option === undefined) return undefined;
       if (!querying) {
         if (!hasOwn.call(this.attr(), 'multiple') && typeof value == 'object') {
@@ -423,9 +423,9 @@ exports.removeAttr = function (name) {
 exports.hasClass = function (className) {
   return this.toArray().some(function (elem) {
     var attrs = elem.attribs,
-      clazz = attrs && attrs['class'],
-      idx = -1,
-      end;
+        clazz = attrs && attrs['class'],
+        idx = -1,
+        end;
 
     if (clazz && className.length) {
       while ((idx = clazz.indexOf(className, idx + 1)) > -1) {
@@ -471,7 +471,7 @@ exports.addClass = function (value) {
   if (!value || typeof value !== 'string') return this;
 
   var classNames = value.split(rspace),
-    numElements = this.length;
+      numElements = this.length;
 
   for (var i = 0; i < numElements; i++) {
     // If selected element isn't a tag, move on
@@ -479,8 +479,8 @@ exports.addClass = function (value) {
 
     // If we don't already have classes
     var className = getAttr(this[i], 'class'),
-      numClasses,
-      setClass;
+        numClasses,
+        setClass;
 
     if (!className) {
       setAttr(this[i], 'class', classNames.join(' ').trim());
@@ -546,8 +546,8 @@ exports.removeClass = function (value) {
       el.attribs.class = '';
     } else {
       var elClasses = splitClass(el.attribs.class),
-        index,
-        changed;
+          index,
+          changed;
 
       for (var j = 0; j < numClasses; j++) {
         index = elClasses.indexOf(classes[j]);
@@ -602,11 +602,11 @@ exports.toggleClass = function (value, stateVal) {
   if (!value || typeof value !== 'string') return this;
 
   var classNames = value.split(rspace),
-    numClasses = classNames.length,
-    state = typeof stateVal === 'boolean' ? (stateVal ? 1 : -1) : 0,
-    numElements = this.length,
-    elementClasses,
-    index;
+      numClasses = classNames.length,
+      state = typeof stateVal === 'boolean' ? (stateVal ? 1 : -1) : 0,
+      numElements = this.length,
+      elementClasses,
+      index;
 
   for (var i = 0; i < numElements; i++) {
     // If selected element isn't a tag, move on

--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -8,25 +8,25 @@ exports = exports; // eslint-disable-line no-self-assign
 // The preceeding statement is necessary for proper documentation generation.
 
 var text = require('../static').text,
-    utils = require('../utils'),
-    isTag = utils.isTag,
-    domEach = utils.domEach,
-    hasOwn = Object.prototype.hasOwnProperty,
-    camelCase = utils.camelCase,
-    cssCase = utils.cssCase,
-    rspace = /\s+/,
-    dataAttrPrefix = 'data-',
-    // Lookup table for coercing string data-* attributes to their corresponding
-    // JavaScript primitives
-    primitives = {
-      null: null,
-      true: true,
-      false: false,
-    },
-    // Attributes that are booleans
-    rboolean = /^(?:autofocus|autoplay|async|checked|controls|defer|disabled|hidden|loop|multiple|open|readonly|required|scoped|selected)$/i,
-    // Matches strings that look like JSON objects or arrays
-    rbrace = /^(?:\{[\w\W]*\}|\[[\w\W]*\])$/;
+  utils = require('../utils'),
+  isTag = utils.isTag,
+  domEach = utils.domEach,
+  hasOwn = Object.prototype.hasOwnProperty,
+  camelCase = utils.camelCase,
+  cssCase = utils.cssCase,
+  rspace = /\s+/,
+  dataAttrPrefix = 'data-',
+  // Lookup table for coercing string data-* attributes to their corresponding
+  // JavaScript primitives
+  primitives = {
+    null: null,
+    true: true,
+    false: false,
+  },
+  // Attributes that are booleans
+  rboolean = /^(?:autofocus|autoplay|async|checked|controls|defer|disabled|hidden|loop|multiple|open|readonly|required|scoped|selected)$/i,
+  // Matches strings that look like JSON objects or arrays
+  rbrace = /^(?:\{[\w\W]*\}|\[[\w\W]*\])$/;
 
 var getAttr = function (elem, name) {
   if (!elem || !isTag(elem)) return;
@@ -99,9 +99,10 @@ exports.attr = function (name, value) {
       if (!isTag(el)) return;
 
       if (typeof name === 'object') {
-        for (const [objName, objValue] of Object.entries(name)) {
+        Object.keys(name).forEach((objName) => {
+          const objValue = name[objName];
           setAttr(el, objName, objValue);
-        }
+        });
       } else {
         setAttr(el, name, value);
       }
@@ -117,8 +118,8 @@ var getProp = function (el, name) {
   return name in el
     ? el[name]
     : rboolean.test(name)
-      ? getAttr(el, name) !== undefined
-      : getAttr(el, name);
+    ? getAttr(el, name) !== undefined
+    : getAttr(el, name);
 };
 
 var setProp = function (el, name, value) {
@@ -144,16 +145,16 @@ var setProp = function (el, name, value) {
  */
 exports.prop = function (name, value) {
   var i = 0,
-      property;
+    property;
 
   if (typeof name === 'string' && value === undefined) {
     switch (name) {
       case 'style':
         property = this.css();
 
-        for (const p of Object.keys(property)) {
+        Object.keys(property).forEach((p) => {
           property[i++] = p;
-        }
+        });
 
         property.length = i;
 
@@ -183,9 +184,10 @@ exports.prop = function (name, value) {
       if (!isTag(el)) return;
 
       if (typeof name === 'object') {
-        for (const [key, val] of Object.entries(name)) {
+        Object.keys(name).forEach((key) => {
+          const val = name[key];
           setProp(el, key, val);
-        }
+        });
       } else {
         setProp(el, name, value);
       }
@@ -315,7 +317,7 @@ exports.data = function (name, value) {
  */
 exports.val = function (value) {
   var querying = arguments.length === 0,
-      element = this[0];
+    element = this[0];
 
   if (!element) return;
 
@@ -335,7 +337,7 @@ exports.val = function (value) {
       return this.attr('value', value);
     case 'select':
       var option = this.find('option:selected'),
-          returnValue;
+        returnValue;
       if (option === undefined) return undefined;
       if (!querying) {
         if (!hasOwn.call(this.attr(), 'multiple') && typeof value == 'object') {
@@ -421,9 +423,9 @@ exports.removeAttr = function (name) {
 exports.hasClass = function (className) {
   return Array.from(this).some(function (elem) {
     var attrs = elem.attribs,
-        clazz = attrs && attrs['class'],
-        idx = -1,
-        end;
+      clazz = attrs && attrs['class'],
+      idx = -1,
+      end;
 
     if (clazz && className.length) {
       while ((idx = clazz.indexOf(className, idx + 1)) > -1) {
@@ -469,7 +471,7 @@ exports.addClass = function (value) {
   if (!value || typeof value !== 'string') return this;
 
   var classNames = value.split(rspace),
-      numElements = this.length;
+    numElements = this.length;
 
   for (var i = 0; i < numElements; i++) {
     // If selected element isn't a tag, move on
@@ -477,8 +479,8 @@ exports.addClass = function (value) {
 
     // If we don't already have classes
     var className = getAttr(this[i], 'class'),
-        numClasses,
-        setClass;
+      numClasses,
+      setClass;
 
     if (!className) {
       setAttr(this[i], 'class', classNames.join(' ').trim());
@@ -544,8 +546,8 @@ exports.removeClass = function (value) {
       el.attribs.class = '';
     } else {
       var elClasses = splitClass(el.attribs.class),
-          index,
-          changed;
+        index,
+        changed;
 
       for (var j = 0; j < numClasses; j++) {
         index = elClasses.indexOf(classes[j]);
@@ -600,11 +602,11 @@ exports.toggleClass = function (value, stateVal) {
   if (!value || typeof value !== 'string') return this;
 
   var classNames = value.split(rspace),
-      numClasses = classNames.length,
-      state = typeof stateVal === 'boolean' ? (stateVal ? 1 : -1) : 0,
-      numElements = this.length,
-      elementClasses,
-      index;
+    numClasses = classNames.length,
+    state = typeof stateVal === 'boolean' ? (stateVal ? 1 : -1) : 0,
+    numElements = this.length,
+    elementClasses,
+    index;
 
   for (var i = 0; i < numElements; i++) {
     // If selected element isn't a tag, move on

--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -16,11 +16,6 @@ var text = require('../static').text,
     cssCase = utils.cssCase,
     rspace = /\s+/,
     dataAttrPrefix = 'data-',
-    _ = {
-      forEach: require('lodash/forEach'),
-      extend: require('lodash/assignIn'),
-      some: require('lodash/some'),
-    },
     // Lookup table for coercing string data-* attributes to their corresponding
     // JavaScript primitives
     primitives = {
@@ -104,9 +99,9 @@ exports.attr = function (name, value) {
       if (!isTag(el)) return;
 
       if (typeof name === 'object') {
-        _.forEach(name, function (objValue, objName) {
+        for (const [objName, objValue] of Object.entries(name)) {
           setAttr(el, objName, objValue);
-        });
+        }
       } else {
         setAttr(el, name, value);
       }
@@ -156,9 +151,9 @@ exports.prop = function (name, value) {
       case 'style':
         property = this.css();
 
-        _.forEach(property, function (v, p) {
+        for (const p of Object.keys(property)) {
           property[i++] = p;
-        });
+        }
 
         property.length = i;
 
@@ -188,9 +183,9 @@ exports.prop = function (name, value) {
       if (!isTag(el)) return;
 
       if (typeof name === 'object') {
-        _.forEach(name, function (val, key) {
+        for (const [key, val] of Object.entries(name)) {
           setProp(el, key, val);
-        });
+        }
       } else {
         setProp(el, name, value);
       }
@@ -203,7 +198,7 @@ var setData = function (el, name, value) {
     el.data = {};
   }
 
-  if (typeof name === 'object') return _.extend(el.data, name);
+  if (typeof name === 'object') return Object.assign(el.data, name);
   if (typeof name === 'string' && value !== undefined) {
     el.data[name] = value;
   }
@@ -424,7 +419,7 @@ exports.removeAttr = function (name) {
  * @see {@link http://api.jquery.com/hasClass/}
  */
 exports.hasClass = function (className) {
-  return _.some(this, function (elem) {
+  return Array.from(this).some(function (elem) {
     var attrs = elem.attribs,
         clazz = attrs && attrs['class'],
         idx = -1,

--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -100,7 +100,7 @@ exports.attr = function (name, value) {
 
       if (typeof name === 'object') {
         Object.keys(name).forEach(function (objName) {
-          const objValue = name[objName];
+          var objValue = name[objName];
           setAttr(el, objName, objValue);
         });
       } else {
@@ -185,7 +185,7 @@ exports.prop = function (name, value) {
 
       if (typeof name === 'object') {
         Object.keys(name).forEach(function (key) {
-          const val = name[key];
+          var val = name[key];
           setProp(el, key, val);
         });
       } else {

--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -421,7 +421,7 @@ exports.removeAttr = function (name) {
  * @see {@link http://api.jquery.com/hasClass/}
  */
 exports.hasClass = function (className) {
-  return Array.from(this).some(function (elem) {
+  return this.toArray().some(function (elem) {
     var attrs = elem.attribs,
       clazz = attrs && attrs['class'],
       idx = -1,

--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -99,7 +99,7 @@ exports.attr = function (name, value) {
       if (!isTag(el)) return;
 
       if (typeof name === 'object') {
-        Object.keys(name).forEach((objName) => {
+        Object.keys(name).forEach(function (objName) {
           const objValue = name[objName];
           setAttr(el, objName, objValue);
         });
@@ -152,7 +152,7 @@ exports.prop = function (name, value) {
       case 'style':
         property = this.css();
 
-        Object.keys(property).forEach((p) => {
+        Object.keys(property).forEach(function (p) {
           property[i++] = p;
         });
 
@@ -184,7 +184,7 @@ exports.prop = function (name, value) {
       if (!isTag(el)) return;
 
       if (typeof name === 'object') {
-        Object.keys(name).forEach((key) => {
+        Object.keys(name).forEach(function (key) {
           const val = name[key];
           setProp(el, key, val);
         });

--- a/lib/api/css.js
+++ b/lib/api/css.js
@@ -5,10 +5,7 @@
 exports = exports; // eslint-disable-line no-self-assign
 // The preceeding statement is necessary for proper documentation generation.
 
-var domEach = require('../utils').domEach,
-    _ = {
-      pick: require('lodash/pick'),
-    };
+var domEach = require('../utils').domEach;
 
 var toString = Object.prototype.toString;
 
@@ -85,7 +82,13 @@ function getCss(el, prop) {
   if (typeof prop === 'string') {
     return styles[prop];
   } else if (Array.isArray(prop)) {
-    return _.pick(styles, prop);
+    var newStyles = {};
+    for (const item of prop) {
+      if (styles[item] != null) {
+        newStyles[item] = styles[item];
+      }
+    }
+    return newStyles;
   } else {
     return styles;
   }

--- a/lib/api/css.js
+++ b/lib/api/css.js
@@ -83,11 +83,11 @@ function getCss(el, prop) {
     return styles[prop];
   } else if (Array.isArray(prop)) {
     var newStyles = {};
-    for (const item of prop) {
+    prop.forEach((item) => {
       if (styles[item] != null) {
         newStyles[item] = styles[item];
       }
-    }
+    });
     return newStyles;
   } else {
     return styles;

--- a/lib/api/css.js
+++ b/lib/api/css.js
@@ -83,7 +83,7 @@ function getCss(el, prop) {
     return styles[prop];
   } else if (Array.isArray(prop)) {
     var newStyles = {};
-    prop.forEach((item) => {
+    prop.forEach(function (item) {
       if (styles[item] != null) {
         newStyles[item] = styles[item];
       }

--- a/lib/api/forms.js
+++ b/lib/api/forms.js
@@ -9,10 +9,7 @@ exports = exports; // eslint-disable-line no-self-assign
 // https://github.com/jquery/jquery/blob/2.1.3/src/serialize.js
 var submittableSelector = 'input,select,textarea,keygen',
     r20 = /%20/g,
-    rCRLF = /\r?\n/g,
-    _ = {
-      map: require('lodash/map'),
-    };
+    rCRLF = /\r?\n/g;
 
 /**
  * Encode a set of form elements as a string for submission.
@@ -24,7 +21,7 @@ exports.serialize = function () {
   var arr = this.serializeArray();
 
   // Serialize each element into a key/value string
-  var retArr = _.map(arr, function (data) {
+  var retArr = arr.map(function (data) {
     return encodeURIComponent(data.name) + '=' + encodeURIComponent(data.value);
   });
 
@@ -74,7 +71,7 @@ exports.serializeArray = function () {
 
       // If we have an array of values (e.g. `<select multiple>`), return an array of key/value pairs
       if (Array.isArray(value)) {
-        return _.map(value, function (val) {
+        return value.map(function (val) {
           // We trim replace any line endings (e.g. `\r` or `\r\n` with `\r\n`) to guarantee consistency across platforms
           //   These can occur inside of `<textarea>'s`
           return { name: name, value: val.replace(rCRLF, '\r\n') };

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -32,11 +32,12 @@ exports._makeDomArray = function makeDomArray(elem, clone) {
   } else if (elem.cheerio) {
     return clone ? cloneDom(elem.get(), elem.options) : elem.get();
   } else if (Array.isArray(elem)) {
-    var newElems = [];
-    elem.forEach(function (el) {
-      newElems = newElems.concat(this._makeDomArray(el, clone));
-    }, this);
-    return newElems;
+    return elem.reduce(
+      function (newElems, el) {
+        return newElems.concat(this._makeDomArray(el, clone));
+      }.bind(this),
+      []
+    );
   } else if (typeof elem === 'string') {
     return evaluate(elem, this.options, false);
   } else {
@@ -275,7 +276,8 @@ exports.wrap = function (wrapper) {
   var wrapperFn = typeof wrapper === 'function' && wrapper,
     lastIdx = this.length - 1;
 
-  this.toArray().forEach(function (el, i) {
+  for (var i = 0; i < this.length; i++) {
+    var el = this[i];
     var parent = el.parent || el.root,
       siblings = parent.children,
       wrapperDom,
@@ -320,7 +322,7 @@ exports.wrap = function (wrapper) {
     // array, so the `dom` array can be inserted without removing any
     // additional elements.
     uniqueSplice(siblings, index, 0, wrapperDom, parent);
-  }, this);
+  }
 
   return this;
 };
@@ -368,7 +370,8 @@ exports.wrapInner = function (wrapper) {
   var wrapperFn = typeof wrapper === 'function' && wrapper,
     lastIdx = this.length - 1;
 
-  this.toArray().forEach(function (el, i) {
+  for (var i = 0; i < this.length; i++) {
+    var el = this[i];
     var children = el.children,
       wrapperDom,
       elInsertLocation,
@@ -403,7 +406,7 @@ exports.wrapInner = function (wrapper) {
 
     updateDOM(children, elInsertLocation);
     updateDOM(wrapperDom, el);
-  }, this);
+  }
 
   return this;
 };

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -33,9 +33,9 @@ exports._makeDomArray = function makeDomArray(elem, clone) {
     return clone ? cloneDom(elem.get(), elem.options) : elem.get();
   } else if (Array.isArray(elem)) {
     const newElems = [];
-    elem.forEach((el) => {
+    elem.forEach(function (el) {
       newElems.push(...this._makeDomArray(el, clone));
-    });
+    }, this);
     return newElems;
   } else if (typeof elem === 'string') {
     return evaluate(elem, this.options, false);
@@ -275,7 +275,7 @@ exports.wrap = function (wrapper) {
   var wrapperFn = typeof wrapper === 'function' && wrapper,
     lastIdx = this.length - 1;
 
-  Array.from(this).forEach((el, i) => {
+  Array.from(this).forEach(function (el, i) {
     var parent = el.parent || el.root,
       siblings = parent.children,
       wrapperDom,
@@ -320,7 +320,7 @@ exports.wrap = function (wrapper) {
     // array, so the `dom` array can be inserted without removing any
     // additional elements.
     uniqueSplice(siblings, index, 0, wrapperDom, parent);
-  });
+  }, this);
 
   return this;
 };
@@ -368,7 +368,7 @@ exports.wrapInner = function (wrapper) {
   var wrapperFn = typeof wrapper === 'function' && wrapper,
     lastIdx = this.length - 1;
 
-  Array.from(this).forEach((el, i) => {
+  Array.from(this).forEach(function (el, i) {
     var children = el.children,
       wrapperDom,
       elInsertLocation,
@@ -403,7 +403,7 @@ exports.wrapInner = function (wrapper) {
 
     updateDOM(children, elInsertLocation);
     updateDOM(wrapperDom, el);
-  });
+  }, this);
 
   return this;
 };

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -32,7 +32,7 @@ exports._makeDomArray = function makeDomArray(elem, clone) {
   } else if (elem.cheerio) {
     return clone ? cloneDom(elem.get(), elem.options) : elem.get();
   } else if (Array.isArray(elem)) {
-    const newElems = [];
+    var newElems = [];
     elem.forEach(function (el) {
       newElems.push(...this._makeDomArray(el, clone));
     }, this);

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -33,9 +33,9 @@ exports._makeDomArray = function makeDomArray(elem, clone) {
     return clone ? cloneDom(elem.get(), elem.options) : elem.get();
   } else if (Array.isArray(elem)) {
     const newElems = [];
-    for (const el of elem) {
+    elem.forEach((el) => {
       newElems.push(...this._makeDomArray(el, clone));
-    }
+    });
     return newElems;
   } else if (typeof elem === 'string') {
     return evaluate(elem, this.options, false);

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -8,15 +8,15 @@ exports = exports; // eslint-disable-line no-self-assign
 // The preceeding statement is necessary for proper documentation generation.
 
 var parse = require('../parse'),
-  html = require('../static').html,
-  text = require('../static').text,
-  updateDOM = parse.update,
-  evaluate = parse.evaluate,
-  utils = require('../utils'),
-  domEach = utils.domEach,
-  cloneDom = utils.cloneDom,
-  isHtml = utils.isHtml,
-  slice = Array.prototype.slice;
+    html = require('../static').html,
+    text = require('../static').text,
+    updateDOM = parse.update,
+    evaluate = parse.evaluate,
+    utils = require('../utils'),
+    domEach = utils.domEach,
+    cloneDom = utils.cloneDom,
+    isHtml = utils.isHtml,
+    slice = Array.prototype.slice;
 
 /**
  * Create an array of nodes, recursing into arrays and parsing strings if
@@ -48,7 +48,7 @@ exports._makeDomArray = function makeDomArray(elem, clone) {
 var _insert = function (concatenator) {
   return function () {
     var elems = slice.call(arguments),
-      lastIdx = this.length - 1;
+        lastIdx = this.length - 1;
 
     return domEach(this, function (i, el) {
       var dom, domSrc;
@@ -78,8 +78,8 @@ var _insert = function (concatenator) {
  */
 var uniqueSplice = function (array, spliceIdx, spliceCount, newElems, parent) {
   var spliceArgs = [spliceIdx, spliceCount].concat(newElems),
-    prev = array[spliceIdx - 1] || null,
-    next = array[spliceIdx] || null;
+      prev = array[spliceIdx - 1] || null,
+      next = array[spliceIdx] || null;
   var idx, len, prevIdx, node, oldParent;
 
   // Before splicing in new elements, ensure they do not already appear in the
@@ -274,16 +274,16 @@ exports.prepend = _insert(function (dom, children, parent) {
  */
 exports.wrap = function (wrapper) {
   var wrapperFn = typeof wrapper === 'function' && wrapper,
-    lastIdx = this.length - 1;
+      lastIdx = this.length - 1;
 
   for (var i = 0; i < this.length; i++) {
     var el = this[i];
     var parent = el.parent || el.root,
-      siblings = parent.children,
-      wrapperDom,
-      elInsertLocation,
-      j,
-      index;
+        siblings = parent.children,
+        wrapperDom,
+        elInsertLocation,
+        j,
+        index;
 
     if (!parent) {
       return;
@@ -368,14 +368,14 @@ exports.wrap = function (wrapper) {
  */
 exports.wrapInner = function (wrapper) {
   var wrapperFn = typeof wrapper === 'function' && wrapper,
-    lastIdx = this.length - 1;
+      lastIdx = this.length - 1;
 
   for (var i = 0; i < this.length; i++) {
     var el = this[i];
     var children = el.children,
-      wrapperDom,
-      elInsertLocation,
-      j;
+        wrapperDom,
+        elInsertLocation,
+        j;
 
     if (wrapperFn) {
       wrapper = wrapperFn.call(el, i);
@@ -429,7 +429,7 @@ exports.wrapInner = function (wrapper) {
  */
 exports.after = function () {
   var elems = slice.call(arguments),
-    lastIdx = this.length - 1;
+      lastIdx = this.length - 1;
 
   domEach(this, function (i, el) {
     var parent = el.parent || el.root;
@@ -438,9 +438,9 @@ exports.after = function () {
     }
 
     var siblings = parent.children,
-      index = siblings.indexOf(el),
-      domSrc,
-      dom;
+        index = siblings.indexOf(el),
+        domSrc,
+        dom;
 
     // If not found, move on
     if (index < 0) return;
@@ -479,7 +479,7 @@ exports.after = function () {
  */
 exports.insertAfter = function (target) {
   var clones = [],
-    self = this;
+      self = this;
   if (typeof target === 'string') {
     target = this.constructor.call(
       this.constructor,
@@ -498,7 +498,7 @@ exports.insertAfter = function (target) {
     }
 
     var siblings = parent.children,
-      index = siblings.indexOf(el);
+        index = siblings.indexOf(el);
 
     // If not found, move on
     if (index < 0) return;
@@ -528,7 +528,7 @@ exports.insertAfter = function (target) {
  */
 exports.before = function () {
   var elems = slice.call(arguments),
-    lastIdx = this.length - 1;
+      lastIdx = this.length - 1;
 
   domEach(this, function (i, el) {
     var parent = el.parent || el.root;
@@ -537,9 +537,9 @@ exports.before = function () {
     }
 
     var siblings = parent.children,
-      index = siblings.indexOf(el),
-      domSrc,
-      dom;
+        index = siblings.indexOf(el),
+        domSrc,
+        dom;
 
     // If not found, move on
     if (index < 0) return;
@@ -579,7 +579,7 @@ exports.before = function () {
  */
 exports.insertBefore = function (target) {
   var clones = [],
-    self = this;
+      self = this;
   if (typeof target === 'string') {
     target = this.constructor.call(
       this.constructor,
@@ -598,7 +598,7 @@ exports.insertBefore = function (target) {
     }
 
     var siblings = parent.children,
-      index = siblings.indexOf(el);
+        index = siblings.indexOf(el);
 
     // If not found, move on
     if (index < 0) return;
@@ -640,7 +640,7 @@ exports.remove = function (selector) {
     }
 
     var siblings = parent.children,
-      index = siblings.indexOf(el);
+        index = siblings.indexOf(el);
 
     if (index < 0) return;
 
@@ -685,10 +685,10 @@ exports.replaceWith = function (content) {
     }
 
     var siblings = parent.children,
-      dom = self._makeDomArray(
-        typeof content === 'function' ? content.call(el, i, el) : content
-      ),
-      index;
+        dom = self._makeDomArray(
+          typeof content === 'function' ? content.call(el, i, el) : content
+        ),
+        index;
 
     // In the case that `dom` contains nodes that already exist in other
     // structures, ensure those nodes are properly removed.

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -34,7 +34,7 @@ exports._makeDomArray = function makeDomArray(elem, clone) {
   } else if (Array.isArray(elem)) {
     var newElems = [];
     elem.forEach(function (el) {
-      newElems.push(...this._makeDomArray(el, clone));
+      newElems = newElems.concat(this._makeDomArray(el, clone));
     }, this);
     return newElems;
   } else if (typeof elem === 'string') {

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -8,20 +8,15 @@ exports = exports; // eslint-disable-line no-self-assign
 // The preceeding statement is necessary for proper documentation generation.
 
 var parse = require('../parse'),
-    html = require('../static').html,
-    text = require('../static').text,
-    updateDOM = parse.update,
-    evaluate = parse.evaluate,
-    utils = require('../utils'),
-    domEach = utils.domEach,
-    cloneDom = utils.cloneDom,
-    isHtml = utils.isHtml,
-    slice = Array.prototype.slice,
-    _ = {
-      flatten: require('lodash/flatten'),
-      bind: require('lodash/bind'),
-      forEach: require('lodash/forEach'),
-    };
+  html = require('../static').html,
+  text = require('../static').text,
+  updateDOM = parse.update,
+  evaluate = parse.evaluate,
+  utils = require('../utils'),
+  domEach = utils.domEach,
+  cloneDom = utils.cloneDom,
+  isHtml = utils.isHtml,
+  slice = Array.prototype.slice;
 
 /**
  * Create an array of nodes, recursing into arrays and parsing strings if
@@ -37,11 +32,11 @@ exports._makeDomArray = function makeDomArray(elem, clone) {
   } else if (elem.cheerio) {
     return clone ? cloneDom(elem.get(), elem.options) : elem.get();
   } else if (Array.isArray(elem)) {
-    return _.flatten(
-      elem.map(function (el) {
-        return this._makeDomArray(el, clone);
-      }, this)
-    );
+    const newElems = [];
+    for (const el of elem) {
+      newElems.push(...this._makeDomArray(el, clone));
+    }
+    return newElems;
   } else if (typeof elem === 'string') {
     return evaluate(elem, this.options, false);
   } else {
@@ -52,7 +47,7 @@ exports._makeDomArray = function makeDomArray(elem, clone) {
 var _insert = function (concatenator) {
   return function () {
     var elems = slice.call(arguments),
-        lastIdx = this.length - 1;
+      lastIdx = this.length - 1;
 
     return domEach(this, function (i, el) {
       var dom, domSrc;
@@ -82,8 +77,8 @@ var _insert = function (concatenator) {
  */
 var uniqueSplice = function (array, spliceIdx, spliceCount, newElems, parent) {
   var spliceArgs = [spliceIdx, spliceCount].concat(newElems),
-      prev = array[spliceIdx - 1] || null,
-      next = array[spliceIdx] || null;
+    prev = array[spliceIdx - 1] || null,
+    next = array[spliceIdx] || null;
   var idx, len, prevIdx, node, oldParent;
 
   // Before splicing in new elements, ensure they do not already appear in the
@@ -278,57 +273,54 @@ exports.prepend = _insert(function (dom, children, parent) {
  */
 exports.wrap = function (wrapper) {
   var wrapperFn = typeof wrapper === 'function' && wrapper,
-      lastIdx = this.length - 1;
+    lastIdx = this.length - 1;
 
-  _.forEach(
-    this,
-    _.bind(function (el, i) {
-      var parent = el.parent || el.root,
-          siblings = parent.children,
-          wrapperDom,
-          elInsertLocation,
-          j,
-          index;
+  Array.from(this).forEach((el, i) => {
+    var parent = el.parent || el.root,
+      siblings = parent.children,
+      wrapperDom,
+      elInsertLocation,
+      j,
+      index;
 
-      if (!parent) {
-        return;
+    if (!parent) {
+      return;
+    }
+
+    if (wrapperFn) {
+      wrapper = wrapperFn.call(el, i);
+    }
+
+    if (typeof wrapper === 'string' && !isHtml(wrapper)) {
+      wrapper = this.parents().last().find(wrapper).clone();
+    }
+
+    wrapperDom = this._makeDomArray(wrapper, i < lastIdx).slice(0, 1);
+    elInsertLocation = wrapperDom[0];
+    // Find the deepest child. Only consider the first tag child of each node
+    // (ignore text); stop if no children are found.
+    j = 0;
+
+    while (elInsertLocation && elInsertLocation.children) {
+      if (j >= elInsertLocation.children.length) {
+        break;
       }
 
-      if (wrapperFn) {
-        wrapper = wrapperFn.call(el, i);
+      if (elInsertLocation.children[j].type === 'tag') {
+        elInsertLocation = elInsertLocation.children[j];
+        j = 0;
+      } else {
+        j++;
       }
+    }
+    index = siblings.indexOf(el);
 
-      if (typeof wrapper === 'string' && !isHtml(wrapper)) {
-        wrapper = this.parents().last().find(wrapper).clone();
-      }
-
-      wrapperDom = this._makeDomArray(wrapper, i < lastIdx).slice(0, 1);
-      elInsertLocation = wrapperDom[0];
-      // Find the deepest child. Only consider the first tag child of each node
-      // (ignore text); stop if no children are found.
-      j = 0;
-
-      while (elInsertLocation && elInsertLocation.children) {
-        if (j >= elInsertLocation.children.length) {
-          break;
-        }
-
-        if (elInsertLocation.children[j].type === 'tag') {
-          elInsertLocation = elInsertLocation.children[j];
-          j = 0;
-        } else {
-          j++;
-        }
-      }
-      index = siblings.indexOf(el);
-
-      updateDOM([el], elInsertLocation);
-      // The previous operation removed the current element from the `siblings`
-      // array, so the `dom` array can be inserted without removing any
-      // additional elements.
-      uniqueSplice(siblings, index, 0, wrapperDom, parent);
-    }, this)
-  );
+    updateDOM([el], elInsertLocation);
+    // The previous operation removed the current element from the `siblings`
+    // array, so the `dom` array can be inserted without removing any
+    // additional elements.
+    uniqueSplice(siblings, index, 0, wrapperDom, parent);
+  });
 
   return this;
 };
@@ -374,47 +366,44 @@ exports.wrap = function (wrapper) {
  */
 exports.wrapInner = function (wrapper) {
   var wrapperFn = typeof wrapper === 'function' && wrapper,
-      lastIdx = this.length - 1;
+    lastIdx = this.length - 1;
 
-  _.forEach(
-    this,
-    _.bind(function (el, i) {
-      var children = el.children,
-          wrapperDom,
-          elInsertLocation,
-          j;
+  Array.from(this).forEach((el, i) => {
+    var children = el.children,
+      wrapperDom,
+      elInsertLocation,
+      j;
 
-      if (wrapperFn) {
-        wrapper = wrapperFn.call(el, i);
+    if (wrapperFn) {
+      wrapper = wrapperFn.call(el, i);
+    }
+
+    if (typeof wrapper === 'string' && !isHtml(wrapper)) {
+      wrapper = this.parents().last().find(wrapper).clone();
+    }
+
+    wrapperDom = this._makeDomArray(wrapper, i < lastIdx).slice(0, 1);
+    elInsertLocation = wrapperDom[0];
+    // Find the deepest child. Only consider the first tag child of each node
+    // (ignore text); stop if no children are found.
+    j = 0;
+
+    while (elInsertLocation && elInsertLocation.children) {
+      if (j >= elInsertLocation.children.length) {
+        break;
       }
 
-      if (typeof wrapper === 'string' && !isHtml(wrapper)) {
-        wrapper = this.parents().last().find(wrapper).clone();
+      if (elInsertLocation.children[j].type === 'tag') {
+        elInsertLocation = elInsertLocation.children[j];
+        j = 0;
+      } else {
+        j++;
       }
+    }
 
-      wrapperDom = this._makeDomArray(wrapper, i < lastIdx).slice(0, 1);
-      elInsertLocation = wrapperDom[0];
-      // Find the deepest child. Only consider the first tag child of each node
-      // (ignore text); stop if no children are found.
-      j = 0;
-
-      while (elInsertLocation && elInsertLocation.children) {
-        if (j >= elInsertLocation.children.length) {
-          break;
-        }
-
-        if (elInsertLocation.children[j].type === 'tag') {
-          elInsertLocation = elInsertLocation.children[j];
-          j = 0;
-        } else {
-          j++;
-        }
-      }
-
-      updateDOM(children, elInsertLocation);
-      updateDOM(wrapperDom, el);
-    }, this)
-  );
+    updateDOM(children, elInsertLocation);
+    updateDOM(wrapperDom, el);
+  });
 
   return this;
 };
@@ -437,7 +426,7 @@ exports.wrapInner = function (wrapper) {
  */
 exports.after = function () {
   var elems = slice.call(arguments),
-      lastIdx = this.length - 1;
+    lastIdx = this.length - 1;
 
   domEach(this, function (i, el) {
     var parent = el.parent || el.root;
@@ -446,9 +435,9 @@ exports.after = function () {
     }
 
     var siblings = parent.children,
-        index = siblings.indexOf(el),
-        domSrc,
-        dom;
+      index = siblings.indexOf(el),
+      domSrc,
+      dom;
 
     // If not found, move on
     if (index < 0) return;
@@ -487,7 +476,7 @@ exports.after = function () {
  */
 exports.insertAfter = function (target) {
   var clones = [],
-      self = this;
+    self = this;
   if (typeof target === 'string') {
     target = this.constructor.call(
       this.constructor,
@@ -506,7 +495,7 @@ exports.insertAfter = function (target) {
     }
 
     var siblings = parent.children,
-        index = siblings.indexOf(el);
+      index = siblings.indexOf(el);
 
     // If not found, move on
     if (index < 0) return;
@@ -536,7 +525,7 @@ exports.insertAfter = function (target) {
  */
 exports.before = function () {
   var elems = slice.call(arguments),
-      lastIdx = this.length - 1;
+    lastIdx = this.length - 1;
 
   domEach(this, function (i, el) {
     var parent = el.parent || el.root;
@@ -545,9 +534,9 @@ exports.before = function () {
     }
 
     var siblings = parent.children,
-        index = siblings.indexOf(el),
-        domSrc,
-        dom;
+      index = siblings.indexOf(el),
+      domSrc,
+      dom;
 
     // If not found, move on
     if (index < 0) return;
@@ -587,7 +576,7 @@ exports.before = function () {
  */
 exports.insertBefore = function (target) {
   var clones = [],
-      self = this;
+    self = this;
   if (typeof target === 'string') {
     target = this.constructor.call(
       this.constructor,
@@ -606,7 +595,7 @@ exports.insertBefore = function (target) {
     }
 
     var siblings = parent.children,
-        index = siblings.indexOf(el);
+      index = siblings.indexOf(el);
 
     // If not found, move on
     if (index < 0) return;
@@ -648,7 +637,7 @@ exports.remove = function (selector) {
     }
 
     var siblings = parent.children,
-        index = siblings.indexOf(el);
+      index = siblings.indexOf(el);
 
     if (index < 0) return;
 
@@ -693,10 +682,10 @@ exports.replaceWith = function (content) {
     }
 
     var siblings = parent.children,
-        dom = self._makeDomArray(
-          typeof content === 'function' ? content.call(el, i, el) : content
-        ),
-        index;
+      dom = self._makeDomArray(
+        typeof content === 'function' ? content.call(el, i, el) : content
+      ),
+      index;
 
     // In the case that `dom` contains nodes that already exist in other
     // structures, ensure those nodes are properly removed.
@@ -725,7 +714,7 @@ exports.replaceWith = function (content) {
  */
 exports.empty = function () {
   domEach(this, function (i, el) {
-    _.forEach(el.children, function (child) {
+    el.children.forEach(function (child) {
       child.next = child.prev = child.parent = null;
     });
 
@@ -760,7 +749,7 @@ exports.html = function (str) {
   var opts = this.options;
 
   domEach(this, function (i, el) {
-    _.forEach(el.children, function (child) {
+    el.children.forEach(function (child) {
       child.next = child.prev = child.parent = null;
     });
 
@@ -813,7 +802,7 @@ exports.text = function (str) {
 
   // Append text node to each selected elements
   domEach(this, function (i, el) {
-    _.forEach(el.children, function (child) {
+    el.children.forEach(function (child) {
       child.next = child.prev = child.parent = null;
     });
 

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -275,7 +275,7 @@ exports.wrap = function (wrapper) {
   var wrapperFn = typeof wrapper === 'function' && wrapper,
     lastIdx = this.length - 1;
 
-  Array.from(this).forEach(function (el, i) {
+  this.toArray().forEach(function (el, i) {
     var parent = el.parent || el.root,
       siblings = parent.children,
       wrapperDom,
@@ -368,7 +368,7 @@ exports.wrapInner = function (wrapper) {
   var wrapperFn = typeof wrapper === 'function' && wrapper,
     lastIdx = this.length - 1;
 
-  Array.from(this).forEach(function (el, i) {
+  this.toArray().forEach(function (el, i) {
     var children = el.children,
       wrapperDom,
       elInsertLocation,

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -31,7 +31,7 @@ var select = require('css-select'),
 exports.find = function (selectorOrHaystack) {
   var elems = [];
   this.toArray().forEach(function (elem) {
-    elems.push(...elem.children.filter(isTag));
+    elems = elems.concat(elem.children.filter(isTag));
   });
   var contains = this.constructor.contains;
   var haystack;
@@ -505,7 +505,7 @@ exports.siblings = function (selector) {
 exports.children = function (selector) {
   var elems = [];
   this.toArray().forEach(function (elem) {
-    elems.push(...elem.children.filter(isTag));
+    elems = elems.concat(elem.children.filter(isTag));
   });
 
   if (selector === undefined) return this._make(elems);
@@ -525,9 +525,9 @@ exports.children = function (selector) {
  * @see {@link http://api.jquery.com/contents/}
  */
 exports.contents = function () {
-  const elems = [];
+  var elems = [];
   this.toArray().forEach(function (elem) {
-    elems.push(...elem.children);
+    elems = elems.concat(elem.children);
   });
   return this._make(elems);
 };
@@ -582,15 +582,11 @@ exports.each = function (fn) {
  * @see {@link http://api.jquery.com/map/}
  */
 exports.map = function (fn) {
-  const elems = [];
+  var elems = [];
   Array.from(this).forEach(function (el, i) {
     var val = fn.call(el, i, el);
     if (val != null) {
-      if (Array.isArray(val)) {
-        elems.push(...val);
-      } else {
-        elems.push(val);
-      }
+      elems = elems.concat(val);
     }
   });
   return this._make(elems);

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -8,10 +8,10 @@ exports = exports; // eslint-disable-line no-self-assign
 // The preceeding statement is necessary for proper documentation generation.
 
 var select = require('css-select'),
-  utils = require('../utils'),
-  domEach = utils.domEach,
-  uniqueSort = require('htmlparser2').DomUtils.uniqueSort,
-  isTag = utils.isTag;
+    utils = require('../utils'),
+    domEach = utils.domEach,
+    uniqueSort = require('htmlparser2').DomUtils.uniqueSort,
+    isTag = utils.isTag;
 
 /**
  * Get the descendants of each element in the current set of matched elements,
@@ -142,8 +142,8 @@ exports.parents = function (selector) {
  */
 exports.parentsUntil = function (selector, filter) {
   var parentNodes = [],
-    untilNode,
-    untilNodes;
+      untilNode,
+      untilNodes;
 
   if (typeof selector === 'string') {
     untilNode = select(selector, this.parents().toArray(), this.options)[0];
@@ -305,8 +305,8 @@ exports.nextUntil = function (selector, filterSelector) {
     return this;
   }
   var elems = [],
-    untilNode,
-    untilNodes;
+      untilNode,
+      untilNodes;
 
   if (typeof selector === 'string') {
     untilNode = select(selector, this.nextAll().get(), this.options)[0];
@@ -423,8 +423,8 @@ exports.prevUntil = function (selector, filterSelector) {
     return this;
   }
   var elems = [],
-    untilNode,
-    untilNodes;
+      untilNode,
+      untilNodes;
 
   if (typeof selector === 'string') {
     untilNode = select(selector, this.prevAll().get(), this.options)[0];
@@ -553,7 +553,7 @@ exports.contents = function () {
  */
 exports.each = function (fn) {
   var i = 0,
-    len = this.length;
+      len = this.length;
   while (i < len && fn.call(this[i], i, this[i]) !== false) ++i;
   return this;
 };

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -30,9 +30,9 @@ var select = require('css-select'),
  */
 exports.find = function (selectorOrHaystack) {
   var elems = [];
-  for (const elem of Array.from(this)) {
+  this.toArray().forEach((elem) => {
     elems.push(...elem.children.filter(isTag));
-  }
+  });
   var contains = this.constructor.contains;
   var haystack;
 
@@ -504,9 +504,9 @@ exports.siblings = function (selector) {
  */
 exports.children = function (selector) {
   var elems = [];
-  for (const elem of Array.from(this)) {
+  this.toArray().forEach((elem) => {
     elems.push(...elem.children.filter(isTag));
-  }
+  });
 
   if (selector === undefined) return this._make(elems);
 
@@ -526,9 +526,9 @@ exports.children = function (selector) {
  */
 exports.contents = function () {
   const elems = [];
-  for (const elem of Array.from(this)) {
+  this.toArray().forEach((elem) => {
     elems.push(...elem.children);
-  }
+  });
   return this._make(elems);
 };
 

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -239,7 +239,7 @@ exports.next = function (selector) {
   }
   var elems = [];
 
-  Array.from(this).forEach(function (elem) {
+  this.toArray().forEach(function (elem) {
     while ((elem = elem.next)) {
       if (isTag(elem)) {
         elems.push(elem);
@@ -274,7 +274,7 @@ exports.nextAll = function (selector) {
   }
   var elems = [];
 
-  Array.from(this).forEach(function (elem) {
+  this.toArray().forEach(function (elem) {
     while ((elem = elem.next)) {
       if (isTag(elem) && elems.indexOf(elem) === -1) {
         elems.push(elem);
@@ -317,7 +317,7 @@ exports.nextUntil = function (selector, filterSelector) {
     untilNode = selector;
   }
 
-  Array.from(this).forEach(function (elem) {
+  this.toArray().forEach(function (elem) {
     while ((elem = elem.next)) {
       if (
         (untilNode && elem !== untilNode) ||
@@ -357,7 +357,7 @@ exports.prev = function (selector) {
   }
   var elems = [];
 
-  Array.from(this).forEach(function (elem) {
+  this.toArray().forEach(function (elem) {
     while ((elem = elem.prev)) {
       if (isTag(elem)) {
         elems.push(elem);
@@ -392,7 +392,7 @@ exports.prevAll = function (selector) {
   }
   var elems = [];
 
-  Array.from(this).forEach(function (elem) {
+  this.toArray().forEach(function (elem) {
     while ((elem = elem.prev)) {
       if (isTag(elem) && elems.indexOf(elem) === -1) {
         elems.push(elem);
@@ -435,7 +435,7 @@ exports.prevUntil = function (selector, filterSelector) {
     untilNode = selector;
   }
 
-  Array.from(this).forEach(function (elem) {
+  this.toArray().forEach(function (elem) {
     while ((elem = elem.prev)) {
       if (
         (untilNode && elem !== untilNode) ||
@@ -474,11 +474,11 @@ exports.prevUntil = function (selector, filterSelector) {
 exports.siblings = function (selector) {
   var parent = this.parent();
 
-  var elems = Array.from(
-    parent ? parent.children() : this.siblingsAndMe()
-  ).filter(function (elem) {
-    return isTag(elem) && !this.is(elem);
-  }, this);
+  var elems = (parent ? parent.children() : this.siblingsAndMe())
+    .toArray()
+    .filter(function (elem) {
+      return isTag(elem) && !this.is(elem);
+    }, this);
 
   if (selector !== undefined) {
     return exports.filter.call(elems, selector, this);
@@ -583,7 +583,7 @@ exports.each = function (fn) {
  */
 exports.map = function (fn) {
   var elems = [];
-  Array.from(this).forEach(function (el, i) {
+  this.toArray().forEach(function (el, i) {
     var val = fn.call(el, i, el);
     if (val != null) {
       elems = elems.concat(val);
@@ -642,7 +642,7 @@ var makeFilterMethod = function (filterFn) {
  * @see {@link http://api.jquery.com/filter/}
  */
 exports.filter = makeFilterMethod(function (elements, test) {
-  return Array.from(elements).filter(test);
+  return (elements.toArray ? elements.toArray() : elements).filter(test);
 });
 
 /**
@@ -673,7 +673,7 @@ exports.filter = makeFilterMethod(function (elements, test) {
  * @see {@link http://api.jquery.com/not/}
  */
 exports.not = makeFilterMethod(function (elements, test) {
-  return Array.from(elements).filter(function (item, index) {
+  return elements.toArray().filter(function (item, index) {
     return test(item, index) === false;
   });
 });

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -30,7 +30,7 @@ var select = require('css-select'),
  */
 exports.find = function (selectorOrHaystack) {
   var elems = [];
-  this.toArray().forEach((elem) => {
+  this.toArray().forEach(function (elem) {
     elems.push(...elem.children.filter(isTag));
   });
   var contains = this.constructor.contains;
@@ -208,7 +208,7 @@ exports.closest = function (selector) {
     return this._make(set);
   }
 
-  domEach(this, (idx, elem) => {
+  domEach(this, function (idx, elem) {
     var closestElem = traverseParents(this, elem, selector, 1)[0];
 
     // Do not add duplicate elements to the set
@@ -476,9 +476,9 @@ exports.siblings = function (selector) {
 
   var elems = Array.from(
     parent ? parent.children() : this.siblingsAndMe()
-  ).filter((elem) => {
+  ).filter(function (elem) {
     return isTag(elem) && !this.is(elem);
-  });
+  }, this);
 
   if (selector !== undefined) {
     return exports.filter.call(elems, selector, this);
@@ -504,7 +504,7 @@ exports.siblings = function (selector) {
  */
 exports.children = function (selector) {
   var elems = [];
-  this.toArray().forEach((elem) => {
+  this.toArray().forEach(function (elem) {
     elems.push(...elem.children.filter(isTag));
   });
 
@@ -526,7 +526,7 @@ exports.children = function (selector) {
  */
 exports.contents = function () {
   const elems = [];
-  this.toArray().forEach((elem) => {
+  this.toArray().forEach(function (elem) {
     elems.push(...elem.children);
   });
   return this._make(elems);
@@ -583,7 +583,7 @@ exports.each = function (fn) {
  */
 exports.map = function (fn) {
   const elems = [];
-  Array.from(this).forEach((el, i) => {
+  Array.from(this).forEach(function (el, i) {
     var val = fn.call(el, i, el);
     if (val != null) {
       if (Array.isArray(val)) {
@@ -645,9 +645,9 @@ var makeFilterMethod = function (filterFn) {
  *
  * @see {@link http://api.jquery.com/filter/}
  */
-exports.filter = makeFilterMethod((elements, test) =>
-  Array.from(elements).filter(test)
-);
+exports.filter = makeFilterMethod(function (elements, test) {
+  return Array.from(elements).filter(test);
+});
 
 /**
  * Remove elements from the set of matched elements. Given a jQuery object that
@@ -676,9 +676,11 @@ exports.filter = makeFilterMethod((elements, test) =>
  *
  * @see {@link http://api.jquery.com/not/}
  */
-exports.not = makeFilterMethod((elements, test) =>
-  Array.from(elements).filter((item, index) => test(item, index) === false)
-);
+exports.not = makeFilterMethod(function (elements, test) {
+  return Array.from(elements).filter(function (item, index) {
+    return test(item, index) === false;
+  });
+});
 
 /**
  * Filters the set of matched elements to only those which have the given DOM

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -29,10 +29,9 @@ var select = require('css-select'),
  * @see {@link http://api.jquery.com/find/}
  */
 exports.find = function (selectorOrHaystack) {
-  var elems = [];
-  this.toArray().forEach(function (elem) {
-    elems = elems.concat(elem.children.filter(isTag));
-  });
+  var elems = this.toArray().reduce(function (newElems, elem) {
+    return newElems.concat(elem.children.filter(isTag));
+  }, []);
   var contains = this.constructor.contains;
   var haystack;
 
@@ -503,10 +502,9 @@ exports.siblings = function (selector) {
  * @see {@link http://api.jquery.com/children/}
  */
 exports.children = function (selector) {
-  var elems = [];
-  this.toArray().forEach(function (elem) {
-    elems = elems.concat(elem.children.filter(isTag));
-  });
+  var elems = this.toArray().reduce(function (newElems, elem) {
+    return newElems.concat(elem.children.filter(isTag));
+  }, []);
 
   if (selector === undefined) return this._make(elems);
 
@@ -525,10 +523,9 @@ exports.children = function (selector) {
  * @see {@link http://api.jquery.com/contents/}
  */
 exports.contents = function () {
-  var elems = [];
-  this.toArray().forEach(function (elem) {
-    elems = elems.concat(elem.children);
-  });
+  var elems = this.toArray().reduce(function (newElems, elem) {
+    return newElems.concat(elem.children);
+  }, []);
   return this._make(elems);
 };
 
@@ -583,12 +580,13 @@ exports.each = function (fn) {
  */
 exports.map = function (fn) {
   var elems = [];
-  this.toArray().forEach(function (el, i) {
+  for (var i = 0; i < this.length; i++) {
+    var el = this[i];
     var val = fn.call(el, i, el);
     if (val != null) {
       elems = elems.concat(val);
     }
-  });
+  }
   return this._make(elems);
 };
 

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -8,17 +8,10 @@ exports = exports; // eslint-disable-line no-self-assign
 // The preceeding statement is necessary for proper documentation generation.
 
 var select = require('css-select'),
-    utils = require('../utils'),
-    domEach = utils.domEach,
-    uniqueSort = require('htmlparser2').DomUtils.uniqueSort,
-    isTag = utils.isTag,
-    _ = {
-      bind: require('lodash/bind'),
-      forEach: require('lodash/forEach'),
-      reject: require('lodash/reject'),
-      filter: require('lodash/filter'),
-      reduce: require('lodash/reduce'),
-    };
+  utils = require('../utils'),
+  domEach = utils.domEach,
+  uniqueSort = require('htmlparser2').DomUtils.uniqueSort,
+  isTag = utils.isTag;
 
 /**
  * Get the descendants of each element in the current set of matched elements,
@@ -36,13 +29,10 @@ var select = require('css-select'),
  * @see {@link http://api.jquery.com/find/}
  */
 exports.find = function (selectorOrHaystack) {
-  var elems = _.reduce(
-    this,
-    function (memo, elem) {
-      return memo.concat(_.filter(elem.children, isTag));
-    },
-    []
-  );
+  var elems = [];
+  for (const elem of Array.from(this)) {
+    elems.push(...elem.children.filter(isTag));
+  }
   var contains = this.constructor.contains;
   var haystack;
 
@@ -153,8 +143,8 @@ exports.parents = function (selector) {
  */
 exports.parentsUntil = function (selector, filter) {
   var parentNodes = [],
-      untilNode,
-      untilNodes;
+    untilNode,
+    untilNodes;
 
   if (typeof selector === 'string') {
     untilNode = select(selector, this.parents().toArray(), this.options)[0];
@@ -218,17 +208,14 @@ exports.closest = function (selector) {
     return this._make(set);
   }
 
-  domEach(
-    this,
-    function (idx, elem) {
-      var closestElem = traverseParents(this, elem, selector, 1)[0];
+  domEach(this, (idx, elem) => {
+    var closestElem = traverseParents(this, elem, selector, 1)[0];
 
-      // Do not add duplicate elements to the set
-      if (closestElem && set.indexOf(closestElem) < 0) {
-        set.push(closestElem);
-      }
-    }.bind(this)
-  );
+    // Do not add duplicate elements to the set
+    if (closestElem && set.indexOf(closestElem) < 0) {
+      set.push(closestElem);
+    }
+  });
 
   return this._make(set);
 };
@@ -252,7 +239,7 @@ exports.next = function (selector) {
   }
   var elems = [];
 
-  _.forEach(this, function (elem) {
+  Array.from(this).forEach(function (elem) {
     while ((elem = elem.next)) {
       if (isTag(elem)) {
         elems.push(elem);
@@ -287,7 +274,7 @@ exports.nextAll = function (selector) {
   }
   var elems = [];
 
-  _.forEach(this, function (elem) {
+  Array.from(this).forEach(function (elem) {
     while ((elem = elem.next)) {
       if (isTag(elem) && elems.indexOf(elem) === -1) {
         elems.push(elem);
@@ -319,8 +306,8 @@ exports.nextUntil = function (selector, filterSelector) {
     return this;
   }
   var elems = [],
-      untilNode,
-      untilNodes;
+    untilNode,
+    untilNodes;
 
   if (typeof selector === 'string') {
     untilNode = select(selector, this.nextAll().get(), this.options)[0];
@@ -330,7 +317,7 @@ exports.nextUntil = function (selector, filterSelector) {
     untilNode = selector;
   }
 
-  _.forEach(this, function (elem) {
+  Array.from(this).forEach(function (elem) {
     while ((elem = elem.next)) {
       if (
         (untilNode && elem !== untilNode) ||
@@ -370,7 +357,7 @@ exports.prev = function (selector) {
   }
   var elems = [];
 
-  _.forEach(this, function (elem) {
+  Array.from(this).forEach(function (elem) {
     while ((elem = elem.prev)) {
       if (isTag(elem)) {
         elems.push(elem);
@@ -405,7 +392,7 @@ exports.prevAll = function (selector) {
   }
   var elems = [];
 
-  _.forEach(this, function (elem) {
+  Array.from(this).forEach(function (elem) {
     while ((elem = elem.prev)) {
       if (isTag(elem) && elems.indexOf(elem) === -1) {
         elems.push(elem);
@@ -437,8 +424,8 @@ exports.prevUntil = function (selector, filterSelector) {
     return this;
   }
   var elems = [],
-      untilNode,
-      untilNodes;
+    untilNode,
+    untilNodes;
 
   if (typeof selector === 'string') {
     untilNode = select(selector, this.prevAll().get(), this.options)[0];
@@ -448,7 +435,7 @@ exports.prevUntil = function (selector, filterSelector) {
     untilNode = selector;
   }
 
-  _.forEach(this, function (elem) {
+  Array.from(this).forEach(function (elem) {
     while ((elem = elem.prev)) {
       if (
         (untilNode && elem !== untilNode) ||
@@ -487,12 +474,11 @@ exports.prevUntil = function (selector, filterSelector) {
 exports.siblings = function (selector) {
   var parent = this.parent();
 
-  var elems = _.filter(
-    parent ? parent.children() : this.siblingsAndMe(),
-    _.bind(function (elem) {
-      return isTag(elem) && !this.is(elem);
-    }, this)
-  );
+  var elems = Array.from(
+    parent ? parent.children() : this.siblingsAndMe()
+  ).filter((elem) => {
+    return isTag(elem) && !this.is(elem);
+  });
 
   if (selector !== undefined) {
     return exports.filter.call(elems, selector, this);
@@ -517,13 +503,10 @@ exports.siblings = function (selector) {
  * @see {@link http://api.jquery.com/children/}
  */
 exports.children = function (selector) {
-  var elems = _.reduce(
-    this,
-    function (memo, elem) {
-      return memo.concat(_.filter(elem.children, isTag));
-    },
-    []
-  );
+  var elems = [];
+  for (const elem of Array.from(this)) {
+    elems.push(...elem.children.filter(isTag));
+  }
 
   if (selector === undefined) return this._make(elems);
 
@@ -542,16 +525,11 @@ exports.children = function (selector) {
  * @see {@link http://api.jquery.com/contents/}
  */
 exports.contents = function () {
-  return this._make(
-    _.reduce(
-      this,
-      function (all, elem) {
-        all.push.apply(all, elem.children);
-        return all;
-      },
-      []
-    )
-  );
+  const elems = [];
+  for (const elem of Array.from(this)) {
+    elems.push(...elem.children);
+  }
+  return this._make(elems);
 };
 
 /**
@@ -578,7 +556,7 @@ exports.contents = function () {
  */
 exports.each = function (fn) {
   var i = 0,
-      len = this.length;
+    len = this.length;
   while (i < len && fn.call(this[i], i, this[i]) !== false) ++i;
   return this;
 };
@@ -604,16 +582,18 @@ exports.each = function (fn) {
  * @see {@link http://api.jquery.com/map/}
  */
 exports.map = function (fn) {
-  return this._make(
-    _.reduce(
-      this,
-      function (memo, el, i) {
-        var val = fn.call(el, i, el);
-        return val == null ? memo : memo.concat(val);
-      },
-      []
-    )
-  );
+  const elems = [];
+  Array.from(this).forEach((el, i) => {
+    var val = fn.call(el, i, el);
+    if (val != null) {
+      if (Array.isArray(val)) {
+        elems.push(...val);
+      } else {
+        elems.push(val);
+      }
+    }
+  });
+  return this._make(elems);
 };
 
 var makeFilterMethod = function (filterFn) {
@@ -665,7 +645,9 @@ var makeFilterMethod = function (filterFn) {
  *
  * @see {@link http://api.jquery.com/filter/}
  */
-exports.filter = makeFilterMethod(_.filter);
+exports.filter = makeFilterMethod((elements, test) =>
+  Array.from(elements).filter(test)
+);
 
 /**
  * Remove elements from the set of matched elements. Given a jQuery object that
@@ -694,7 +676,9 @@ exports.filter = makeFilterMethod(_.filter);
  *
  * @see {@link http://api.jquery.com/not/}
  */
-exports.not = makeFilterMethod(_.reject);
+exports.not = makeFilterMethod((elements, test) =>
+  Array.from(elements).filter((item, index) => test(item, index) === false)
+);
 
 /**
  * Filters the set of matched elements to only those which have the given DOM

--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -4,15 +4,9 @@
 */
 
 var parse = require('./parse'),
-    defaultOptions = require('./options').default,
-    flattenOptions = require('./options').flatten,
-    isHtml = require('./utils').isHtml,
-    _ = {
-      extend: require('lodash/assignIn'),
-      bind: require('lodash/bind'),
-      forEach: require('lodash/forEach'),
-      defaults: require('lodash/defaults'),
-    };
+  defaultOptions = require('./options').default,
+  flattenOptions = require('./options').flatten,
+  isHtml = require('./utils').isHtml;
 
 /*
  * The API
@@ -46,10 +40,11 @@ var Cheerio = (module.exports = function (selector, context, root, options) {
   if (!(this instanceof Cheerio))
     return new Cheerio(selector, context, root, options);
 
-  this.options = _.defaults(
-    flattenOptions(options),
+  this.options = Object.assign(
+    {},
+    defaultOptions,
     this.options,
-    defaultOptions
+    flattenOptions(options)
   );
 
   // $(), $(null), $(undefined), $(false)
@@ -68,12 +63,9 @@ var Cheerio = (module.exports = function (selector, context, root, options) {
 
   // $([dom])
   if (Array.isArray(selector)) {
-    _.forEach(
-      selector,
-      _.bind(function (elem, idx) {
-        this[idx] = elem;
-      }, this)
-    );
+    selector.forEach((elem, idx) => {
+      this[idx] = elem;
+    });
     this.length = selector.length;
     return this;
   }
@@ -148,7 +140,7 @@ if (typeof Symbol !== 'undefined') {
 
 // Plug in the API
 api.forEach(function (mod) {
-  _.extend(Cheerio.prototype, mod);
+  Object.assign(Cheerio.prototype, mod);
 });
 
 var isNode = function (obj) {

--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -4,9 +4,9 @@
 */
 
 var parse = require('./parse'),
-  defaultOptions = require('./options').default,
-  flattenOptions = require('./options').flatten,
-  isHtml = require('./utils').isHtml;
+    defaultOptions = require('./options').default,
+    flattenOptions = require('./options').flatten,
+    isHtml = require('./utils').isHtml;
 
 /*
  * The API

--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -63,9 +63,9 @@ var Cheerio = (module.exports = function (selector, context, root, options) {
 
   // $([dom])
   if (Array.isArray(selector)) {
-    selector.forEach((elem, idx) => {
+    selector.forEach(function (elem, idx) {
       this[idx] = elem;
-    });
+    }, this);
     this.length = selector.length;
     return this;
   }

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,5 +1,3 @@
-var assign = require('lodash/assign');
-
 /*
  * Cheerio default options
  */
@@ -13,6 +11,6 @@ exports.default = {
 
 exports.flatten = function (options) {
   return options && options.xml
-    ? assign({ xmlMode: true }, options.xml)
+    ? Object.assign({ xmlMode: true }, options.xml)
     : options;
 };

--- a/lib/static.js
+++ b/lib/static.js
@@ -160,8 +160,8 @@ exports.text = function (elems) {
   }
 
   var ret = '',
-    len = elems.length,
-    elem;
+      len = elems.length,
+      elem;
 
   for (var i = 0; i < len; i++) {
     elem = elems[i];

--- a/lib/static.js
+++ b/lib/static.js
@@ -14,10 +14,6 @@ var flattenOptions = require('./options').flatten;
 var select = require('css-select');
 var parse5 = require('parse5');
 var parse = require('./parse');
-var _ = {
-  merge: require('lodash/merge'),
-  defaults: require('lodash/defaults'),
-};
 
 /**
  * Create a querying function, bound to a document created from the provided
@@ -37,7 +33,7 @@ exports.load = function (content, options, isDocument) {
 
   var Cheerio = require('./cheerio');
 
-  options = _.defaults(flattenOptions(options || {}), defaultOptions);
+  options = Object.assign({}, defaultOptions, flattenOptions(options || {}));
 
   if (isDocument === void 0) isDocument = true;
 
@@ -47,7 +43,7 @@ exports.load = function (content, options, isDocument) {
     if (!(this instanceof initialize)) {
       return new initialize(selector, context, r, opts);
     }
-    opts = _.defaults(opts || {}, options);
+    opts = Object.assign({}, options, opts);
     return Cheerio.call(this, selector, context, r || root, opts);
   };
 
@@ -64,7 +60,7 @@ exports.load = function (content, options, isDocument) {
   initialize.prototype._originalRoot = root;
 
   // Add in the static methods
-  _.merge(initialize, exports);
+  Object.assign(initialize, exports);
 
   // Add in the root
   initialize._root = root;
@@ -132,10 +128,11 @@ exports.html = function (dom, options) {
 
   // sometimes $.html() used without preloading html
   // so fallback non existing options to the default ones
-  options = _.defaults(
-    flattenOptions(options || {}),
+  options = Object.assign(
+    {},
+    defaultOptions,
     this._options,
-    defaultOptions
+    flattenOptions(options || {})
   );
 
   return render(this, dom, options);
@@ -147,7 +144,7 @@ exports.html = function (dom, options) {
  * @param {string|cheerio|node} [dom] - Element to render.
  */
 exports.xml = function (dom) {
-  var options = _.defaults({ xml: true }, this._options);
+  var options = Object.assign({}, this._options, { xml: true });
 
   return render(this, dom, options);
 };
@@ -163,8 +160,8 @@ exports.text = function (elems) {
   }
 
   var ret = '',
-      len = elems.length,
-      elem;
+    len = elems.length,
+    elem;
 
   for (var i = 0; i < len; i++) {
     elem = elems[i];

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -1,16 +1,13 @@
 var expect = require('expect.js'),
-    htmlparser2 = require('htmlparser2'),
-    cheerio = require('../'),
-    fixtures = require('./fixtures'),
-    fruits = fixtures.fruits,
-    food = fixtures.food,
-    _ = {
-      filter: require('lodash/filter'),
-    };
+  htmlparser2 = require('htmlparser2'),
+  cheerio = require('../'),
+  fixtures = require('./fixtures'),
+  fruits = fixtures.fruits,
+  food = fixtures.food;
 
 // HTML
 var script = '<script src="script.js" type="text/javascript"></script>',
-    multiclass = '<p><a class="btn primary" href="#">Save</a></p>';
+  multiclass = '<p><a class="btn primary" href="#">Save</a></p>';
 
 describe('cheerio', function () {
   it('should get the version', function () {
@@ -106,8 +103,8 @@ describe('cheerio', function () {
 
   it('should select only elements inside given context (Issue #193)', function () {
     var $ = cheerio.load(food),
-        $fruits = $('#fruits'),
-        fruitElements = $('li', $fruits);
+      $fruits = $('#fruits'),
+      fruitElements = $('li', $fruits);
 
     expect(fruitElements).to.have.length(3);
   });
@@ -151,10 +148,10 @@ describe('cheerio', function () {
     var $elems = cheerio('.apple, #fruits', fruits);
     expect($elems).to.have.length(2);
 
-    var $apple = _.filter($elems, function (elem) {
+    var $apple = Array.from($elems).filter(function (elem) {
       return elem.attribs['class'] === 'apple';
     });
-    var $fruits = _.filter($elems, function (elem) {
+    var $fruits = Array.from($elems).filter(function (elem) {
       return elem.attribs.id === 'fruits';
     });
     testAppleSelect($apple);
@@ -249,8 +246,8 @@ describe('cheerio', function () {
 
     it('should be able to filter down using the context', function () {
       var $ = cheerio.load(fruits),
-          apple = $('.apple', 'ul'),
-          lis = $('li', 'ul');
+        apple = $('.apple', 'ul'),
+        lis = $('li', 'ul');
 
       expect(apple).to.have.length(1);
       expect(lis).to.have.length(3);
@@ -258,15 +255,15 @@ describe('cheerio', function () {
 
     it('should allow loading a pre-parsed DOM', function () {
       var dom = htmlparser2.parseDOM(food),
-          $ = cheerio.load(dom);
+        $ = cheerio.load(dom);
 
       expect($('ul')).to.have.length(3);
     });
 
     it('should render xml in html() when options.xml = true', function () {
       var str = '<MixedCaseTag UPPERCASEATTRIBUTE=""></MixedCaseTag>',
-          expected = '<MixedCaseTag UPPERCASEATTRIBUTE=""/>',
-          $ = cheerio.load(str, { xml: true });
+        expected = '<MixedCaseTag UPPERCASEATTRIBUTE=""/>',
+        $ = cheerio.load(str, { xml: true });
 
       expect($('MixedCaseTag').get(0).tagName).to.equal('MixedCaseTag');
       expect($.html()).to.be(expected);
@@ -274,12 +271,12 @@ describe('cheerio', function () {
 
     it('should render xml in html() when options.xml = true passed to html()', function () {
       var str = '<MixedCaseTag UPPERCASEATTRIBUTE=""></MixedCaseTag>',
-          // since parsing done without xml flag, all tags converted to lowercase
-          expectedXml =
+        // since parsing done without xml flag, all tags converted to lowercase
+        expectedXml =
           '<html><head/><body><mixedcasetag uppercaseattribute=""/></body></html>',
-          expectedNoXml =
+        expectedNoXml =
           '<html><head></head><body><mixedcasetag uppercaseattribute=""></mixedcasetag></body></html>',
-          $ = cheerio.load(str);
+        $ = cheerio.load(str);
 
       expect($('MixedCaseTag').get(0).tagName).to.equal('mixedcasetag');
       expect($.html()).to.be(expectedNoXml);
@@ -289,12 +286,12 @@ describe('cheerio', function () {
     it('should respect options on the element level', function () {
       var str =
           '<!doctype html><html><head><title>Some test</title></head><body><footer><p>Copyright &copy; 2003-2014</p></footer></body></html>',
-          expectedHtml = '<p>Copyright &copy; 2003-2014</p>',
-          expectedXml = '<p>Copyright © 2003-2014</p>',
-          domNotEncoded = cheerio.load(str, {
-            xml: { decodeEntities: false },
-          }),
-          domEncoded = cheerio.load(str);
+        expectedHtml = '<p>Copyright &copy; 2003-2014</p>',
+        expectedXml = '<p>Copyright © 2003-2014</p>',
+        domNotEncoded = cheerio.load(str, {
+          xml: { decodeEntities: false },
+        }),
+        domEncoded = cheerio.load(str);
 
       expect(domNotEncoded('footer').html()).to.be(expectedHtml);
       // TODO: Make it more html friendly, maybe with custom encode tables

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -148,10 +148,10 @@ describe('cheerio', function () {
     var $elems = cheerio('.apple, #fruits', fruits);
     expect($elems).to.have.length(2);
 
-    var $apple = Array.from($elems).filter(function (elem) {
+    var $apple = $elems.toArray().filter(function (elem) {
       return elem.attribs['class'] === 'apple';
     });
-    var $fruits = Array.from($elems).filter(function (elem) {
+    var $fruits = $elems.toArray().filter(function (elem) {
       return elem.attribs.id === 'fruits';
     });
     testAppleSelect($apple);

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -1,13 +1,13 @@
 var expect = require('expect.js'),
-  htmlparser2 = require('htmlparser2'),
-  cheerio = require('../'),
-  fixtures = require('./fixtures'),
-  fruits = fixtures.fruits,
-  food = fixtures.food;
+    htmlparser2 = require('htmlparser2'),
+    cheerio = require('../'),
+    fixtures = require('./fixtures'),
+    fruits = fixtures.fruits,
+    food = fixtures.food;
 
 // HTML
 var script = '<script src="script.js" type="text/javascript"></script>',
-  multiclass = '<p><a class="btn primary" href="#">Save</a></p>';
+    multiclass = '<p><a class="btn primary" href="#">Save</a></p>';
 
 describe('cheerio', function () {
   it('should get the version', function () {
@@ -103,8 +103,8 @@ describe('cheerio', function () {
 
   it('should select only elements inside given context (Issue #193)', function () {
     var $ = cheerio.load(food),
-      $fruits = $('#fruits'),
-      fruitElements = $('li', $fruits);
+        $fruits = $('#fruits'),
+        fruitElements = $('li', $fruits);
 
     expect(fruitElements).to.have.length(3);
   });
@@ -246,8 +246,8 @@ describe('cheerio', function () {
 
     it('should be able to filter down using the context', function () {
       var $ = cheerio.load(fruits),
-        apple = $('.apple', 'ul'),
-        lis = $('li', 'ul');
+          apple = $('.apple', 'ul'),
+          lis = $('li', 'ul');
 
       expect(apple).to.have.length(1);
       expect(lis).to.have.length(3);
@@ -255,15 +255,15 @@ describe('cheerio', function () {
 
     it('should allow loading a pre-parsed DOM', function () {
       var dom = htmlparser2.parseDOM(food),
-        $ = cheerio.load(dom);
+          $ = cheerio.load(dom);
 
       expect($('ul')).to.have.length(3);
     });
 
     it('should render xml in html() when options.xml = true', function () {
       var str = '<MixedCaseTag UPPERCASEATTRIBUTE=""></MixedCaseTag>',
-        expected = '<MixedCaseTag UPPERCASEATTRIBUTE=""/>',
-        $ = cheerio.load(str, { xml: true });
+          expected = '<MixedCaseTag UPPERCASEATTRIBUTE=""/>',
+          $ = cheerio.load(str, { xml: true });
 
       expect($('MixedCaseTag').get(0).tagName).to.equal('MixedCaseTag');
       expect($.html()).to.be(expected);
@@ -271,12 +271,12 @@ describe('cheerio', function () {
 
     it('should render xml in html() when options.xml = true passed to html()', function () {
       var str = '<MixedCaseTag UPPERCASEATTRIBUTE=""></MixedCaseTag>',
-        // since parsing done without xml flag, all tags converted to lowercase
-        expectedXml =
+          // since parsing done without xml flag, all tags converted to lowercase
+          expectedXml =
           '<html><head/><body><mixedcasetag uppercaseattribute=""/></body></html>',
-        expectedNoXml =
+          expectedNoXml =
           '<html><head></head><body><mixedcasetag uppercaseattribute=""></mixedcasetag></body></html>',
-        $ = cheerio.load(str);
+          $ = cheerio.load(str);
 
       expect($('MixedCaseTag').get(0).tagName).to.equal('mixedcasetag');
       expect($.html()).to.be(expectedNoXml);
@@ -286,12 +286,12 @@ describe('cheerio', function () {
     it('should respect options on the element level', function () {
       var str =
           '<!doctype html><html><head><title>Some test</title></head><body><footer><p>Copyright &copy; 2003-2014</p></footer></body></html>',
-        expectedHtml = '<p>Copyright &copy; 2003-2014</p>',
-        expectedXml = '<p>Copyright © 2003-2014</p>',
-        domNotEncoded = cheerio.load(str, {
-          xml: { decodeEntities: false },
-        }),
-        domEncoded = cheerio.load(str);
+          expectedHtml = '<p>Copyright &copy; 2003-2014</p>',
+          expectedXml = '<p>Copyright © 2003-2014</p>',
+          domNotEncoded = cheerio.load(str, {
+            xml: { decodeEntities: false },
+          }),
+          domEncoded = cheerio.load(str);
 
       expect(domNotEncoded('footer').html()).to.be(expectedHtml);
       // TODO: Make it more html friendly, maybe with custom encode tables

--- a/test/parse.js
+++ b/test/parse.js
@@ -1,5 +1,4 @@
 var expect = require('expect.js'),
-    assign = require('lodash/assign'),
     parse = require('../lib/parse'),
     defaultOpts = require('../lib/options').default;
 
@@ -380,7 +379,7 @@ describe('parse', function () {
     it('should pass the options for including the location info to parse5', function () {
       var root = parse(
         '<p>Hello</p>',
-        assign({}, defaultOpts, { sourceCodeLocationInfo: true }),
+        Object.assign({}, defaultOpts, { sourceCodeLocationInfo: true }),
         false
       );
       var location = root.children[0].sourceCodeLocation;

--- a/test/xml.js
+++ b/test/xml.js
@@ -1,11 +1,8 @@
 var expect = require('expect.js'),
-    cheerio = require('..'),
-    _ = {
-      extend: require('lodash/assignIn'),
-    };
+    cheerio = require('..');
 
 var xml = function (str, options) {
-  options = _.extend({ xml: true }, options);
+  options = Object.assign({ xml: true }, options);
   var $ = cheerio.load(str, options);
   return $.xml();
 };


### PR DESCRIPTION
Lodash is quite big package https://packagephobia.com/result?p=lodash
and often used where modern javascript feature do a good job.

In this diff I replaced lodash with native functions or for/of loop.

The only left case is lodash/cloneDeepWith which does not have clear
alternative. I will try to replace it with something in another PR and
remove lodash dependency.