### PR TITLE
refactor(types): Use `domhandler` DOM types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,28 +1,6 @@
-interface Document {}
+import { Document, Element } from 'domhandler';
 
 declare namespace cheerio {
-  interface Element {
-    // Document References
-    // Node Console
-    tagName: string;
-    type: string;
-    name: string;
-    attribs: { [attr: string]: string };
-    children: Element[];
-    childNodes: Element[];
-    lastChild: Element;
-    firstChild: Element;
-    next: Element;
-    nextSibling: Element;
-    prev: Element;
-    previousSibling: Element;
-    parent: Element;
-    parentNode: Element;
-    nodeValue: string;
-    data?: string;
-    startIndex?: number;
-  }
-
   type AttrFunction = (el: Element, i: number, currentValue: string) => any;
 
   interface Cheerio {


### PR DESCRIPTION
Improves the accuracy of types, by using the types that `domhandler` already provides.