### PR TITLE
fix(attr): Fix handling of `undefined` as value

### DIFF
--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -86,7 +86,7 @@ var setAttr = function (el, name, value) {
  */
 exports.attr = function (name, value) {
   // Set the value (with attr map support)
-  if (typeof name === 'object' || value !== undefined) {
+  if (typeof name === 'object' || arguments.length > 1) {
     if (typeof value === 'function') {
       return domEach(this, function (i, el) {
         setAttr(el, name, value.call(el, i, el.attribs[name]));
@@ -335,16 +335,13 @@ exports.val = function (value) {
     case 'textarea':
       return this.text(value);
     case 'input':
-      if (this.attr('type') === 'radio') {
-        if (querying) {
-          return this.attr('value');
-        }
-
-        this.attr('value', value);
-        return this;
+      if (querying) {
+        return this.attr('value');
       }
 
-      return this.attr('value', value);
+      this.attr('value', value);
+      return this;
+
     case 'select':
       var option = this.find('option:selected');
       var returnValue;

--- a/test/api/attributes.js
+++ b/test/api/attributes.js
@@ -137,6 +137,23 @@ describe('$(...)', function () {
       expect($pear.attr('autofocus')).to.be(undefined);
       expect($pear.attr('style')).to.equal('color:blue');
     });
+
+    it('(chaining) setting value and calling attr returns result', function () {
+      var pearAttr = $('.pear').attr('foo', 'bar').attr('foo');
+      expect(pearAttr).to.equal('bar');
+    });
+
+    it('(chaining) setting attr to null returns a $', function () {
+      var $pear = $('.pear').attr('foo', null);
+      expect($pear).to.be.a($);
+    });
+
+    it('(chaining) setting attr to undefined returns a $', function () {
+      var $pear = $('.pear').attr('foo', undefined);
+      expect($('.pear')).to.have.length(1);
+      expect($('.pear').attr('foo')).to.be('undefined');
+      expect($pear).to.be.a($);
+    });
   });
 
   describe('.prop', function () {


### PR DESCRIPTION
Fixes #554

This makes cheerio behave like jQuery with these values.

Tests were part of the issue above, contributed by @iwarren.