### PR TITLE
fix(xml): Fix `.xml` calls on HTML documents

### DIFF
--- a/lib/static.js
+++ b/lib/static.js
@@ -146,7 +146,7 @@ exports.html = function (dom, options) {
  * @param {string|cheerio|node} [dom] - Element to render.
  */
 exports.xml = function (dom) {
-  var options = Object.assign({}, this._options, { xml: true });
+  var options = Object.assign({}, this._options, { xmlMode: true });
 
   return render(this, dom, options);
 };

--- a/test/xml.js
+++ b/test/xml.js
@@ -31,6 +31,11 @@ describe('render', function () {
       var str = '<tag attr="foo &amp; bar"/>';
       expect(xml(str)).to.equal(str);
     });
+
+    it('should render HTML as XML', function () {
+      var $ = cheerio.load('<foo></foo>', null, false);
+      expect($.xml()).to.equal('<foo/>');
+    });
   });
 
   describe('(dom)', function () {


### PR DESCRIPTION
We passed the wrong option to `render` (should have been `xmlMode`, was `xml`).