### PR TITLE
refactor: Use domutils for `isTag`, removing elements

### DIFF
--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -17,6 +17,7 @@ var cloneDom = utils.cloneDom;
 var isHtml = utils.isHtml;
 var slice = Array.prototype.slice;
 var domhandler = require('domhandler');
+var DomUtils = require('htmlparser2').DomUtils;
 
 /**
  * Create an array of nodes, recursing into arrays and parsing strings if
@@ -637,23 +638,7 @@ exports.remove = function (selector) {
   if (selector) elems = elems.filter(selector);
 
   domEach(elems, function (i, el) {
-    var parent = el.parent;
-    if (!parent) {
-      return;
-    }
-
-    var siblings = parent.children;
-    var index = siblings.indexOf(el);
-
-    if (index < 0) return;
-
-    siblings.splice(index, 1);
-    if (el.prev) {
-      el.prev.next = el.next;
-    }
-    if (el.next) {
-      el.next.prev = el.prev;
-    }
+    DomUtils.removeElement(el);
     el.prev = el.next = el.parent = null;
   });
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -5,6 +5,7 @@ var htmlparser = require('htmlparser2');
 var parse5 = require('parse5');
 var htmlparser2Adapter = require('parse5-htmlparser2-tree-adapter');
 var domhandler = require('domhandler');
+var DomUtils = htmlparser.DomUtils;
 
 /*
   Parser
@@ -73,16 +74,8 @@ exports.update = function (arr, parent) {
     var node = arr[i];
 
     // Cleanly remove existing nodes from their previous structures.
-    var oldParent = node.parent;
-    var oldSiblings = oldParent && oldParent.children;
-    if (oldSiblings && oldSiblings !== arr) {
-      oldSiblings.splice(oldSiblings.indexOf(node), 1);
-      if (node.prev) {
-        node.prev.next = node.next;
-      }
-      if (node.next) {
-        node.next.prev = node.prev;
-      }
+    if (node.parent && node.parent.children !== arr) {
+      DomUtils.removeElement(node);
     }
 
     if (parent) {
@@ -97,5 +90,3 @@ exports.update = function (arr, parent) {
 
   return parent;
 };
-
-// module.exports = $.extend(exports);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,5 @@
+var htmlparser2 = require('htmlparser2');
 var domhandler = require('domhandler');
-
-// HTML Tags
-var tags = { tag: true, script: true, style: true };
 
 /**
  * Check if the DOM element is a tag.
@@ -12,10 +10,7 @@ var tags = { tag: true, script: true, style: true };
  *
  * @private
  */
-exports.isTag = function (type) {
-  if (type.type) type = type.type;
-  return tags[type] || false;
-};
+exports.isTag = htmlparser2.DomUtils.isTag;
 
 /**
  * Convert a string to camel case notation.


### PR DESCRIPTION
`isTag` now no longer returns `true` when passed a string, which seems like it was unintended in the first place. (There are several locations in the codebase that would break should an element be just a string instead of a Node object.)