### PR TITLE
refactor: Use the parser's DOM without modifications

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -182,7 +182,6 @@ The options in the `xml` object are taken directly from [htmlparser2](https://gi
 
 ```js
 {
-    withDomLvl1: true,
     normalizeWhitespace: false,
     xmlMode: true,
     decodeEntities: true

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -11,7 +11,6 @@ var parse = require('../parse');
 var html = require('../static').html;
 var text = require('../static').text;
 var updateDOM = parse.update;
-var evaluate = parse.evaluate;
 var utils = require('../utils');
 var domEach = utils.domEach;
 var cloneDom = utils.cloneDom;
@@ -39,7 +38,7 @@ exports._makeDomArray = function makeDomArray(elem, clone) {
       []
     );
   } else if (typeof elem === 'string') {
-    return evaluate(elem, this.options, false);
+    return parse(elem, this.options, false).children;
   }
   return clone ? cloneDom([elem]) : [elem];
 };
@@ -90,7 +89,7 @@ var uniqueSplice = function (array, spliceIdx, spliceCount, newElems, parent) {
   // current array.
   for (idx = 0, len = newElems.length; idx < len; ++idx) {
     node = newElems[idx];
-    oldParent = node.parent || node.root;
+    oldParent = node.parent;
     prevIdx = oldParent && oldParent.children.indexOf(newElems[idx]);
 
     if (oldParent && prevIdx > -1) {
@@ -100,7 +99,6 @@ var uniqueSplice = function (array, spliceIdx, spliceCount, newElems, parent) {
       }
     }
 
-    node.root = null;
     node.parent = parent;
 
     if (node.prev) {
@@ -282,7 +280,7 @@ exports.wrap = function (wrapper) {
 
   for (var i = 0; i < this.length; i++) {
     var el = this[i];
-    var parent = el.parent || el.root;
+    var parent = el.parent;
     var siblings = parent.children;
     var wrapperDom;
     var elInsertLocation;
@@ -436,7 +434,7 @@ exports.after = function () {
   var lastIdx = this.length - 1;
 
   domEach(this, function (i, el) {
-    var parent = el.parent || el.root;
+    var parent = el.parent;
     if (!parent) {
       return;
     }
@@ -496,7 +494,7 @@ exports.insertAfter = function (target) {
   self.remove();
   domEach(target, function (i, el) {
     var clonedSelf = self._makeDomArray(self.clone());
-    var parent = el.parent || el.root;
+    var parent = el.parent;
     if (!parent) {
       return;
     }
@@ -535,7 +533,7 @@ exports.before = function () {
   var lastIdx = this.length - 1;
 
   domEach(this, function (i, el) {
-    var parent = el.parent || el.root;
+    var parent = el.parent;
     if (!parent) {
       return;
     }
@@ -596,7 +594,7 @@ exports.insertBefore = function (target) {
   self.remove();
   domEach(target, function (i, el) {
     var clonedSelf = self._makeDomArray(self.clone());
-    var parent = el.parent || el.root;
+    var parent = el.parent;
     if (!parent) {
       return;
     }
@@ -638,7 +636,7 @@ exports.remove = function (selector) {
   if (selector) elems = elems.filter(selector);
 
   domEach(elems, function (i, el) {
-    var parent = el.parent || el.root;
+    var parent = el.parent;
     if (!parent) {
       return;
     }
@@ -655,7 +653,7 @@ exports.remove = function (selector) {
     if (el.next) {
       el.next.prev = el.prev;
     }
-    el.prev = el.next = el.parent = el.root = null;
+    el.prev = el.next = el.parent = null;
   });
 
   return this;
@@ -683,7 +681,7 @@ exports.replaceWith = function (content) {
   var self = this;
 
   domEach(this, function (i, el) {
-    var parent = el.parent || el.root;
+    var parent = el.parent;
     if (!parent) {
       return;
     }
@@ -702,7 +700,7 @@ exports.replaceWith = function (content) {
 
     // Completely remove old element
     uniqueSplice(siblings, index, 1, dom, parent);
-    el.parent = el.prev = el.next = el.root = null;
+    el.parent = el.prev = el.next = null;
   });
 
   return this;
@@ -762,7 +760,7 @@ exports.html = function (str) {
 
     var content = str.cheerio
       ? str.clone().get()
-      : evaluate('' + str, opts, false);
+      : parse('' + str, opts, false).children;
 
     updateDOM(content, el);
   });
@@ -813,7 +811,7 @@ exports.text = function (str) {
       child.next = child.prev = child.parent = null;
     });
 
-    var textNode = evaluate(' ', opts)[0];
+    var textNode = parse(' ', opts).children[0];
     textNode.data = str;
 
     updateDOM(textNode, el);

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -78,7 +78,11 @@ exports.parent = function (selector) {
 
   domEach(this, function (idx, elem) {
     var parentElem = elem.parent;
-    if (parentElem && set.indexOf(parentElem) < 0) {
+    if (
+      parentElem &&
+      parentElem.type !== 'root' &&
+      set.indexOf(parentElem) < 0
+    ) {
       set.push(parentElem);
     }
   });
@@ -848,7 +852,7 @@ exports.slice = function () {
 
 function traverseParents(self, elem, selector, limit) {
   var elems = [];
-  while (elem && elems.length < limit) {
+  while (elem && elems.length < limit && elem.type !== 'root') {
     if (!selector || exports.filter.call([elem], selector, self).length) {
       elems.push(elem);
     }

--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -145,5 +145,10 @@ api.forEach(function (mod) {
 });
 
 var isNode = function (obj) {
-  return obj.name || obj.type === 'text' || obj.type === 'comment';
+  return (
+    obj.name ||
+    obj.type === 'root' ||
+    obj.type === 'text' ||
+    obj.type === 'comment'
+  );
 };

--- a/lib/options.js
+++ b/lib/options.js
@@ -3,7 +3,6 @@
  */
 
 exports.default = {
-  withDomLvl1: true,
   normalizeWhitespace: false,
   xml: false,
   decodeEntities: true,

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -8,31 +8,7 @@ var htmlparser2Adapter = require('parse5-htmlparser2-tree-adapter');
 /*
   Parser
 */
-exports = module.exports = function (content, options, isDocument) {
-  var dom = exports.evaluate(content, options, isDocument);
-  // Generic root element
-  var root = exports.evaluate('<root></root>', options, false)[0];
-
-  root.type = 'root';
-  root.parent = null;
-
-  // Update the dom using the root
-  exports.update(dom, root);
-
-  return root;
-};
-
-function parseWithParse5(content, options, isDocument) {
-  var parse = isDocument ? parse5.parse : parse5.parseFragment;
-  var root = parse(content, {
-    treeAdapter: htmlparser2Adapter,
-    sourceCodeLocationInfo: options.sourceCodeLocationInfo,
-  });
-
-  return root.children;
-}
-
-exports.evaluate = function (content, options, isDocument) {
+exports = module.exports = function parse(content, options, isDocument) {
   // options = options || $.fn.options;
 
   var dom;
@@ -45,14 +21,38 @@ exports.evaluate = function (content, options, isDocument) {
     var useHtmlParser2 = options.xmlMode || options._useHtmlParser2;
 
     dom = useHtmlParser2
-      ? htmlparser.parseDOM(content, options)
+      ? htmlparser.parseDocument(content, options)
       : parseWithParse5(content, options, isDocument);
   } else {
-    dom = content;
+    if (
+      typeof content === 'object' &&
+      content != null &&
+      content.type === 'root'
+    ) {
+      dom = content;
+    } else {
+      // Generic root element
+      var root = parse('', options, false);
+      root.children.length = 0;
+
+      // Update the dom using the root
+      exports.update(content, root);
+
+      dom = root;
+    }
   }
 
   return dom;
 };
+
+function parseWithParse5(content, options, isDocument) {
+  var parse = isDocument ? parse5.parse : parse5.parseFragment;
+
+  return parse(content, {
+    treeAdapter: htmlparser2Adapter,
+    sourceCodeLocationInfo: options.sourceCodeLocationInfo,
+  });
+}
 
 /*
   Update the dom structure, for one changed layer
@@ -73,7 +73,7 @@ exports.update = function (arr, parent) {
     var node = arr[i];
 
     // Cleanly remove existing nodes from their previous structures.
-    var oldParent = node.parent || node.root;
+    var oldParent = node.parent;
     var oldSiblings = oldParent && oldParent.children;
     if (oldSiblings && oldSiblings !== arr) {
       oldSiblings.splice(oldSiblings.indexOf(node), 1);
@@ -92,13 +92,7 @@ exports.update = function (arr, parent) {
       node.prev = node.next = null;
     }
 
-    if (parent && parent.type === 'root') {
-      node.root = parent;
-      node.parent = null;
-    } else {
-      node.root = null;
-      node.parent = parent;
-    }
+    node.parent = parent;
   }
 
   return parent;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -67,7 +67,7 @@ exports.cloneDom = function (dom) {
   var parents =
     'length' in dom
       ? Array.prototype.map.call(dom, function (el) {
-          return el.parent;
+          return el.parent && el.parent.type === 'root' ? null : el.parent;
         })
       : [dom.parent];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1157,9 +1157,9 @@
       "dev": true
     },
     "css-select": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-3.1.1.tgz",
-      "integrity": "sha512-6h3ECMuVhTcISNgmavw2YqWiuPY0jurQYWdob5au8z0H84xkFE23Sv6ML+Y42fMNqXsaUB69+3MTpX4uFEMY+g==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-3.1.2.tgz",
+      "integrity": "sha512-qmss1EihSuBNWNNhHjxzxSfJoFBM/lERB/Q4EnsJQQC62R2evJDW481091oAdOr9uh46/0n4nrg0It5cAnj1RA==",
       "requires": {
         "boolbase": "^1.0.0",
         "css-what": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "node": ">= 0.6"
   },
   "dependencies": {
-    "css-select": "~3.1.1",
+    "css-select": "^3.1.2",
     "dom-serializer": "~1.2.0",
     "entities": "~2.1.0",
     "htmlparser2": "^6.0.0",

--- a/test/api/manipulation.js
+++ b/test/api/manipulation.js
@@ -502,12 +502,12 @@ describe('$(...)', function () {
 
     it('($(...)) : should remove from root element', function () {
       var $plum = $('<li class="plum">Plum</li>');
-      var root = $plum[0].root;
-      expect(root).to.be.ok();
+      var parent = $plum[0].parent;
+      expect(parent).to.be.ok();
 
       $fruits.append($plum);
-      expect($plum[0].root).to.not.be.ok();
-      expect(root.childNodes).to.not.contain($plum[0]);
+      expect($plum[0].parent.type).to.not.be('root');
+      expect(parent.childNodes).to.not.contain($plum[0]);
     });
   });
 
@@ -667,11 +667,11 @@ describe('$(...)', function () {
 
     it('($(...)) : should remove from root element', function () {
       var $plum = $('<li class="plum">Plum</li>');
-      var root = $plum[0].root;
-      expect(root).to.be.ok();
+      var root = $plum[0].parent;
+      expect(root.type).to.be('root');
 
       $fruits.prepend($plum);
-      expect($plum[0].root).to.not.be.ok();
+      expect($plum[0].parent.type).to.not.be('root');
       expect(root.childNodes).to.not.contain($plum[0]);
     });
   });
@@ -869,11 +869,11 @@ describe('$(...)', function () {
 
     it('($(...)) : should remove from root element', function () {
       var $plum = $('<li class="plum">Plum</li>');
-      var root = $plum[0].root;
-      expect(root).to.be.ok();
+      var root = $plum[0].parent;
+      expect(root.type).to.be('root');
 
       $fruits.after($plum);
-      expect($plum[0].root).to.not.be.ok();
+      expect($plum[0].parent.type).to.not.be('root');
       expect(root.childNodes).to.not.contain($plum[0]);
     });
   });
@@ -1146,11 +1146,11 @@ describe('$(...)', function () {
 
     it('($(...)) : should remove from root element', function () {
       var $plum = $('<li class="plum">Plum</li>');
-      var root = $plum[0].root;
-      expect(root).to.be.ok();
+      var root = $plum[0].parent;
+      expect(root.type).to.be('root');
 
       $fruits.before($plum);
-      expect($plum[0].root).to.not.be.ok();
+      expect($plum[0].parent.type).to.not.be('root');
       expect(root.childNodes).to.not.contain($plum[0]);
     });
   });
@@ -1309,11 +1309,11 @@ describe('$(...)', function () {
 
     it('($(...)) : should remove from root element', function () {
       var $plum = $('<li class="plum">Plum</li>');
-      var root = $plum[0].root;
-      expect(root).to.be.ok();
+      var root = $plum[0].parent;
+      expect(root.type).to.be('root');
 
       $plum.remove();
-      expect($plum[0].root).to.not.be.ok();
+      expect($plum[0].parent).to.be(null);
       expect(root.childNodes).to.not.contain($plum[0]);
     });
   });
@@ -1435,11 +1435,11 @@ describe('$(...)', function () {
 
     it('($(...)) : should remove from root element', function () {
       var $plum = $('<li class="plum">Plum</li>');
-      var root = $plum[0].root;
-      expect(root).to.be.ok();
+      var root = $plum[0].parent;
+      expect(root.type).to.be('root');
 
       $fruits.children().replaceWith($plum);
-      expect($plum[0].root).to.not.be.ok();
+      expect($plum[0].parent.type).to.not.be('root');
       expect(root.childNodes).to.not.contain($plum[0]);
     });
   });

--- a/test/api/utils.js
+++ b/test/api/utils.js
@@ -33,7 +33,7 @@ describe('cheerio', function () {
       var $ = cheerio.load('<div>a div</div><span>a span</span>');
       var $collection = $('div').add($.root()).add('span');
       var expected =
-        '<span>a span</span><html><head></head><body><div>a div</div><span>a span</span></body></html><div>a div</div>';
+        '<html><head></head><body><div>a div</div><span>a span</span></body></html><div>a div</div><span>a span</span>';
       expect(cheerio.html($collection)).to.equal(expected);
     });
   });

--- a/test/parse.js
+++ b/test/parse.js
@@ -38,16 +38,16 @@ var styleEmpty = '<style></style>';
 var directive = '<!doctype html>';
 
 describe('parse', function () {
-  describe('.eval', function () {
+  describe('evaluate', function () {
     it('should parse basic empty tags: ' + basic, function () {
-      var tag = parse.evaluate(basic, defaultOpts, true)[0];
+      var tag = parse(basic, defaultOpts, true).children[0];
       expect(tag.type).to.equal('tag');
       expect(tag.tagName).to.equal('html');
       expect(tag.childNodes).to.have.length(2);
     });
 
     it('should handle sibling tags: ' + siblings, function () {
-      var dom = parse.evaluate(siblings, defaultOpts, false);
+      var dom = parse(siblings, defaultOpts, false).children;
       var h2 = dom[0];
       var p = dom[1];
 
@@ -57,21 +57,21 @@ describe('parse', function () {
     });
 
     it('should handle single tags: ' + single, function () {
-      var tag = parse.evaluate(single, defaultOpts, false)[0];
+      var tag = parse(single, defaultOpts, false).children[0];
       expect(tag.type).to.equal('tag');
       expect(tag.tagName).to.equal('br');
       expect(tag.childNodes).to.be.empty();
     });
 
     it('should handle malformatted single tags: ' + singleWrong, function () {
-      var tag = parse.evaluate(singleWrong, defaultOpts, false)[0];
+      var tag = parse(singleWrong, defaultOpts, false).children[0];
       expect(tag.type).to.equal('tag');
       expect(tag.tagName).to.equal('br');
       expect(tag.childNodes).to.be.empty();
     });
 
     it('should handle tags with children: ' + children, function () {
-      var tag = parse.evaluate(children, defaultOpts, true)[0];
+      var tag = parse(children, defaultOpts, true).children[0];
       expect(tag.type).to.equal('tag');
       expect(tag.tagName).to.equal('html');
       expect(tag.childNodes).to.be.ok();
@@ -80,33 +80,33 @@ describe('parse', function () {
     });
 
     it('should handle tags with children: ' + li, function () {
-      var tag = parse.evaluate(li, defaultOpts, false)[0];
+      var tag = parse(li, defaultOpts, false).children[0];
       expect(tag.childNodes).to.have.length(1);
       expect(tag.childNodes[0].data).to.equal('Durian');
     });
 
     it('should handle tags with attributes: ' + attributes, function () {
-      var attrs = parse.evaluate(attributes, defaultOpts, false)[0].attribs;
+      var attrs = parse(attributes, defaultOpts, false).children[0].attribs;
       expect(attrs).to.be.ok();
       expect(attrs.src).to.equal('hello.png');
       expect(attrs.alt).to.equal('man waving');
     });
 
     it('should handle value-less attributes: ' + noValueAttribute, function () {
-      var attrs = parse.evaluate(noValueAttribute, defaultOpts, false)[0]
+      var attrs = parse(noValueAttribute, defaultOpts, false).children[0]
         .attribs;
       expect(attrs).to.be.ok();
       expect(attrs.disabled).to.equal('');
     });
 
     it('should handle comments: ' + comment, function () {
-      var elem = parse.evaluate(comment, defaultOpts, false)[0];
+      var elem = parse(comment, defaultOpts, false).children[0];
       expect(elem.type).to.equal('comment');
       expect(elem.data).to.equal(' sexy ');
     });
 
     it('should handle conditional comments: ' + conditional, function () {
-      var elem = parse.evaluate(conditional, defaultOpts, false)[0];
+      var elem = parse(conditional, defaultOpts, false).children[0];
       expect(elem.type).to.equal('comment');
       expect(elem.data).to.equal(
         conditional.replace('<!--', '').replace('-->', '')
@@ -114,13 +114,13 @@ describe('parse', function () {
     });
 
     it('should handle text: ' + text, function () {
-      var text_ = parse.evaluate(text, defaultOpts, false)[0];
+      var text_ = parse(text, defaultOpts, false).children[0];
       expect(text_.type).to.equal('text');
       expect(text_.data).to.equal('lorem ipsum');
     });
 
     it('should handle script tags: ' + script, function () {
-      var script_ = parse.evaluate(script, defaultOpts, false)[0];
+      var script_ = parse(script, defaultOpts, false).children[0];
       expect(script_.type).to.equal('script');
       expect(script_.tagName).to.equal('script');
       expect(script_.attribs.type).to.equal('text/javascript');
@@ -130,7 +130,7 @@ describe('parse', function () {
     });
 
     it('should handle style tags: ' + style, function () {
-      var style_ = parse.evaluate(style, defaultOpts, false)[0];
+      var style_ = parse(style, defaultOpts, false).children[0];
       expect(style_.type).to.equal('style');
       expect(style_.tagName).to.equal('style');
       expect(style_.attribs.type).to.equal('text/css');
@@ -140,7 +140,7 @@ describe('parse', function () {
     });
 
     it('should handle directives: ' + directive, function () {
-      var elem = parse.evaluate(directive, defaultOpts, true)[0];
+      var elem = parse(directive, defaultOpts, true).children[0];
       expect(elem.type).to.equal('directive');
       expect(elem.data).to.equal('!DOCTYPE html ""');
       expect(elem.tagName).to.equal('!doctype');
@@ -158,7 +158,7 @@ describe('parse', function () {
       expect(root.parentNode).to.be(null);
 
       var child = root.childNodes[0];
-      expect(child.parentNode).to.be(null);
+      expect(child.parentNode).to.be(root);
     }
 
     it('should add root to: ' + basic, function () {
@@ -174,7 +174,7 @@ describe('parse', function () {
       expect(root.childNodes).to.have.length(2);
       expect(root.childNodes[0].tagName).to.equal('h2');
       expect(root.childNodes[1].tagName).to.equal('p');
-      expect(root.childNodes[1].parent).to.equal(null);
+      expect(root.childNodes[1].parent).to.equal(root);
     });
 
     it('should add root to: ' + comment, function () {


### PR DESCRIPTION
BREAKING: This removes the `root` property from top-level nodes. Instead, the `root` reference is kept in the (previously `null`) `parent` property. Cheerio now uses the root object generated by either of the parsers.

Also bumps `css-select`, as the new version includes a fix for `parent` references that aren't elements.