### PR TITLE
refactor: Use `domhandler` nodes directly

### DIFF
--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -16,6 +16,7 @@ var domEach = utils.domEach;
 var cloneDom = utils.cloneDom;
 var isHtml = utils.isHtml;
 var slice = Array.prototype.slice;
+var domhandler = require('domhandler');
 
 /**
  * Create an array of nodes, recursing into arrays and parsing strings if
@@ -803,16 +804,13 @@ exports.text = function (str) {
     });
   }
 
-  var opts = this.options;
-
   // Append text node to each selected elements
   domEach(this, function (i, el) {
     el.children.forEach(function (child) {
       child.next = child.prev = child.parent = null;
     });
 
-    var textNode = parse(' ', opts).children[0];
-    textNode.data = str;
+    var textNode = new domhandler.Text(str);
 
     updateDOM(textNode, el);
   });

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -4,6 +4,7 @@
 var htmlparser = require('htmlparser2');
 var parse5 = require('parse5');
 var htmlparser2Adapter = require('parse5-htmlparser2-tree-adapter');
+var domhandler = require('domhandler');
 
 /*
   Parser
@@ -32,11 +33,10 @@ exports = module.exports = function parse(content, options, isDocument) {
       dom = content;
     } else {
       // Generic root element
-      var root = parse('', options, false);
-      root.children.length = 0;
-
-      // Update the dom using the root
-      exports.update(content, root);
+      var root = new domhandler.Document(content);
+      content.forEach(function (node) {
+        node.parent = root;
+      });
 
       dom = root;
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,4 @@
-var cloneDeepWith = require('lodash/cloneDeepWith');
+var domhandler = require('domhandler');
 
 // HTML Tags
 var tags = { tag: true, script: true, style: true };
@@ -64,20 +64,20 @@ exports.domEach = function (cheerio, fn) {
  * @private
  */
 exports.cloneDom = function (dom) {
-  var parents =
+  var clone =
     'length' in dom
       ? Array.prototype.map.call(dom, function (el) {
-          return el.parent && el.parent.type === 'root' ? null : el.parent;
+          return domhandler.cloneNode(el, true);
         })
-      : [dom.parent];
+      : [domhandler.cloneNode(dom, true)];
 
-  function filterOutParent(node) {
-    if (parents.indexOf(node) > -1) {
-      return null;
-    }
-  }
+  // Add a root node around the cloned nodes
+  var root = new domhandler.Document(clone);
+  clone.forEach(function (node) {
+    node.parent = root;
+  });
 
-  return cloneDeepWith(dom, filterOutParent);
+  return clone;
 };
 
 /*

--- a/package-lock.json
+++ b/package-lock.json
@@ -2860,7 +2860,8 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
     },
     "lodash.flattendeep": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
   "dependencies": {
     "css-select": "^3.1.2",
     "dom-serializer": "~1.2.0",
+    "domhandler": "^4.0.0",
     "entities": "~2.1.0",
     "htmlparser2": "^6.0.0",
-    "lodash": "^4.17.20",
     "parse5": "^6.0.0",
     "parse5-htmlparser2-tree-adapter": "^6.0.0"
   },


### PR DESCRIPTION
Avoids unnecessary parser calls. Fixes #1166.

Allows us to drop lodash. Fixes #1506.