### PR TITLE
refactor: Move parsers to their own files

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,10 +1,9 @@
 /*
   Module Dependencies
 */
-var htmlparser = require('htmlparser2');
-var parse5 = require('parse5');
-var htmlparser2Adapter = require('parse5-htmlparser2-tree-adapter');
-var DomUtils = htmlparser.DomUtils;
+var DomUtils = require('htmlparser2').DomUtils;
+var parseWithHtmlparser2 = require('./parsers/htmlparser2').parse;
+var parseWithParse5 = require('./parsers/parse5').parse;
 var Document = require('domhandler').Document;
 
 /*
@@ -17,7 +16,7 @@ exports = module.exports = function parse(content, options, isDocument) {
 
   if (typeof content === 'string') {
     return options.xmlMode || options._useHtmlParser2
-      ? htmlparser.parseDocument(content, options)
+      ? parseWithHtmlparser2(content, options)
       : parseWithParse5(content, options, isDocument);
   }
 
@@ -38,15 +37,6 @@ exports = module.exports = function parse(content, options, isDocument) {
 
   return root;
 };
-
-function parseWithParse5(content, options, isDocument) {
-  var parse = isDocument ? parse5.parse : parse5.parseFragment;
-
-  return parse(content, {
-    treeAdapter: htmlparser2Adapter,
-    sourceCodeLocationInfo: options.sourceCodeLocationInfo,
-  });
-}
 
 /*
   Update the dom structure, for one changed layer

--- a/lib/parsers/htmlparser2.js
+++ b/lib/parsers/htmlparser2.js
@@ -1,0 +1,2 @@
+exports.parse = require('htmlparser2').parseDocument;
+exports.render = require('dom-serializer').default;

--- a/lib/parsers/parse5.js
+++ b/lib/parsers/parse5.js
@@ -1,0 +1,28 @@
+var parse5 = require('parse5');
+var htmlparser2Adapter = require('parse5-htmlparser2-tree-adapter');
+
+exports.parse = function (content, options, isDocument) {
+  var parse = isDocument ? parse5.parse : parse5.parseFragment;
+
+  return parse(content, {
+    treeAdapter: htmlparser2Adapter,
+    sourceCodeLocationInfo: options.sourceCodeLocationInfo,
+  });
+};
+
+exports.render = function (dom) {
+  // `dom-serializer` passes over the special "root" node and renders the
+  // node's children in its place. To mimic this behavior with `parse5`, an
+  // equivalent operation must be applied to the input array.
+  var nodes = 'length' in dom ? dom : [dom];
+  for (var index = 0; index < nodes.length; index += 1) {
+    if (nodes[index].type === 'root') {
+      nodes.splice.apply(nodes, [index, 1].concat(nodes[index].children));
+    }
+  }
+
+  return parse5.serialize(
+    { children: nodes },
+    { treeAdapter: htmlparser2Adapter }
+  );
+};

--- a/lib/static.js
+++ b/lib/static.js
@@ -1,15 +1,12 @@
-var htmlparser2Adapter = require('parse5-htmlparser2-tree-adapter');
-
 /**
  * @module cheerio/static
  * @ignore
  */
-
-var serialize = require('dom-serializer').default;
 var defaultOptions = require('./options').default;
 var flattenOptions = require('./options').flatten;
 var select = require('cheerio-select-tmp').select;
-var parse5 = require('parse5');
+var renderWithParse5 = require('./parsers/parse5').render;
+var renderWithHtmlparser2 = require('./parsers/htmlparser2').render;
 var parse = require('./parse');
 
 /**
@@ -84,24 +81,9 @@ function render(that, dom, options) {
     dom = select(dom, that._root, options);
   }
 
-  if (options.xmlMode || options._useHtmlParser2) {
-    return serialize(dom, options);
-  }
-
-  // `dom-serializer` passes over the special "root" node and renders the
-  // node's children in its place. To mimic this behavior with `parse5`, an
-  // equivalent operation must be applied to the input array.
-  var nodes = 'length' in dom ? dom : [dom];
-  for (var index = 0; index < nodes.length; index += 1) {
-    if (nodes[index].type === 'root') {
-      nodes.splice.apply(nodes, [index, 1].concat(nodes[index].children));
-    }
-  }
-
-  return parse5.serialize(
-    { children: nodes },
-    { treeAdapter: htmlparser2Adapter }
-  );
+  return options.xmlMode || options._useHtmlParser2
+    ? renderWithHtmlparser2(dom, options)
+    : renderWithParse5(dom);
 }
 
 /**


### PR DESCRIPTION
First step to allow us to provide different entry points for different needs.