### PR TITLE
feat: Use `cheerio-select`, to support positional selectors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
   },
   "plugins": ["jsdoc"],
   "extends": ["eslint:recommended", "prettier"],
-  "globals": {},
+  "globals": { "Set": true },
   "rules": {
     "no-eq-null": 0,
     "no-proto": 2,

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -7,7 +7,7 @@
 exports = exports; // eslint-disable-line no-self-assign
 // The preceeding statement is necessary for proper documentation generation.
 
-var select = require('css-select');
+var select = require('cheerio-select');
 var utils = require('../utils');
 var domEach = utils.domEach;
 var uniqueSort = require('htmlparser2').DomUtils.uniqueSort;
@@ -57,7 +57,7 @@ exports.find = function (selectorOrHaystack) {
 
   var options = { __proto__: this.options, context: this.toArray() };
 
-  return this._make(select.selectAll(selectorOrHaystack || '', elems, options));
+  return this._make(select.select(selectorOrHaystack || '', elems, options));
 };
 
 /**
@@ -151,7 +151,7 @@ exports.parentsUntil = function (selector, filter) {
   var untilNodes;
 
   if (typeof selector === 'string') {
-    untilNode = select.selectAll(
+    untilNode = select.select(
       selector,
       this.parents().toArray(),
       this.options
@@ -185,7 +185,7 @@ exports.parentsUntil = function (selector, filter) {
     }, this);
 
   return this._make(
-    filter ? select.selectAll(filter, parentNodes, this.options) : parentNodes
+    filter ? select.select(filter, parentNodes, this.options) : parentNodes
   );
 };
 
@@ -318,11 +318,7 @@ exports.nextUntil = function (selector, filterSelector) {
   var untilNodes;
 
   if (typeof selector === 'string') {
-    untilNode = select.selectAll(
-      selector,
-      this.nextAll().get(),
-      this.options
-    )[0];
+    untilNode = select.select(selector, this.nextAll().get(), this.options)[0];
   } else if (selector && selector.cheerio) {
     untilNodes = selector.get();
   } else if (selector) {
@@ -440,11 +436,7 @@ exports.prevUntil = function (selector, filterSelector) {
   var untilNodes;
 
   if (typeof selector === 'string') {
-    untilNode = select.selectAll(
-      selector,
-      this.prevAll().get(),
-      this.options
-    )[0];
+    untilNode = select.select(selector, this.prevAll().get(), this.options)[0];
   } else if (selector && selector.cheerio) {
     untilNodes = selector.get();
   } else if (selector) {
@@ -606,28 +598,18 @@ exports.map = function (fn) {
   return this._make(elems);
 };
 
-var makeFilterMethod = function (filterFn) {
-  return function (match, container) {
-    var testFn;
-    container = container || this;
-
-    if (typeof match === 'string') {
-      testFn = select.compile(match, container.options);
-    } else if (typeof match === 'function') {
-      testFn = function (el, i) {
-        return match.call(el, i, el);
-      };
-    } else if (match.cheerio) {
-      testFn = match.is.bind(match);
-    } else {
-      testFn = function (el) {
-        return match === el;
-      };
-    }
-
-    return container._make(filterFn(this, testFn));
+function getFilterFn(match) {
+  if (typeof match === 'function') {
+    return function (el, i) {
+      return match.call(el, i, el);
+    };
+  } else if (match.cheerio) {
+    return match.is.bind(match);
+  }
+  return function (el) {
+    return match === el;
   };
-};
+}
 
 /**
  * Iterates over a cheerio object, reducing the set of selector elements to
@@ -639,6 +621,8 @@ var makeFilterMethod = function (filterFn) {
  * refers to the current element.
  *
  * @function
+ * @param {string | Function} match - Value to look for, following the rules above.
+ * @param {node[]} container - Optional node to filter instead.
  *
  * @example <caption>Selector</caption>
  *
@@ -655,9 +639,18 @@ var makeFilterMethod = function (filterFn) {
  *
  * @see {@link http://api.jquery.com/filter/}
  */
-exports.filter = makeFilterMethod(function (elements, test) {
-  return (elements.toArray ? elements.toArray() : elements).filter(test);
-});
+exports.filter = function (match, container) {
+  container = container || this;
+  var elements = this.toArray ? this.toArray() : this;
+
+  if (typeof match === 'string') {
+    elements = select.filter(match, elements, container.options);
+  } else {
+    elements = elements.filter(getFilterFn(match));
+  }
+
+  return container._make(elements);
+};
 
 /**
  * Remove elements from the set of matched elements. Given a jQuery object that
@@ -670,6 +663,8 @@ exports.filter = makeFilterMethod(function (elements, test) {
  * are included.
  *
  * @function
+ * @param {string | Function} match - Value to look for, following the rules above.
+ * @param {node[]} container - Optional node to filter instead.
  *
  * @example <caption>Selector</caption>
  *
@@ -686,11 +681,26 @@ exports.filter = makeFilterMethod(function (elements, test) {
  *
  * @see {@link http://api.jquery.com/not/}
  */
-exports.not = makeFilterMethod(function (elements, test) {
-  return elements.toArray().filter(function (item, index) {
-    return test(item, index) === false;
-  });
-});
+exports.not = function (match, container) {
+  container = container || this;
+  var elements = container.toArray ? container.toArray() : container;
+  var matches;
+  var filterFn;
+
+  if (typeof match === 'string') {
+    matches = new Set(select.filter(match, elements, this.options));
+    elements = elements.filter(function (el) {
+      return !matches.has(el);
+    });
+  } else {
+    filterFn = getFilterFn(match);
+    elements = elements.filter(function (el, i) {
+      return !filterFn(el, i);
+    });
+  }
+
+  return container._make(elements);
+};
 
 /**
  * Filters the set of matched elements to only those which have the given DOM

--- a/lib/static.js
+++ b/lib/static.js
@@ -11,7 +11,7 @@ exports = exports; // eslint-disable-line no-self-assign
 var serialize = require('dom-serializer').default;
 var defaultOptions = require('./options').default;
 var flattenOptions = require('./options').flatten;
-var select = require('css-select').selectAll;
+var select = require('cheerio-select').select;
 var parse5 = require('parse5');
 var parse = require('./parse');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -855,6 +855,17 @@
         }
       }
     },
+    "cheerio-select": {
+      "version": "github:cheeriojs/cheerio-select#b98d6200519fe229904f2ae39ea44ed8e6d19182",
+      "from": "github:cheeriojs/cheerio-select",
+      "requires": {
+        "css-select": "^3.1.2",
+        "css-what": "^4.0.0",
+        "domelementtype": "^2.1.0",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.4.4"
+      }
+    },
     "chokidar": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">= 0.6"
+    "node": ">= 0.12"
   },
   "dependencies": {
     "cheerio-select": "github:cheeriojs/cheerio-select",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "node": ">= 0.6"
   },
   "dependencies": {
-    "css-select": "^3.1.2",
+    "cheerio-select": "github:cheeriojs/cheerio-select",
     "dom-serializer": "~1.2.0",
     "entities": "~2.1.0",
     "htmlparser2": "^6.0.0",

--- a/test/api/attributes.js
+++ b/test/api/attributes.js
@@ -243,7 +243,7 @@ describe('$(...)', function () {
       expect($el.data()).to.eql({
         a: 'a',
         b: 'b-modified',
-        c: 'c'
+        c: 'c',
       });
     });
 

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -158,11 +158,13 @@ describe('cheerio', function () {
     expect($fruits[0].attribs.id).to.equal('fruits');
   });
 
-  it('should select first element cheerio(:first)');
-  // var $elem = cheerio(':first', fruits);
-  // var $h2 = cheerio('<h2>fruits</h2>');
-  // console.log($elem.before('hi'));
-  // console.log($elem.before($h2));
+  it('should select first element cheerio(:first)', function () {
+    var $elem = cheerio('li:first', fruits);
+    expect($elem.attr('class')).to.equal('apple');
+
+    var $filtered = cheerio('li', fruits).filter(':even');
+    expect($filtered).to.have.length(2);
+  });
 
   it('should be able to select immediate children: cheerio("#fruits > .pear")', function () {
     var $food = cheerio(food);


### PR DESCRIPTION
Adds support for jQuery positional selectors (:eq, :first, :not(:last) etc.).

Fixes #1355
Fixes #129