### PR TITLE
fix(options): Handle `xml: {xmlMode: false}`, simplify types

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -3,13 +3,16 @@
  */
 
 exports.default = {
-  normalizeWhitespace: false,
   xml: false,
   decodeEntities: true,
 };
 
+var xmlModeDefault = { _useHtmlParser2: true, xmlMode: true };
+
 exports.flatten = function (options) {
   return options && options.xml
-    ? Object.assign({ xmlMode: true }, options.xml)
+    ? typeof options.xml === 'boolean'
+      ? xmlModeDefault
+      : Object.assign({}, xmlModeDefault, options.xml)
     : options;
 };

--- a/lib/static.js
+++ b/lib/static.js
@@ -35,7 +35,7 @@ exports.load = function (content, options, isDocument) {
 
   var Cheerio = require('./cheerio');
 
-  options = Object.assign({}, defaultOptions, flattenOptions(options || {}));
+  options = Object.assign({}, defaultOptions, flattenOptions(options));
 
   if (isDocument === void 0) isDocument = true;
 

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -300,6 +300,13 @@ describe('cheerio', function () {
       expect(domEncoded('footer').html()).to.be(expectedXml);
     });
 
+    it('should use htmlparser2 if xml option is used', function () {
+      var str = '<div></div>';
+      var dom = cheerio.load(str);
+      // Should use htmlparser2 and not add <html>, <body> etc. tags
+      expect(dom.html()).to.be(str);
+    });
+
     it('should return a fully-qualified Function', function () {
       var $ = cheerio.load('<div>');
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,5 @@
-import { Document, Element } from 'domhandler';
+import { Document, Element, DomHandlerOptions } from 'domhandler';
+import { ParserOptions } from 'htmlparser2';
 
 declare namespace cheerio {
   type AttrFunction = (el: Element, i: number, currentValue: string) => any;
@@ -217,23 +218,15 @@ declare namespace cheerio {
     toArray(): Element[];
   }
 
-  interface CheerioParserOptions {
+  interface CheerioParserOptions extends ParserOptions, DomHandlerOptions {
     // Document References
     // Cheerio https://github.com/cheeriojs/cheerio
-    // HTMLParser2 https://github.com/fb55/htmlparser2/wiki/Parser-options
-    // DomHandler https://github.com/fb55/DomHandler
 
-    xmlMode?: boolean;
-    decodeEntities?: boolean;
-    lowerCaseTags?: boolean;
-    lowerCaseAttributeNames?: boolean;
-    recognizeCDATA?: boolean;
-    recognizeSelfClosing?: boolean;
-    normalizeWhitespace?: boolean;
-    withStartIndices?: boolean;
-    withEndIndices?: boolean;
-    ignoreWhitespace?: boolean;
+    xml?: (ParserOptions & DomHandlerOptions) | boolean;
     _useHtmlParser2?: boolean;
+
+    /** Enable location support for parse5 */
+    sourceCodeLocationInfo?: boolean;
   }
 
   interface Selector {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -46,6 +46,28 @@ $ = cheerio.load(html, {
   recognizeSelfClosing: true,
 });
 
+$ = cheerio.load(html, {
+  xml: true,
+});
+
+$ = cheerio.load(html, {
+  xml: { xmlMode: false },
+});
+
+$ = cheerio.load(html, {
+  xml: {
+    normalizeWhitespace: true,
+    withStartIndices: true,
+    withEndIndices: true,
+    xmlMode: false,
+    decodeEntities: true,
+    lowerCaseTags: true,
+    lowerCaseAttributeNames: true,
+    recognizeCDATA: true,
+    recognizeSelfClosing: true,
+  },
+});
+
 /**
  * Selectors
  */


### PR DESCRIPTION
Passing `xml: { xmlMode: false }` is now going to use `htmlparser2`.

The types now use htmlparser2 option types and include the `xml`, `sourceCodeLocationInfo` properties.