### PR TITLE
docs(jsdoc): Add docs, standardize

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,6 @@
   "extends": ["eslint:recommended", "plugin:jsdoc/recommended", "prettier"],
   "globals": { "Set": true, "Symbol": true },
   "rules": {
-    "no-eq-null": 0,
     "no-proto": 2,
     "curly": [2, "multi-line"],
     "one-var": [2, "never"],
@@ -14,6 +13,7 @@
     "no-shadow": 2,
     "no-use-before-define": [2, "nofunc"],
 
+    "jsdoc/require-jsdoc": 0,
     "jsdoc/check-param-names": 2,
     "jsdoc/check-tag-names": 2,
     "jsdoc/check-types": 2,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,7 @@
     "node": true
   },
   "plugins": ["jsdoc"],
-  "extends": ["eslint:recommended", "prettier"],
+  "extends": ["eslint:recommended", "plugin:jsdoc/recommended", "prettier"],
   "globals": { "Set": true, "Symbol": true },
   "rules": {
     "no-eq-null": 0,
@@ -30,6 +30,10 @@
     "jsdoc": {
       "additionalTagNames": {
         "customTags": ["hideconstructor"]
+      },
+      "preferredTypes": {
+        "node": "Node",
+        "cheerio": "Cheerio"
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -22,44 +22,44 @@ exports.text = staticMethods.text;
 exports.xml = staticMethods.xml;
 
 /**
- * In order to promote consistency with the jQuery library, users are
- * encouraged to instead use the static method of the same name.
+ * In order to promote consistency with the jQuery library, users are encouraged
+ * to instead use the static method of the same name.
  *
+ * @deprecated
  * @example
- *     var $ = cheerio.load('<div><p></p></div>');
- *     $.contains($('div').get(0), $('p').get(0)); // true
- *     $.contains($('p').get(0), $('div').get(0)); // false
+ *   var $ = cheerio.load('<div><p></p></div>');
+ *   $.contains($('div').get(0), $('p').get(0)); // true
+ *   $.contains($('p').get(0), $('div').get(0)); // false
  *
  * @function
  * @returns {boolean}
- * @deprecated
  */
 exports.contains = staticMethods.contains;
 
 /**
- * In order to promote consistency with the jQuery library, users are
- * encouraged to instead use the static method of the same name.
+ * In order to promote consistency with the jQuery library, users are encouraged
+ * to instead use the static method of the same name.
  *
+ * @deprecated
  * @example
- *     var $ = cheerio.load('');
- *     $.merge([1, 2], [3, 4]) // [1, 2, 3, 4]
+ *   var $ = cheerio.load('');
+ *   $.merge([1, 2], [3, 4]); // [1, 2, 3, 4]
  *
  * @function
- * @deprecated
  */
 exports.merge = staticMethods.merge;
 
 /**
- * In order to promote consistency with the jQuery library, users are
- * encouraged to instead use the static method of the same name as it is
- * defined on the "loaded" Cheerio factory function.
+ * In order to promote consistency with the jQuery library, users are encouraged
+ * to instead use the static method of the same name as it is defined on the
+ * "loaded" Cheerio factory function.
  *
+ * @deprecated See {@link static/parseHTML}.
  * @example
- *     var $ = cheerio.load('');
- *     $.parseHTML('<b>markup</b>');
+ *   var $ = cheerio.load('');
+ *   $.parseHTML('<b>markup</b>');
  *
  * @function
- * @deprecated See {@link static/parseHTML}.
  */
 exports.parseHTML = staticMethods.parseHTML;
 
@@ -67,11 +67,11 @@ exports.parseHTML = staticMethods.parseHTML;
  * Users seeking to access the top-level element of a parsed document should
  * instead use the `root` static method of a "loaded" Cheerio function.
  *
+ * @deprecated
  * @example
- *     var $ = cheerio.load('');
- *     $.root();
+ *   var $ = cheerio.load('');
+ *   $.root();
  *
  * @function
- * @deprecated
  */
 exports.root = staticMethods.root;

--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -361,7 +361,7 @@ exports.val = function (value) {
  * Remove an attribute.
  *
  * @private
- * @param {node} elem - Node to remove attribute from.
+ * @param {Node} elem - Node to remove attribute from.
  * @param {string} name - Name of the attribute to remove.
  */
 function removeAttribute(elem, name) {
@@ -635,7 +635,7 @@ exports.toggleClass = function (value, stateVal) {
  * function, the function is executed in the context of the selected element,
  * so `this` refers to the current element.
  *
- * @param {string|Function|cheerio|node} selector - Selector for the selection.
+ * @param {string | Function | Cheerio | Node} selector - Selector for the selection.
  *
  * @see {@link http://api.jquery.com/is/}
  */

--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -25,6 +25,17 @@ var rboolean = /^(?:autofocus|autoplay|async|checked|controls|defer|disabled|hid
 // Matches strings that look like JSON objects or arrays
 var rbrace = /^(?:\{[\w\W]*\}|\[[\w\W]*\])$/;
 
+/**
+ * Gets a node's attribute. For boolean attributes, it will return
+ * the value's name should it be set.
+ *
+ * Also supports getting the `value` of several form elements.
+ *
+ * @private
+ * @param {Node} elem - Elenent to get the attribute of.
+ * @param {string} name - Name of the attribute.
+ * @returns {string|undefined} The attribute's value.
+ */
 function getAttr(elem, name) {
   if (!elem || !isTag(elem)) return;
 
@@ -57,6 +68,15 @@ function getAttr(elem, name) {
   }
 }
 
+/**
+ * Sets the value of an attribute.
+ * The attribute will be deleted if the value is `null`.
+ *
+ * @private
+ * @param {Node} el - The element to set the attribute on.
+ * @param {string} name - The attribute's name.
+ * @param {string|null} value - The attribute's value.
+ */
 function setAttr(el, name, value) {
   if (value === null) {
     removeAttribute(el, name);
@@ -81,6 +101,7 @@ function setAttr(el, name, value) {
  *
  * @param {string} name - Name of the attribute.
  * @param {string} [value] - If specified sets the value of the attribute.
+ * @returns {string|Cheerio} If `value` is specified the instance itself, otherwise the attribute's value.
  *
  * @see {@link http://api.jquery.com/attr/}
  */
@@ -109,6 +130,14 @@ exports.attr = function (name, value) {
   return getAttr(this[0], name);
 };
 
+/**
+ * Gets a node's prop.
+ *
+ * @private
+ * @param {Node} el - Elenent to get the prop of.
+ * @param {string} name - Name of the prop.
+ * @returns {string|undefined} The prop's value.
+ */
 function getProp(el, name) {
   if (!el || !isTag(el)) return;
 
@@ -119,6 +148,14 @@ function getProp(el, name) {
     : getAttr(el, name);
 }
 
+/**
+ * Sets the value of a prop.
+ *
+ * @private
+ * @param {Node} el - The element to set the prop on.
+ * @param {string} name - The prop's name.
+ * @param {string|null} value - The prop's value.
+ */
 function setProp(el, name, value) {
   if (name in el) {
     el[name] = value;
@@ -131,6 +168,7 @@ function setProp(el, name, value) {
  * Method for getting and setting properties. Gets the property value for only
  * the first element in the matched set.
  *
+ * @returns {string|Cheerio} If `value` is specified the instance itself, otherwise the prop's value.
  * @example
  *
  * $('input[type="checkbox"]').prop('checked')
@@ -197,21 +235,36 @@ exports.prop = function (name, value) {
   }
 };
 
+/**
+ * Sets the value of a data attribute.
+ *
+ * @private
+ * @param {Node} el - The element to set the data attribute on.
+ * @param {string|object.<string,*>} name - The data attribute's name.
+ * @param {string|null} value - The data attribute's value.
+ */
 function setData(el, name, value) {
   if (!el.data) {
     el.data = {};
   }
 
-  if (typeof name === 'object') return Object.assign(el.data, name);
-  if (typeof name === 'string' && value !== undefined) {
+  if (typeof name === 'object') Object.assign(el.data, name);
+  else if (typeof name === 'string' && value !== undefined) {
     el.data[name] = value;
   }
 }
 
-// Read the specified attribute from the equivalent HTML5 `data-*` attribute,
-// and (if present) cache the value in the node's internal data store. If no
-// attribute name is specified, read *all* HTML5 `data-*` attributes in this
-// manner.
+/**
+ * Read the specified attribute from the equivalent HTML5 `data-*` attribute,
+ * and (if present) cache the value in the node's internal data store. If no
+ * attribute name is specified, read *all* HTML5 `data-*` attributes in this
+ * manner.
+ *
+ * @private
+ * @param {Node} el - Elenent to get the data attribute of.
+ * @param {string} [name] - Name of the data attribute.
+ * @returns {*} The data attribute's value, or a map with all of the data attribute.
+ */
 function readData(el, name) {
   var readAll = arguments.length === 1;
   var domNames;
@@ -273,6 +326,7 @@ function readData(el, name) {
  *
  * @param {string} name - Name of the attribute.
  * @param {any} [value] - If specified new value.
+ * @returns {string|Cheerio} If `value` is specified the instance itself, otherwise the data attribute's value.
  *
  * @see {@link http://api.jquery.com/data/}
  */
@@ -307,6 +361,7 @@ exports.data = function (name, value) {
  * Method for getting and setting the value of input, select, and textarea.
  * Note: Support for `map`, and `function` has not been added yet.
  *
+ * @returns {string|Cheerio} If a new `value` is specified the instance itself, otherwise the value.
  * @example
  *
  * $('input[type="text"]').val()
@@ -394,6 +449,7 @@ function splitNames(names) {
  * //=> <li>Apple</li>
  *
  * @param {string} name - Name of the attribute.
+ * @returns {Cheerio} The instance itself.
  *
  * @see {@link http://api.jquery.com/removeAttr/}
  */
@@ -424,7 +480,7 @@ exports.removeAttr = function (name) {
  * //=> true
  *
  * @param {string} className - Name of the class.
- * @returns {boolean}
+ * @returns {boolean} Indicates if an element has the given `className`.
  *
  * @see {@link http://api.jquery.com/hasClass/}
  */
@@ -461,6 +517,7 @@ exports.hasClass = function (className) {
  * //=> <li class="apple fruit red">Apple</li>
  *
  * @param {string} value - Name of new class.
+ * @returns {Cheerio} The instance itself.
  *
  * @see {@link http://api.jquery.com/addClass/}
  */
@@ -517,6 +574,7 @@ exports.addClass = function (value) {
  * $('.apple').addClass('red').removeClass().html()
  * //=> <li class="">Apple</li>
  * @param {string} value - Name of the class.
+ * @returns {Cheerio} The instance itself.
  *
  * @see {@link http://api.jquery.com/removeClass/}
  */
@@ -579,6 +637,7 @@ exports.removeClass = function (value) {
  *
  * @param {(string|Function)} value - Name of the class. Can also be a function.
  * @param {boolean} [stateVal] - If specified the state of the class.
+ * @returns {Cheerio} The instance itself.
  *
  * @see {@link http://api.jquery.com/toggleClass/}
  */
@@ -636,6 +695,7 @@ exports.toggleClass = function (value, stateVal) {
  * so `this` refers to the current element.
  *
  * @param {string | Function | Cheerio | Node} selector - Selector for the selection.
+ * @returns {Cheerio} The instance itself.
  *
  * @see {@link http://api.jquery.com/is/}
  */

--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -26,15 +26,15 @@ var rboolean = /^(?:autofocus|autoplay|async|checked|controls|defer|disabled|hid
 var rbrace = /^(?:\{[\w\W]*\}|\[[\w\W]*\])$/;
 
 /**
- * Gets a node's attribute. For boolean attributes, it will return
- * the value's name should it be set.
+ * Gets a node's attribute. For boolean attributes, it will return the value's
+ * name should it be set.
  *
  * Also supports getting the `value` of several form elements.
  *
  * @private
  * @param {Node} elem - Elenent to get the attribute of.
  * @param {string} name - Name of the attribute.
- * @returns {string|undefined} The attribute's value.
+ * @returns {string | undefined} The attribute's value.
  */
 function getAttr(elem, name) {
   if (!elem || !isTag(elem)) return;
@@ -69,13 +69,12 @@ function getAttr(elem, name) {
 }
 
 /**
- * Sets the value of an attribute.
- * The attribute will be deleted if the value is `null`.
+ * Sets the value of an attribute. The attribute will be deleted if the value is `null`.
  *
  * @private
  * @param {Node} el - The element to set the attribute on.
  * @param {string} name - The attribute's name.
- * @param {string|null} value - The attribute's value.
+ * @param {string | null} value - The attribute's value.
  */
 function setAttr(el, name, value) {
   if (value === null) {
@@ -92,18 +91,18 @@ function setAttr(el, name, value) {
  * like jQuery.
  *
  * @example
+ *   $('ul').attr('id');
+ *   //=> fruits
  *
- * $('ul').attr('id')
- * //=> fruits
- *
- * $('.apple').attr('id', 'favorite').html()
- * //=> <li class="apple" id="favorite">Apple</li>
+ *   $('.apple').attr('id', 'favorite').html();
+ *   //=> <li class="apple" id="favorite">Apple</li>
  *
  * @param {string} name - Name of the attribute.
  * @param {string} [value] - If specified sets the value of the attribute.
- * @returns {string|Cheerio} If `value` is specified the instance itself, otherwise the attribute's value.
- *
  * @see {@link http://api.jquery.com/attr/}
+ *
+ * @returns {string | Cheerio} If `value` is specified the instance itself,
+ *     otherwise the attribute's value.
  */
 exports.attr = function (name, value) {
   // Set the value (with attr map support)
@@ -136,7 +135,7 @@ exports.attr = function (name, value) {
  * @private
  * @param {Node} el - Elenent to get the prop of.
  * @param {string} name - Name of the prop.
- * @returns {string|undefined} The prop's value.
+ * @returns {string | undefined} The prop's value.
  */
 function getProp(el, name) {
   if (!el || !isTag(el)) return;
@@ -154,7 +153,7 @@ function getProp(el, name) {
  * @private
  * @param {Node} el - The element to set the prop on.
  * @param {string} name - The prop's name.
- * @param {string|null} value - The prop's value.
+ * @param {string | null} value - The prop's value.
  */
 function setProp(el, name, value) {
   if (name in el) {
@@ -168,19 +167,19 @@ function setProp(el, name, value) {
  * Method for getting and setting properties. Gets the property value for only
  * the first element in the matched set.
  *
- * @returns {string|Cheerio} If `value` is specified the instance itself, otherwise the prop's value.
  * @example
+ *   $('input[type="checkbox"]').prop('checked');
+ *   //=> false
  *
- * $('input[type="checkbox"]').prop('checked')
- * //=> false
- *
- * $('input[type="checkbox"]').prop('checked', true).val()
- * //=> ok
+ *   $('input[type="checkbox"]').prop('checked', true).val();
+ *   //=> ok
  *
  * @param {string} name - Name of the property.
  * @param {any} [value] - If specified set the property to this.
- *
  * @see {@link http://api.jquery.com/prop/}
+ *
+ * @returns {string | Cheerio} If `value` is specified the instance itself,
+ *     otherwise the prop's value.
  */
 exports.prop = function (name, value) {
   if (typeof name === 'string' && value === undefined) {
@@ -240,8 +239,8 @@ exports.prop = function (name, value) {
  *
  * @private
  * @param {Node} el - The element to set the data attribute on.
- * @param {string|object.<string,*>} name - The data attribute's name.
- * @param {string|null} value - The data attribute's value.
+ * @param {string|object<string,*>} name - The data attribute's name.
+ * @param {string | null} value - The data attribute's value.
  */
 function setData(el, name, value) {
   if (!el.data) {
@@ -257,13 +256,12 @@ function setData(el, name, value) {
 /**
  * Read the specified attribute from the equivalent HTML5 `data-*` attribute,
  * and (if present) cache the value in the node's internal data store. If no
- * attribute name is specified, read *all* HTML5 `data-*` attributes in this
- * manner.
+ * attribute name is specified, read *all* HTML5 `data-*` attributes in this manner.
  *
  * @private
  * @param {Node} el - Elenent to get the data attribute of.
  * @param {string} [name] - Name of the data attribute.
- * @returns {*} The data attribute's value, or a map with all of the data attribute.
+ * @returns {any} The data attribute's value, or a map with all of the data attribute.
  */
 function readData(el, name) {
   var readAll = arguments.length === 1;
@@ -313,22 +311,22 @@ function readData(el, name) {
  * attribute value for only the first element in the matched set.
  *
  * @example
+ *   $('<div data-apple-color="red"></div>').data();
+ *   //=> { appleColor: 'red' }
  *
- * $('<div data-apple-color="red"></div>').data()
- * //=> { appleColor: 'red' }
+ *   $('<div data-apple-color="red"></div>').data('apple-color');
+ *   //=> 'red'
  *
- * $('<div data-apple-color="red"></div>').data('apple-color')
- * //=> 'red'
- *
- * const apple = $('.apple').data('kind', 'mac')
- * apple.data('kind')
- * //=> 'mac'
+ *   const apple = $('.apple').data('kind', 'mac');
+ *   apple.data('kind');
+ *   //=> 'mac'
  *
  * @param {string} name - Name of the attribute.
  * @param {any} [value] - If specified new value.
- * @returns {string|Cheerio} If `value` is specified the instance itself, otherwise the data attribute's value.
- *
  * @see {@link http://api.jquery.com/data/}
+ *
+ * @returns {string | Cheerio} If `value` is specified the instance itself,
+ *     otherwise the data attribute's value.
  */
 exports.data = function (name, value) {
   var elem = this[0];
@@ -361,18 +359,18 @@ exports.data = function (name, value) {
  * Method for getting and setting the value of input, select, and textarea.
  * Note: Support for `map`, and `function` has not been added yet.
  *
- * @returns {string|Cheerio} If a new `value` is specified the instance itself, otherwise the value.
  * @example
+ *   $('input[type="text"]').val();
+ *   //=> input_text
  *
- * $('input[type="text"]').val()
- * //=> input_text
- *
- * $('input[type="text"]').val('test').html()
- * //=> <input type="text" value="test"/>
+ *   $('input[type="text"]').val('test').html();
+ *   //=> <input type="text" value="test"/>
  *
  * @param {string} [value] - If specified new value.
- *
  * @see {@link http://api.jquery.com/val/}
+ *
+ * @returns {string | Cheerio} If a new `value` is specified the instance
+ *     itself, otherwise the value.
  */
 exports.val = function (value) {
   var querying = arguments.length === 0;
@@ -426,10 +424,9 @@ function removeAttribute(elem, name) {
 }
 
 /**
- * Splits a space-separated list of names to individual
- * names.
+ * Splits a space-separated list of names to individual names.
  *
- * @param {string} names -  Names to split.
+ * @param {string} names - Names to split.
  * @returns {string[]} - Split names.
  */
 function splitNames(names) {
@@ -440,18 +437,17 @@ function splitNames(names) {
  * Method for removing attributes by `name`.
  *
  * @example
+ *   $('.pear').removeAttr('class').html();
+ *   //=> <li>Pear</li>
  *
- * $('.pear').removeAttr('class').html()
- * //=> <li>Pear</li>
- *
- * $('.apple').attr('id', 'favorite')
- * $('.apple').removeAttr('id class').html()
- * //=> <li>Apple</li>
+ *   $('.apple').attr('id', 'favorite');
+ *   $('.apple').removeAttr('id class').html();
+ *   //=> <li>Apple</li>
  *
  * @param {string} name - Name of the attribute.
- * @returns {Cheerio} The instance itself.
- *
  * @see {@link http://api.jquery.com/removeAttr/}
+ *
+ * @returns {Cheerio} The instance itself.
  */
 exports.removeAttr = function (name) {
   var attrNames = splitNames(name);
@@ -469,20 +465,19 @@ exports.removeAttr = function (name) {
  * Check to see if *any* of the matched elements have the given `className`.
  *
  * @example
+ *   $('.pear').hasClass('pear');
+ *   //=> true
  *
- * $('.pear').hasClass('pear')
- * //=> true
+ *   $('apple').hasClass('fruit');
+ *   //=> false
  *
- * $('apple').hasClass('fruit')
- * //=> false
- *
- * $('li').hasClass('pear')
- * //=> true
+ *   $('li').hasClass('pear');
+ *   //=> true
  *
  * @param {string} className - Name of the class.
- * @returns {boolean} Indicates if an element has the given `className`.
- *
  * @see {@link http://api.jquery.com/hasClass/}
+ *
+ * @returns {boolean} Indicates if an element has the given `className`.
  */
 exports.hasClass = function (className) {
   return this.toArray().some(function (elem) {
@@ -505,21 +500,19 @@ exports.hasClass = function (className) {
 };
 
 /**
- * Adds class(es) to all of the matched elements. Also accepts a `function`
- * like jQuery.
+ * Adds class(es) to all of the matched elements. Also accepts a `function` like jQuery.
  *
  * @example
+ *   $('.pear').addClass('fruit').html();
+ *   //=> <li class="pear fruit">Pear</li>
  *
- * $('.pear').addClass('fruit').html()
- * //=> <li class="pear fruit">Pear</li>
- *
- * $('.apple').addClass('fruit red').html()
- * //=> <li class="apple fruit red">Apple</li>
+ *   $('.apple').addClass('fruit red').html();
+ *   //=> <li class="apple fruit red">Apple</li>
  *
  * @param {string} value - Name of new class.
- * @returns {Cheerio} The instance itself.
- *
  * @see {@link http://api.jquery.com/addClass/}
+ *
+ * @returns {Cheerio} The instance itself.
  */
 exports.addClass = function (value) {
   // Support functions
@@ -562,21 +555,21 @@ exports.addClass = function (value) {
 };
 
 /**
- * Removes one or more space-separated classes from the selected elements. If
- * no `className` is defined, all classes will be removed. Also accepts a
+ * Removes one or more space-separated classes from the selected elements. If no
+ * `className` is defined, all classes will be removed. Also accepts a
  * `function` like jQuery.
  *
  * @example
+ *   $('.pear').removeClass('pear').html();
+ *   //=> <li class="">Pear</li>
  *
- * $('.pear').removeClass('pear').html()
- * //=> <li class="">Pear</li>
+ *   $('.apple').addClass('red').removeClass().html();
+ *   //=> <li class="">Apple</li>
  *
- * $('.apple').addClass('red').removeClass().html()
- * //=> <li class="">Apple</li>
  * @param {string} value - Name of the class.
- * @returns {Cheerio} The instance itself.
- *
  * @see {@link http://api.jquery.com/removeClass/}
+ *
+ * @returns {Cheerio} The instance itself.
  */
 exports.removeClass = function (value) {
   // Handle if value is a function
@@ -628,18 +621,17 @@ exports.removeClass = function (value) {
  * `function` like jQuery.
  *
  * @example
+ *   $('.apple.green').toggleClass('fruit green red').html();
+ *   //=> <li class="apple fruit red">Apple</li>
  *
- * $('.apple.green').toggleClass('fruit green red').html()
- * //=> <li class="apple fruit red">Apple</li>
+ *   $('.apple.green').toggleClass('fruit green red', true).html();
+ *   //=> <li class="apple green fruit red">Apple</li>
  *
- * $('.apple.green').toggleClass('fruit green red', true).html()
- * //=> <li class="apple green fruit red">Apple</li>
- *
- * @param {(string|Function)} value - Name of the class. Can also be a function.
+ * @param {string | Function} value - Name of the class. Can also be a function.
  * @param {boolean} [stateVal] - If specified the state of the class.
- * @returns {Cheerio} The instance itself.
- *
  * @see {@link http://api.jquery.com/toggleClass/}
+ *
+ * @returns {Cheerio} The instance itself.
  */
 exports.toggleClass = function (value, stateVal) {
   // Support functions
@@ -695,9 +687,9 @@ exports.toggleClass = function (value, stateVal) {
  * so `this` refers to the current element.
  *
  * @param {string | Function | Cheerio | Node} selector - Selector for the selection.
- * @returns {Cheerio} The instance itself.
- *
  * @see {@link http://api.jquery.com/is/}
+ *
+ * @returns {Cheerio} The instance itself.
  */
 exports.is = function (selector) {
   if (selector) {

--- a/lib/api/css.js
+++ b/lib/api/css.js
@@ -1,21 +1,18 @@
-/**
- * @module cheerio/css
- */
+/** @module cheerio/css */
 
 var domEach = require('../utils').domEach;
 
 var toString = Object.prototype.toString;
 
 /**
- * Get the value of a style property for the first element in the set of
- * matched elements or set one or more CSS properties for every matched
- * element.
+ * Get the value of a style property for the first element in the set of matched
+ * elements or set one or more CSS properties for every matched element.
  *
- * @param {string|object} prop - The name of the property.
+ * @param {string | object} prop - The name of the property.
  * @param {string} [val] - If specified the new value.
- * @returns {Cheerio} The instance itself.
- *
  * @see {@link http://api.jquery.com/css/}
+ *
+ * @returns {Cheerio} The instance itself.
  */
 exports.css = function (prop, val) {
   if (
@@ -33,11 +30,12 @@ exports.css = function (prop, val) {
 /**
  * Set styles of all elements.
  *
+ * @private
+ *
  * @param {object} el - Element to set style of.
- * @param {string|object} prop - Name of property.
+ * @param {string | object} prop - Name of property.
  * @param {string} val - Value to set property to.
  * @param {number} [idx] - Optional index within the selection.
- * @private
  */
 function setCss(el, prop, val, idx) {
   if ('string' == typeof prop) {
@@ -63,10 +61,11 @@ function setCss(el, prop, val, idx) {
 /**
  * Get parsed styles of the first element.
  *
+ * @private
+ *
  * @param {Node} el - Element to get styles from.
  * @param {string} prop - Name of the prop.
  * @returns {object} The parsed styles.
- * @private
  */
 function getCss(el, prop) {
   if (!el || !el.attribs) {
@@ -91,9 +90,10 @@ function getCss(el, prop) {
 /**
  * Stringify `obj` to styles.
  *
+ * @private
+ *
  * @param {object} obj - Object to stringify.
  * @returns {string} The serialized styles.
- * @private
  */
 function stringify(obj) {
   return Object.keys(obj || {}).reduce(function (str, prop) {
@@ -104,9 +104,10 @@ function stringify(obj) {
 /**
  * Parse `styles`.
  *
+ * @private
+ *
  * @param {string} styles - Styles to be parsed.
  * @returns {object} The parsed styles.
- * @private
  */
 function parse(styles) {
   styles = (styles || '').trim();

--- a/lib/api/css.js
+++ b/lib/api/css.js
@@ -64,7 +64,7 @@ function setCss(el, prop, val, idx) {
 /**
  * Get parsed styles of the first element.
  *
- * @param {node} el - Element to get styles from.
+ * @param {Node} el - Element to get styles from.
  * @param {string} prop - Name of the prop.
  * @returns {object}
  * @private

--- a/lib/api/css.js
+++ b/lib/api/css.js
@@ -13,7 +13,7 @@ var toString = Object.prototype.toString;
  *
  * @param {string|object} prop - The name of the property.
  * @param {string} [val] - If specified the new value.
- * @returns {self}
+ * @returns {Cheerio} The instance itself.
  *
  * @see {@link http://api.jquery.com/css/}
  */
@@ -37,7 +37,6 @@ exports.css = function (prop, val) {
  * @param {string|object} prop - Name of property.
  * @param {string} val - Value to set property to.
  * @param {number} [idx] - Optional index within the selection.
- * @returns {self}
  * @private
  */
 function setCss(el, prop, val, idx) {
@@ -66,7 +65,7 @@ function setCss(el, prop, val, idx) {
  *
  * @param {Node} el - Element to get styles from.
  * @param {string} prop - Name of the prop.
- * @returns {object}
+ * @returns {object} The parsed styles.
  * @private
  */
 function getCss(el, prop) {
@@ -93,7 +92,7 @@ function getCss(el, prop) {
  * Stringify `obj` to styles.
  *
  * @param {object} obj - Object to stringify.
- * @returns {object}
+ * @returns {string} The serialized styles.
  * @private
  */
 function stringify(obj) {
@@ -106,7 +105,7 @@ function stringify(obj) {
  * Parse `styles`.
  *
  * @param {string} styles - Styles to be parsed.
- * @returns {object}
+ * @returns {object} The parsed styles.
  * @private
  */
 function parse(styles) {

--- a/lib/api/forms.js
+++ b/lib/api/forms.js
@@ -11,6 +11,7 @@ var rCRLF = /\r?\n/g;
 /**
  * Encode a set of form elements as a string for submission.
  *
+ * @returns {string} The serialized form.
  * @see {@link http://api.jquery.com/serialize/}
  */
 exports.serialize = function () {
@@ -29,6 +30,7 @@ exports.serialize = function () {
 /**
  * Encode a set of form elements as an array of names and values.
  *
+ * @returns {{name:string, value:string}[]} The serialized form.
  * @example
  * $('<form><input name="foo" value="bar" /></form>').serializeArray()
  * //=> [ { name: 'foo', value: 'bar' } ]

--- a/lib/api/forms.js
+++ b/lib/api/forms.js
@@ -1,6 +1,4 @@
-/**
- * @module cheerio/forms
- */
+/** @module cheerio/forms */
 
 // https://github.com/jquery/jquery/blob/2.1.3/src/manipulation/var/rcheckableType.js
 // https://github.com/jquery/jquery/blob/2.1.3/src/serialize.js
@@ -11,8 +9,9 @@ var rCRLF = /\r?\n/g;
 /**
  * Encode a set of form elements as a string for submission.
  *
- * @returns {string} The serialized form.
  * @see {@link http://api.jquery.com/serialize/}
+ *
+ * @returns {string} The serialized form.
  */
 exports.serialize = function () {
   // Convert form elements into name/value objects
@@ -30,12 +29,13 @@ exports.serialize = function () {
 /**
  * Encode a set of form elements as an array of names and values.
  *
- * @returns {{name:string, value:string}[]} The serialized form.
  * @example
- * $('<form><input name="foo" value="bar" /></form>').serializeArray()
- * //=> [ { name: 'foo', value: 'bar' } ]
+ *   $('<form><input name="foo" value="bar" /></form>').serializeArray();
+ *   //=> [ { name: 'foo', value: 'bar' } ]
  *
  * @see {@link http://api.jquery.com/serializeArray/}
+ *
+ * @returns {{ name: string; value: string }[]} The serialized form.
  */
 exports.serializeArray = function () {
   // Resolve all form elements from either forms or collections of form elements

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -22,6 +22,7 @@ var DomUtils = require('htmlparser2').DomUtils;
  *
  * @param {Cheerio | string | Cheerio[] | string[]} [elem] - Elements to make an array of.
  * @param {boolean} [clone] - Optionally clone nodes.
+ * @returns {Node[]} The array of nodes.
  * @private
  */
 exports._makeDomArray = function makeDomArray(elem, clone) {
@@ -59,14 +60,16 @@ function _insert(concatenator) {
   };
 }
 
-/*
+/**
  * Modify an array in-place, removing some number of elements and adding new
  * elements directly following them.
  *
- * @param {Array} array Target array to splice.
- * @param {Number} spliceIdx Index at which to begin changing the array.
- * @param {Number} spliceCount Number of elements to remove from the array.
- * @param {Array} newElems Elements to insert into the array.
+ * @param {Node[]} array - Target array to splice.
+ * @param {number} spliceIdx - Index at which to begin changing the array.
+ * @param {number} spliceCount - Number of elements to remove from the array.
+ * @param {Node[]} newElems - Elements to insert into the array.
+ * @param {Node} parent - The parent of the node.
+ * @returns {Node[]} The spliced array.
  *
  * @private
  */
@@ -117,6 +120,7 @@ function uniqueSplice(array, spliceIdx, spliceCount, newElems, parent) {
  * target.
  *
  * @param {string | Cheerio} target - Element to append elements to.
+ * @returns {Cheerio} The instance itself.
  *
  * @example
  *
@@ -151,6 +155,7 @@ exports.appendTo = function (target) {
  * target.
  *
  * @param {string | Cheerio} target - Element to prepend elements to.
+ * @returns {Cheerio} The instance itself.
  *
  * @example
  *
@@ -366,6 +371,7 @@ exports.wrapInner = _wrap(function (el, elInsertLocation, wrapperDom) {
 /**
  * Insert content next to each element in the set of matched elements.
  *
+ * @returns {Cheerio} The instance itself.
  * @example
  *
  * $('.apple').after('<li class="plum">Plum</li>')
@@ -410,6 +416,7 @@ exports.after = function () {
 /**
  * Insert every element in the set of matched elements after the target.
  *
+ * @returns {Cheerio} The set of newly inserted elements.
  * @example
  *
  * $('<li class="plum">Plum</li>').insertAfter('.apple')
@@ -461,6 +468,7 @@ exports.insertAfter = function (target) {
 /**
  * Insert content previous to each element in the set of matched elements.
  *
+ * @returns {Cheerio} The instance itself.
  * @example
  *
  * $('.apple').before('<li class="plum">Plum</li>')
@@ -505,6 +513,7 @@ exports.before = function () {
 /**
  * Insert every element in the set of matched elements before the target.
  *
+ * @returns {Cheerio} The set of newly inserted elements.
  * @example
  *
  * $('<li class="plum">Plum</li>').insertBefore('.apple')
@@ -557,6 +566,7 @@ exports.insertBefore = function (target) {
  * Removes the set of matched elements from the DOM and all their children.
  * `selector` filters the set of matched elements to be removed.
  *
+ * @returns {Cheerio} The instance itself.
  * @example
  *
  * $('.pear').remove()
@@ -585,6 +595,7 @@ exports.remove = function (selector) {
 /**
  * Replaces matched elements with `content`.
  *
+ * @returns {Cheerio} The instance itself.
  * @example
  *
  * const plum = $('<li class="plum">Plum</li>')
@@ -630,6 +641,7 @@ exports.replaceWith = function (content) {
 /**
  * Empties an element, removing all its children.
  *
+ * @returns {Cheerio} The instance itself.
  * @example
  *
  * $('ul').empty()
@@ -653,6 +665,7 @@ exports.empty = function () {
  * is specified, each selected element's content is replaced by the new
  * content.
  *
+ * @returns {Cheerio} The instance itself.
  * @param {string} str - If specified used to replace selection's contents.
  *
  * @example
@@ -686,6 +699,11 @@ exports.html = function (str) {
   });
 };
 
+/**
+ * Turns the collection to a string. Alias for `.html()`.
+ *
+ * @returns {string} The rendered document.
+ */
 exports.toString = function () {
   return html(this, this.options);
 };
@@ -696,6 +714,7 @@ exports.toString = function () {
  * selected element's content is replaced by the new text content.
  *
  * @param {string} [str] - If specified replacement for the selected element's contents.
+ * @returns {Cheerio | string} The instance itself when setting text, otherwise the rendered document.
  *
  * @example
  *
@@ -735,6 +754,7 @@ exports.text = function (str) {
 /**
  * Clone the cheerio object.
  *
+ * @returns {Cheerio} The cloned object.
  * @example
  *
  * const moreFruit = $('#fruits').clone()

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -20,7 +20,7 @@ var DomUtils = require('htmlparser2').DomUtils;
  * Create an array of nodes, recursing into arrays and parsing strings if
  * necessary.
  *
- * @param {cheerio|string|cheerio[]|string[]} [elem] - Elements to make an array of.
+ * @param {Cheerio | string | Cheerio[] | string[]} [elem] - Elements to make an array of.
  * @param {boolean} [clone] - Optionally clone nodes.
  * @private
  */
@@ -116,7 +116,7 @@ function uniqueSplice(array, spliceIdx, spliceCount, newElems, parent) {
  * Insert every element in the set of matched elements to the end of the
  * target.
  *
- * @param {string|cheerio} target - Element to append elements to.
+ * @param {string | Cheerio} target - Element to append elements to.
  *
  * @example
  *
@@ -150,7 +150,7 @@ exports.appendTo = function (target) {
  * Insert every element in the set of matched elements to the beginning of the
  * target.
  *
- * @param {string|cheerio} target - Element to prepend elements to.
+ * @param {string | Cheerio} target - Element to prepend elements to.
  *
  * @example
  *
@@ -275,7 +275,7 @@ function _wrap(insert) {
  * set of matched elements. This method returns the original set of elements
  * for chaining purposes.
  *
- * @param {cheerio} wrapper - The DOM structure to wrap around each element in the selection.
+ * @param {Cheerio} wrapper - The DOM structure to wrap around each element in the selection.
  *
  * @example
  *
@@ -326,7 +326,7 @@ exports.wrap = _wrap(function (el, elInsertLocation, wrapperDom) {
  * structure will be wrapped around the content of each of the elements in the set
  * of matched elements.
  *
- * @param {cheerio} wrapper - The DOM structure to wrap around the content of each element in the selection.
+ * @param {Cheerio} wrapper - The DOM structure to wrap around the content of each element in the selection.
  *
  * @example
  *
@@ -421,7 +421,7 @@ exports.after = function () {
  * //      <li class="pear">Pear</li>
  * //    </ul>
  *
- * @param {string|cheerio} target - Element to insert elements after.
+ * @param {string | Cheerio} target - Element to insert elements after.
  *
  * @see {@link http://api.jquery.com/insertAfter/}
  */
@@ -516,7 +516,7 @@ exports.before = function () {
  * //      <li class="pear">Pear</li>
  * //    </ul>
  *
- * @param {string|cheerio} target - Element to insert elements before.
+ * @param {string | Cheerio} target - Element to insert elements before.
  *
  * @see {@link http://api.jquery.com/insertBefore/}
  */
@@ -596,7 +596,7 @@ exports.remove = function (selector) {
  * //     <li class="plum">Plum</li>
  * //   </ul>
  *
- * @param {cheerio|Function} content - Replacement for matched elements.
+ * @param {Cheerio | Function} content - Replacement for matched elements.
  *
  * @see {@link http://api.jquery.com/replaceWith/}
  */

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -17,13 +17,13 @@ var domhandler = require('domhandler');
 var DomUtils = require('htmlparser2').DomUtils;
 
 /**
- * Create an array of nodes, recursing into arrays and parsing strings if
- * necessary.
+ * Create an array of nodes, recursing into arrays and parsing strings if necessary.
+ *
+ * @private
  *
  * @param {Cheerio | string | Cheerio[] | string[]} [elem] - Elements to make an array of.
  * @param {boolean} [clone] - Optionally clone nodes.
  * @returns {Node[]} The array of nodes.
- * @private
  */
 exports._makeDomArray = function makeDomArray(elem, clone) {
   if (elem == null) {
@@ -64,14 +64,14 @@ function _insert(concatenator) {
  * Modify an array in-place, removing some number of elements and adding new
  * elements directly following them.
  *
+ * @private
+ *
  * @param {Node[]} array - Target array to splice.
  * @param {number} spliceIdx - Index at which to begin changing the array.
  * @param {number} spliceCount - Number of elements to remove from the array.
  * @param {Node[]} newElems - Elements to insert into the array.
  * @param {Node} parent - The parent of the node.
  * @returns {Node[]} The spliced array.
- *
- * @private
  */
 function uniqueSplice(array, spliceIdx, spliceCount, newElems, parent) {
   var spliceArgs = [spliceIdx, spliceCount].concat(newElems);
@@ -116,24 +116,22 @@ function uniqueSplice(array, spliceIdx, spliceCount, newElems, parent) {
 }
 
 /**
- * Insert every element in the set of matched elements to the end of the
- * target.
- *
- * @param {string | Cheerio} target - Element to append elements to.
- * @returns {Cheerio} The instance itself.
+ * Insert every element in the set of matched elements to the end of the target.
  *
  * @example
+ *   $('<li class="plum">Plum</li>').appendTo('#fruits');
+ *   $.html();
+ *   //=>  <ul id="fruits">
+ *   //      <li class="apple">Apple</li>
+ *   //      <li class="orange">Orange</li>
+ *   //      <li class="pear">Pear</li>
+ *   //      <li class="plum">Plum</li>
+ *   //    </ul>
  *
- * $('<li class="plum">Plum</li>').appendTo('#fruits')
- * $.html()
- * //=>  <ul id="fruits">
- * //      <li class="apple">Apple</li>
- * //      <li class="orange">Orange</li>
- * //      <li class="pear">Pear</li>
- * //      <li class="plum">Plum</li>
- * //    </ul>
- *
+ * @param {string | Cheerio} target - Element to append elements to.
  * @see {@link http://api.jquery.com/appendTo/}
+ *
+ * @returns {Cheerio} The instance itself.
  */
 exports.appendTo = function (target) {
   if (!target.cheerio) {
@@ -151,24 +149,22 @@ exports.appendTo = function (target) {
 };
 
 /**
- * Insert every element in the set of matched elements to the beginning of the
- * target.
- *
- * @param {string | Cheerio} target - Element to prepend elements to.
- * @returns {Cheerio} The instance itself.
+ * Insert every element in the set of matched elements to the beginning of the target.
  *
  * @example
+ *   $('<li class="plum">Plum</li>').prependTo('#fruits');
+ *   $.html();
+ *   //=>  <ul id="fruits">
+ *   //      <li class="plum">Plum</li>
+ *   //      <li class="apple">Apple</li>
+ *   //      <li class="orange">Orange</li>
+ *   //      <li class="pear">Pear</li>
+ *   //    </ul>
  *
- * $('<li class="plum">Plum</li>').prependTo('#fruits')
- * $.html()
- * //=>  <ul id="fruits">
- * //      <li class="plum">Plum</li>
- * //      <li class="apple">Apple</li>
- * //      <li class="orange">Orange</li>
- * //      <li class="pear">Pear</li>
- * //    </ul>
- *
+ * @param {string | Cheerio} target - Element to prepend elements to.
  * @see {@link http://api.jquery.com/prependTo/}
+ *
+ * @returns {Cheerio} The instance itself.
  */
 exports.prependTo = function (target) {
   if (!target.cheerio) {
@@ -188,18 +184,17 @@ exports.prependTo = function (target) {
 /**
  * Inserts content as the *last* child of each of the selected elements.
  *
- * @function
- *
  * @example
+ *   $('ul').append('<li class="plum">Plum</li>');
+ *   $.html();
+ *   //=>  <ul id="fruits">
+ *   //      <li class="apple">Apple</li>
+ *   //      <li class="orange">Orange</li>
+ *   //      <li class="pear">Pear</li>
+ *   //      <li class="plum">Plum</li>
+ *   //    </ul>
  *
- * $('ul').append('<li class="plum">Plum</li>')
- * $.html()
- * //=>  <ul id="fruits">
- * //      <li class="apple">Apple</li>
- * //      <li class="orange">Orange</li>
- * //      <li class="pear">Pear</li>
- * //      <li class="plum">Plum</li>
- * //    </ul>
+ * @function
  *
  * @see {@link http://api.jquery.com/append/}
  */
@@ -210,18 +205,17 @@ exports.append = _insert(function (dom, children, parent) {
 /**
  * Inserts content as the *first* child of each of the selected elements.
  *
- * @function
- *
  * @example
+ *   $('ul').prepend('<li class="plum">Plum</li>');
+ *   $.html();
+ *   //=>  <ul id="fruits">
+ *   //      <li class="plum">Plum</li>
+ *   //      <li class="apple">Apple</li>
+ *   //      <li class="orange">Orange</li>
+ *   //      <li class="pear">Pear</li>
+ *   //    </ul>
  *
- * $('ul').prepend('<li class="plum">Plum</li>')
- * $.html()
- * //=>  <ul id="fruits">
- * //      <li class="plum">Plum</li>
- * //      <li class="apple">Apple</li>
- * //      <li class="orange">Orange</li>
- * //      <li class="pear">Pear</li>
- * //    </ul>
+ * @function
  *
  * @see {@link http://api.jquery.com/prepend/}
  */
@@ -280,36 +274,35 @@ function _wrap(insert) {
  * set of matched elements. This method returns the original set of elements
  * for chaining purposes.
  *
- * @param {Cheerio} wrapper - The DOM structure to wrap around each element in the selection.
- *
  * @example
+ *   const redFruit = $('<div class="red-fruit"></div>');
+ *   $('.apple').wrap(redFruit);
  *
- * const redFruit = $('<div class="red-fruit"></div>')
- * $('.apple').wrap(redFruit)
+ *   //=> <ul id="fruits">
+ *   //     <div class="red-fruit">
+ *   //      <li class="apple">Apple</li>
+ *   //     </div>
+ *   //     <li class="orange">Orange</li>
+ *   //     <li class="plum">Plum</li>
+ *   //   </ul>
  *
- * //=> <ul id="fruits">
- * //     <div class="red-fruit">
- * //      <li class="apple">Apple</li>
- * //     </div>
- * //     <li class="orange">Orange</li>
- * //     <li class="plum">Plum</li>
- * //   </ul>
+ *   const healthy = $('<div class="healthy"></div>');
+ *   $('li').wrap(healthy);
  *
- * const healthy = $('<div class="healthy"></div>')
- * $('li').wrap(healthy)
+ *   //=> <ul id="fruits">
+ *   //     <div class="healthy">
+ *   //       <li class="apple">Apple</li>
+ *   //     </div>
+ *   //     <div class="healthy">
+ *   //       <li class="orange">Orange</li>
+ *   //     </div>
+ *   //     <div class="healthy">
+ *   //        <li class="plum">Plum</li>
+ *   //     </div>
+ *   //   </ul>
  *
- * //=> <ul id="fruits">
- * //     <div class="healthy">
- * //       <li class="apple">Apple</li>
- * //     </div>
- * //     <div class="healthy">
- * //       <li class="orange">Orange</li>
- * //     </div>
- * //     <div class="healthy">
- * //        <li class="plum">Plum</li>
- * //     </div>
- * //   </ul>
- *
+ * @param {Cheerio} wrapper - The DOM structure to wrap around each element in
+ *     the selection.
  * @see {@link http://api.jquery.com/wrap/}
  */
 exports.wrap = _wrap(function (el, elInsertLocation, wrapperDom) {
@@ -325,42 +318,41 @@ exports.wrap = _wrap(function (el, elInsertLocation, wrapperDom) {
 });
 
 /**
- * The .wrapInner() function can take any string or object that could be passed to
- * the $() factory function to specify a DOM structure. This structure may be
- * nested several levels deep, but should contain only one inmost element. The
- * structure will be wrapped around the content of each of the elements in the set
- * of matched elements.
- *
- * @param {Cheerio} wrapper - The DOM structure to wrap around the content of each element in the selection.
+ * The .wrapInner() function can take any string or object that could be passed
+ * to the $() factory function to specify a DOM structure. This structure may
+ * be nested several levels deep, but should contain only one inmost element.
+ * The structure will be wrapped around the content of each of the elements in
+ * the set of matched elements.
  *
  * @example
+ *   const redFruit = $('<div class="red-fruit"></div>');
+ *   $('.apple').wrapInner(redFruit);
  *
- * const redFruit = $('<div class="red-fruit"></div>')
- * $('.apple').wrapInner(redFruit)
+ *   //=> <ul id="fruits">
+ *   //     <li class="apple">
+ *   //       <div class="red-fruit">Apple</div>
+ *   //     </li>
+ *   //     <li class="orange">Orange</li>
+ *   //     <li class="pear">Pear</li>
+ *   //   </ul>
  *
- * //=> <ul id="fruits">
- * //     <li class="apple">
- * //       <div class="red-fruit">Apple</div>
- * //     </li>
- * //     <li class="orange">Orange</li>
- * //     <li class="pear">Pear</li>
- * //   </ul>
+ *   const healthy = $('<div class="healthy"></div>');
+ *   $('li').wrapInner(healthy);
  *
- * const healthy = $('<div class="healthy"></div>')
- * $('li').wrapInner(healthy)
+ *   //=> <ul id="fruits">
+ *   //     <li class="apple">
+ *   //       <div class="healthy">Apple</div>
+ *   //     </li>
+ *   //     <li class="orange">
+ *   //       <div class="healthy">Orange</div>
+ *   //     </li>
+ *   //     <li class="pear">
+ *   //       <div class="healthy">Pear</div>
+ *   //     </li>
+ *   //   </ul>
  *
- * //=> <ul id="fruits">
- * //     <li class="apple">
- * //       <div class="healthy">Apple</div>
- * //     </li>
- * //     <li class="orange">
- * //       <div class="healthy">Orange</div>
- * //     </li>
- * //     <li class="pear">
- * //       <div class="healthy">Pear</div>
- * //     </li>
- * //   </ul>
- *
+ * @param {Cheerio} wrapper - The DOM structure to wrap around the content of
+ *     each element in the selection.
  * @see {@link http://api.jquery.com/wrapInner/}
  */
 exports.wrapInner = _wrap(function (el, elInsertLocation, wrapperDom) {
@@ -371,19 +363,19 @@ exports.wrapInner = _wrap(function (el, elInsertLocation, wrapperDom) {
 /**
  * Insert content next to each element in the set of matched elements.
  *
- * @returns {Cheerio} The instance itself.
  * @example
- *
- * $('.apple').after('<li class="plum">Plum</li>')
- * $.html()
- * //=>  <ul id="fruits">
- * //      <li class="apple">Apple</li>
- * //      <li class="plum">Plum</li>
- * //      <li class="orange">Orange</li>
- * //      <li class="pear">Pear</li>
- * //    </ul>
+ *   $('.apple').after('<li class="plum">Plum</li>');
+ *   $.html();
+ *   //=>  <ul id="fruits">
+ *   //      <li class="apple">Apple</li>
+ *   //      <li class="plum">Plum</li>
+ *   //      <li class="orange">Orange</li>
+ *   //      <li class="pear">Pear</li>
+ *   //    </ul>
  *
  * @see {@link http://api.jquery.com/after/}
+ *
+ * @returns {Cheerio} The instance itself.
  */
 exports.after = function () {
   var elems = slice.call(arguments);
@@ -416,21 +408,20 @@ exports.after = function () {
 /**
  * Insert every element in the set of matched elements after the target.
  *
- * @returns {Cheerio} The set of newly inserted elements.
  * @example
- *
- * $('<li class="plum">Plum</li>').insertAfter('.apple')
- * $.html()
- * //=>  <ul id="fruits">
- * //      <li class="apple">Apple</li>
- * //      <li class="plum">Plum</li>
- * //      <li class="orange">Orange</li>
- * //      <li class="pear">Pear</li>
- * //    </ul>
+ *   $('<li class="plum">Plum</li>').insertAfter('.apple');
+ *   $.html();
+ *   //=>  <ul id="fruits">
+ *   //      <li class="apple">Apple</li>
+ *   //      <li class="plum">Plum</li>
+ *   //      <li class="orange">Orange</li>
+ *   //      <li class="pear">Pear</li>
+ *   //    </ul>
  *
  * @param {string | Cheerio} target - Element to insert elements after.
- *
  * @see {@link http://api.jquery.com/insertAfter/}
+ *
+ * @returns {Cheerio} The set of newly inserted elements.
  */
 exports.insertAfter = function (target) {
   var clones = [];
@@ -468,19 +459,19 @@ exports.insertAfter = function (target) {
 /**
  * Insert content previous to each element in the set of matched elements.
  *
- * @returns {Cheerio} The instance itself.
  * @example
- *
- * $('.apple').before('<li class="plum">Plum</li>')
- * $.html()
- * //=>  <ul id="fruits">
- * //      <li class="plum">Plum</li>
- * //      <li class="apple">Apple</li>
- * //      <li class="orange">Orange</li>
- * //      <li class="pear">Pear</li>
- * //    </ul>
+ *   $('.apple').before('<li class="plum">Plum</li>');
+ *   $.html();
+ *   //=>  <ul id="fruits">
+ *   //      <li class="plum">Plum</li>
+ *   //      <li class="apple">Apple</li>
+ *   //      <li class="orange">Orange</li>
+ *   //      <li class="pear">Pear</li>
+ *   //    </ul>
  *
  * @see {@link http://api.jquery.com/before/}
+ *
+ * @returns {Cheerio} The instance itself.
  */
 exports.before = function () {
   var elems = slice.call(arguments);
@@ -513,21 +504,20 @@ exports.before = function () {
 /**
  * Insert every element in the set of matched elements before the target.
  *
- * @returns {Cheerio} The set of newly inserted elements.
  * @example
- *
- * $('<li class="plum">Plum</li>').insertBefore('.apple')
- * $.html()
- * //=>  <ul id="fruits">
- * //      <li class="plum">Plum</li>
- * //      <li class="apple">Apple</li>
- * //      <li class="orange">Orange</li>
- * //      <li class="pear">Pear</li>
- * //    </ul>
+ *   $('<li class="plum">Plum</li>').insertBefore('.apple');
+ *   $.html();
+ *   //=>  <ul id="fruits">
+ *   //      <li class="plum">Plum</li>
+ *   //      <li class="apple">Apple</li>
+ *   //      <li class="orange">Orange</li>
+ *   //      <li class="pear">Pear</li>
+ *   //    </ul>
  *
  * @param {string | Cheerio} target - Element to insert elements before.
- *
  * @see {@link http://api.jquery.com/insertBefore/}
+ *
+ * @returns {Cheerio} The set of newly inserted elements.
  */
 exports.insertBefore = function (target) {
   var clones = [];
@@ -566,19 +556,18 @@ exports.insertBefore = function (target) {
  * Removes the set of matched elements from the DOM and all their children.
  * `selector` filters the set of matched elements to be removed.
  *
- * @returns {Cheerio} The instance itself.
  * @example
- *
- * $('.pear').remove()
- * $.html()
- * //=>  <ul id="fruits">
- * //      <li class="apple">Apple</li>
- * //      <li class="orange">Orange</li>
- * //    </ul>
+ *   $('.pear').remove();
+ *   $.html();
+ *   //=>  <ul id="fruits">
+ *   //      <li class="apple">Apple</li>
+ *   //      <li class="orange">Orange</li>
+ *   //    </ul>
  *
  * @param {string} [selector] - Optional selector for elements to remove.
- *
  * @see {@link http://api.jquery.com/remove/}
+ *
+ * @returns {Cheerio} The instance itself.
  */
 exports.remove = function (selector) {
   // Filter if we have selector
@@ -595,21 +584,20 @@ exports.remove = function (selector) {
 /**
  * Replaces matched elements with `content`.
  *
- * @returns {Cheerio} The instance itself.
  * @example
- *
- * const plum = $('<li class="plum">Plum</li>')
- * $('.pear').replaceWith(plum)
- * $.html()
- * //=> <ul id="fruits">
- * //     <li class="apple">Apple</li>
- * //     <li class="orange">Orange</li>
- * //     <li class="plum">Plum</li>
- * //   </ul>
+ *   const plum = $('<li class="plum">Plum</li>');
+ *   $('.pear').replaceWith(plum);
+ *   $.html();
+ *   //=> <ul id="fruits">
+ *   //     <li class="apple">Apple</li>
+ *   //     <li class="orange">Orange</li>
+ *   //     <li class="plum">Plum</li>
+ *   //   </ul>
  *
  * @param {Cheerio | Function} content - Replacement for matched elements.
- *
  * @see {@link http://api.jquery.com/replaceWith/}
+ *
+ * @returns {Cheerio} The instance itself.
  */
 exports.replaceWith = function (content) {
   return domEach(this, function (i, el) {
@@ -641,14 +629,14 @@ exports.replaceWith = function (content) {
 /**
  * Empties an element, removing all its children.
  *
- * @returns {Cheerio} The instance itself.
  * @example
- *
- * $('ul').empty()
- * $.html()
- * //=>  <ul id="fruits"></ul>
+ *   $('ul').empty();
+ *   $.html();
+ *   //=>  <ul id="fruits"></ul>
  *
  * @see {@link http://api.jquery.com/empty/}
+ *
+ * @returns {Cheerio} The instance itself.
  */
 exports.empty = function () {
   return domEach(this, function (i, el) {
@@ -662,21 +650,19 @@ exports.empty = function () {
 
 /**
  * Gets an HTML content string from the first selected element. If `htmlString`
- * is specified, each selected element's content is replaced by the new
- * content.
- *
- * @returns {Cheerio} The instance itself.
- * @param {string} str - If specified used to replace selection's contents.
+ * is specified, each selected element's content is replaced by the new content.
  *
  * @example
+ *   $('.orange').html();
+ *   //=> Orange
  *
- * $('.orange').html()
- * //=> Orange
+ *   $('#fruits').html('<li class="mango">Mango</li>').html();
+ *   //=> <li class="mango">Mango</li>
  *
- * $('#fruits').html('<li class="mango">Mango</li>').html()
- * //=> <li class="mango">Mango</li>
- *
+ * @param {string} str - If specified used to replace selection's contents.
  * @see {@link http://api.jquery.com/html/}
+ *
+ * @returns {Cheerio} The instance itself.
  */
 exports.html = function (str) {
   if (str === undefined) {
@@ -713,20 +699,20 @@ exports.toString = function () {
  * elements, including their descendants. If `textString` is specified, each
  * selected element's content is replaced by the new text content.
  *
- * @param {string} [str] - If specified replacement for the selected element's contents.
- * @returns {Cheerio | string} The instance itself when setting text, otherwise the rendered document.
- *
  * @example
+ *   $('.orange').text();
+ *   //=> Orange
  *
- * $('.orange').text()
- * //=> Orange
+ *   $('ul').text();
+ *   //=>  Apple
+ *   //    Orange
+ *   //    Pear
  *
- * $('ul').text()
- * //=>  Apple
- * //    Orange
- * //    Pear
- *
+ * @param {string} [str] - If specified replacement for the selected element's contents.
  * @see {@link http://api.jquery.com/text/}
+ *
+ * @returns {Cheerio | string} The instance itself when setting text, otherwise
+ *     the rendered document.
  */
 exports.text = function (str) {
   // If `str` is undefined, act as a "getter"
@@ -754,12 +740,12 @@ exports.text = function (str) {
 /**
  * Clone the cheerio object.
  *
- * @returns {Cheerio} The cloned object.
  * @example
- *
- * const moreFruit = $('#fruits').clone()
+ *   const moreFruit = $('#fruits').clone();
  *
  * @see {@link http://api.jquery.com/clone/}
+ *
+ * @returns {Cheerio} The cloned object.
  */
 exports.clone = function () {
   return this._make(cloneDom(this.get(), this.options));

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -22,7 +22,7 @@ var reSiblingSelector = /^\s*[~+]/;
  * $('#fruits').find($('.apple')).length
  * //=> 1
  *
- * @param {string|cheerio|node} selectorOrHaystack - Element to look for.
+ * @param {string | Cheerio | Node} selectorOrHaystack - Element to look for.
  *
  * @see {@link http://api.jquery.com/find/}
  */
@@ -139,7 +139,7 @@ exports.parents = function (selector) {
  * $('.orange').parentsUntil('#food').length
  * // => 1
  *
- * @param {string|node|cheerio} selector - Selector for element to stop at.
+ * @param {string | Node | Cheerio} selector - Selector for element to stop at.
  * @param {string|Function} [filter] - Optional filter for parents.
  *
  * @see {@link http://api.jquery.com/parentsUntil/}
@@ -303,7 +303,7 @@ exports.nextAll = function (selector) {
  * $('.apple').nextUntil('.pear')
  * //=> [<li class="orange">Orange</li>]
  *
- * @param {string|cheerio|node} selector - Selector for element to stop at.
+ * @param {string | Cheerio | Node} selector - Selector for element to stop at.
  * @param {string} [filterSelector] - If specified filter for siblings.
  *
  * @see {@link http://api.jquery.com/nextUntil/}
@@ -421,7 +421,7 @@ exports.prevAll = function (selector) {
  * $('.pear').prevUntil('.apple')
  * //=> [<li class="orange">Orange</li>]
  *
- * @param {string|cheerio|node} selector - Selector for element to stop at.
+ * @param {string | Cheerio | Node} selector - Selector for element to stop at.
  * @param {string} [filterSelector] - If specified filter for siblings.
  *
  * @see {@link http://api.jquery.com/prevUntil/}
@@ -621,7 +621,7 @@ function getFilterFn(match) {
  *
  * @function
  * @param {string | Function} match - Value to look for, following the rules above.
- * @param {node[]} container - Optional node to filter instead.
+ * @param {Node[]} container - Optional node to filter instead.
  *
  * @example <caption>Selector</caption>
  *
@@ -663,7 +663,7 @@ exports.filter = function (match, container) {
  *
  * @function
  * @param {string | Function} match - Value to look for, following the rules above.
- * @param {node[]} container - Optional node to filter instead.
+ * @param {Node[]} container - Optional node to filter instead.
  *
  * @example <caption>Selector</caption>
  *
@@ -714,7 +714,7 @@ exports.not = function (match, container) {
  * $('ul').has($('.pear')[0]).attr('id');
  * //=> fruits
  *
- * @param {string|cheerio|node} selectorOrHaystack - Element to look for.
+ * @param {string | Cheerio | Node} selectorOrHaystack - Element to look for.
  *
  * @see {@link http://api.jquery.com/has/}
  */
@@ -818,7 +818,7 @@ exports.get = function (i) {
  * $('.apple').index($('#fruit, li'))
  * //=> 1
  *
- * @param {string|cheerio|node} [selectorOrNeedle] - Element to look for.
+ * @param {string | Cheerio | Node} [selectorOrNeedle] - Element to look for.
  *
  * @see {@link http://api.jquery.com/index/}
  */
@@ -891,8 +891,8 @@ exports.end = function () {
  * $('.apple').add('.orange').length
  * //=> 2
  *
- * @param {string|cheerio} other - Elements to add.
- * @param {cheerio} [context] - Optionally the context of the new selection.
+ * @param {string | Cheerio} other - Elements to add.
+ * @param {Cheerio} [context] - Optionally the context of the new selection.
  *
  * @see {@link http://api.jquery.com/add/}
  */

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -15,6 +15,8 @@ var reSiblingSelector = /^\s*[~+]/;
  * Get the descendants of each element in the current set of matched elements,
  * filtered by a selector, jQuery object, or element.
  *
+ * @returns {Cheerio} The found elements.
+ *
  * @example
  *
  * $('#fruits').find('li').length
@@ -63,6 +65,8 @@ exports.find = function (selectorOrHaystack) {
  * Get the parent of each element in the current set of matched elements,
  * optionally filtered by a selector.
  *
+ * @returns {Cheerio} The parents.
+ *
  * @example
  *
  * $('.pear').parent().attr('id')
@@ -96,6 +100,8 @@ exports.parent = function (selector) {
 /**
  * Get a set of parents filtered by `selector` of each element in the current
  * set of match elements.
+ *
+ * @returns {Cheerio} The parents.
  *
  * @example
  *
@@ -133,6 +139,8 @@ exports.parents = function (selector) {
  * Get the ancestors of each element in the current set of matched elements, up
  * to but not including the element matched by the selector, DOM node, or
  * cheerio object.
+ *
+ * @returns {Cheerio} The parents.
  *
  * @example
  *
@@ -193,6 +201,8 @@ exports.parentsUntil = function (selector, filter) {
  * by testing the element itself and traversing up through its ancestors in
  * the DOM tree.
  *
+ * @returns {Cheerio} The closest nodes.
+ *
  * @example
  *
  * $('.orange').closest()
@@ -231,6 +241,8 @@ exports.closest = function (selector) {
  * Gets the next sibling of the first selected element, optionally filtered by
  * a selector.
  *
+ * @returns {Cheerio} The next nodes.
+ *
  * @example
  *
  * $('.apple').next().hasClass('orange')
@@ -263,6 +275,8 @@ exports.next = function (selector) {
 /**
  * Gets all the following siblings of the first selected element, optionally
  * filtered by a selector.
+ *
+ * @returns {Cheerio} The next nodes.
  *
  * @example
  *
@@ -297,6 +311,8 @@ exports.nextAll = function (selector) {
 /**
  * Gets all the following siblings up to but not including the element matched
  * by the selector, optionally filtered by another selector.
+ *
+ * @returns {Cheerio} The next nodes.
  *
  * @example
  *
@@ -349,6 +365,8 @@ exports.nextUntil = function (selector, filterSelector) {
  * Gets the previous sibling of the first selected element optionally filtered
  * by a selector.
  *
+ * @returns {Cheerio} The previous nodes.
+ *
  * @example
  *
  * $('.orange').prev().hasClass('apple')
@@ -381,6 +399,8 @@ exports.prev = function (selector) {
 /**
  * Gets all the preceding siblings of the first selected element, optionally
  * filtered by a selector.
+ *
+ * @returns {Cheerio} The previous nodes.
  *
  * @example
  *
@@ -415,6 +435,8 @@ exports.prevAll = function (selector) {
 /**
  * Gets all the preceding siblings up to but not including the element matched
  * by the selector, optionally filtered by another selector.
+ *
+ * @returns {Cheerio} The previous nodes.
  *
  * @example
  *
@@ -466,6 +488,8 @@ exports.prevUntil = function (selector, filterSelector) {
 /**
  * Gets the first selected element's siblings, excluding itself.
  *
+ * @returns {Cheerio} The siblings.
+ *
  * @example
  *
  * $('.pear').siblings().length
@@ -496,6 +520,8 @@ exports.siblings = function (selector) {
 /**
  * Gets the children of the first selected element.
  *
+ * @returns {Cheerio} The children.
+ *
  * @example
  *
  * $('#fruits').children().length
@@ -522,6 +548,8 @@ exports.children = function (selector) {
  * Gets the children of each element in the set of matched elements, including
  * text and comment nodes.
  *
+ * @returns {Cheerio} The children.
+ *
  * @example
  *
  * $('#fruits').contents().length
@@ -542,6 +570,8 @@ exports.contents = function () {
  * the DOM element, so `this` refers to the current element, which is
  * equivalent to the function parameter `element`. To break out of the `each`
  * loop early, return with `false`.
+ *
+ * @returns {Cheerio} The instance itself, useful for chaining.
  *
  * @example
  *
@@ -572,6 +602,8 @@ exports.each = function (fn) {
  * resulting set. If an array is returned, the elements inside the array are
  * inserted into the set. If the function returns null or undefined, no element
  * will be inserted.
+ *
+ * @returns {Cheerio} The mapped elements, wrapped in a Cheerio collection.
  *
  * @example
  *
@@ -619,6 +651,8 @@ function getFilterFn(match) {
  * function is executed in the context of the selected element, so `this`
  * refers to the current element.
  *
+ * @returns {Cheerio} The filtered collection.
+ *
  * @function
  * @param {string | Function} match - Value to look for, following the rules above.
  * @param {Node[]} container - Optional node to filter instead.
@@ -660,6 +694,8 @@ exports.filter = function (match, container) {
  * its argument in the same way that `.filter()` does. Elements for which the
  * function returns true are excluded from the filtered set; all other elements
  * are included.
+ *
+ * @returns {Cheerio} The filtered collection.
  *
  * @function
  * @param {string | Function} match - Value to look for, following the rules above.
@@ -704,6 +740,8 @@ exports.not = function (match, container) {
  * element as a descendant or which have a descendant that matches the given
  * selector. Equivalent to `.filter(':has(selector)')`.
  *
+ * @returns {Cheerio} The filtered collection.
+ *
  * @example <caption>Selector</caption>
  *
  * $('ul').has('.pear').attr('id');
@@ -728,6 +766,8 @@ exports.has = function (selectorOrHaystack) {
 /**
  * Will select the first element of a cheerio object.
  *
+ * @returns {Cheerio} The first element.
+ *
  * @example
  *
  * $('#fruits').children().first().text()
@@ -741,6 +781,8 @@ exports.first = function () {
 
 /**
  * Will select the last element of a cheerio object.
+ *
+ * @returns {Cheerio} The last element.
  *
  * @example
  *
@@ -756,6 +798,8 @@ exports.last = function () {
 /**
  * Reduce the set of matched elements to the one at the specified index. Use
  * `.eq(-i)` to count backwards from the last selected element.
+ *
+ * @returns {Cheerio} The element at the `i`th position.
  *
  * @example
  *
@@ -782,6 +826,8 @@ exports.eq = function (i) {
 /**
  * Retrieve the DOM elements matched by the Cheerio object. If an index is
  * specified, retrieve one of the elements matched by the Cheerio object.
+ *
+ * @returns {Node} The node at the `i`th position.
  *
  * @example
  *
@@ -820,6 +866,8 @@ exports.get = function (i) {
  *
  * @param {string | Cheerio | Node} [selectorOrNeedle] - Element to look for.
  *
+ * @returns {number} The index of the element.
+ *
  * @see {@link http://api.jquery.com/index/}
  */
 exports.index = function (selectorOrNeedle) {
@@ -842,6 +890,8 @@ exports.index = function (selectorOrNeedle) {
 
 /**
  * Gets the elements matching the specified range.
+ *
+ * @returns {Cheerio} The elements matching the specified range.
  *
  * @example
  *
@@ -872,6 +922,8 @@ function traverseParents(self, elem, selector, limit) {
  * End the most recent filtering operation in the current chain and return the
  * set of matched elements to its previous state.
  *
+ * @returns {Cheerio} The previous state of the set of matched elements.
+ *
  * @example
  *
  * $('li').eq(0).end().length
@@ -885,6 +937,8 @@ exports.end = function () {
 
 /**
  * Add elements to the set of matched elements.
+ *
+ * @returns {Cheerio} The combined set.
  *
  * @example
  *
@@ -911,6 +965,8 @@ exports.add = function (other, context) {
 /**
  * Add the previous set of elements on the stack to the current set, optionally
  * filtered by a selector.
+ *
+ * @returns {Cheerio} The combined set.
  *
  * @example
  *

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -15,18 +15,16 @@ var reSiblingSelector = /^\s*[~+]/;
  * Get the descendants of each element in the current set of matched elements,
  * filtered by a selector, jQuery object, or element.
  *
- * @returns {Cheerio} The found elements.
- *
  * @example
- *
- * $('#fruits').find('li').length
- * //=> 3
- * $('#fruits').find($('.apple')).length
- * //=> 1
+ *   $('#fruits').find('li').length;
+ *   //=> 3
+ *   $('#fruits').find($('.apple')).length;
+ *   //=> 1
  *
  * @param {string | Cheerio | Node} selectorOrHaystack - Element to look for.
- *
  * @see {@link http://api.jquery.com/find/}
+ *
+ * @returns {Cheerio} The found elements.
  */
 exports.find = function (selectorOrHaystack) {
   if (!selectorOrHaystack) {
@@ -65,16 +63,14 @@ exports.find = function (selectorOrHaystack) {
  * Get the parent of each element in the current set of matched elements,
  * optionally filtered by a selector.
  *
- * @returns {Cheerio} The parents.
- *
  * @example
- *
- * $('.pear').parent().attr('id')
- * //=> fruits
+ *   $('.pear').parent().attr('id');
+ *   //=> fruits
  *
  * @param {string} [selector] - If specified filter for parent.
- *
  * @see {@link http://api.jquery.com/parent/}
+ *
+ * @returns {Cheerio} The parents.
  */
 exports.parent = function (selector) {
   var set = [];
@@ -101,18 +97,16 @@ exports.parent = function (selector) {
  * Get a set of parents filtered by `selector` of each element in the current
  * set of match elements.
  *
- * @returns {Cheerio} The parents.
- *
  * @example
- *
- * $('.orange').parents().length
- * // => 2
- * $('.orange').parents('#fruits').length
- * // => 1
+ *   $('.orange').parents().length;
+ *   // => 2
+ *   $('.orange').parents('#fruits').length;
+ *   // => 1
  *
  * @param {string} [selector] - If specified filter for parents.
- *
  * @see {@link http://api.jquery.com/parents/}
+ *
+ * @returns {Cheerio} The parents.
  */
 exports.parents = function (selector) {
   var parentNodes = [];
@@ -137,20 +131,17 @@ exports.parents = function (selector) {
 
 /**
  * Get the ancestors of each element in the current set of matched elements, up
- * to but not including the element matched by the selector, DOM node, or
- * cheerio object.
- *
- * @returns {Cheerio} The parents.
+ * to but not including the element matched by the selector, DOM node, or cheerio object.
  *
  * @example
- *
- * $('.orange').parentsUntil('#food').length
- * // => 1
+ *   $('.orange').parentsUntil('#food').length;
+ *   // => 1
  *
  * @param {string | Node | Cheerio} selector - Selector for element to stop at.
- * @param {string|Function} [filter] - Optional filter for parents.
- *
+ * @param {string | Function} [filter] - Optional filter for parents.
  * @see {@link http://api.jquery.com/parentsUntil/}
+ *
+ * @returns {Cheerio} The parents.
  */
 exports.parentsUntil = function (selector, filter) {
   var parentNodes = [];
@@ -198,25 +189,22 @@ exports.parentsUntil = function (selector, filter) {
 
 /**
  * For each element in the set, get the first element that matches the selector
- * by testing the element itself and traversing up through its ancestors in
- * the DOM tree.
- *
- * @returns {Cheerio} The closest nodes.
+ * by testing the element itself and traversing up through its ancestors in the DOM tree.
  *
  * @example
- *
- * $('.orange').closest()
- * // => []
- * $('.orange').closest('.apple')
- * // => []
- * $('.orange').closest('li')
- * // => [<li class="orange">Orange</li>]
- * $('.orange').closest('#fruits')
- * // => [<ul id="fruits"> ... </ul>]
+ *   $('.orange').closest();
+ *   // => []
+ *   $('.orange').closest('.apple');
+ *   // => []
+ *   $('.orange').closest('li');
+ *   // => [<li class="orange">Orange</li>]
+ *   $('.orange').closest('#fruits');
+ *   // => [<ul id="fruits"> ... </ul>]
  *
  * @param {string} [selector] - Selector for the element to find.
- *
  * @see {@link http://api.jquery.com/closest/}
+ *
+ * @returns {Cheerio} The closest nodes.
  */
 exports.closest = function (selector) {
   var set = [];
@@ -238,19 +226,16 @@ exports.closest = function (selector) {
 };
 
 /**
- * Gets the next sibling of the first selected element, optionally filtered by
- * a selector.
- *
- * @returns {Cheerio} The next nodes.
+ * Gets the next sibling of the first selected element, optionally filtered by a selector.
  *
  * @example
- *
- * $('.apple').next().hasClass('orange')
- * //=> true
+ *   $('.apple').next().hasClass('orange');
+ *   //=> true
  *
  * @param {string} [selector] - If specified filter for sibling.
- *
  * @see {@link http://api.jquery.com/next/}
+ *
+ * @returns {Cheerio} The next nodes.
  */
 exports.next = function (selector) {
   if (!this[0]) {
@@ -276,18 +261,16 @@ exports.next = function (selector) {
  * Gets all the following siblings of the first selected element, optionally
  * filtered by a selector.
  *
- * @returns {Cheerio} The next nodes.
- *
  * @example
- *
- * $('.apple').nextAll()
- * //=> [<li class="orange">Orange</li>, <li class="pear">Pear</li>]
- * $('.apple').nextAll('.orange')
- * //=> [<li class="orange">Orange</li>]
+ *   $('.apple').nextAll();
+ *   //=> [<li class="orange">Orange</li>, <li class="pear">Pear</li>]
+ *   $('.apple').nextAll('.orange');
+ *   //=> [<li class="orange">Orange</li>]
  *
  * @param {string} [selector] - If specified filter for siblings.
- *
  * @see {@link http://api.jquery.com/nextAll/}
+ *
+ * @returns {Cheerio} The next nodes.
  */
 exports.nextAll = function (selector) {
   if (!this[0]) {
@@ -312,17 +295,15 @@ exports.nextAll = function (selector) {
  * Gets all the following siblings up to but not including the element matched
  * by the selector, optionally filtered by another selector.
  *
- * @returns {Cheerio} The next nodes.
- *
  * @example
- *
- * $('.apple').nextUntil('.pear')
- * //=> [<li class="orange">Orange</li>]
+ *   $('.apple').nextUntil('.pear');
+ *   //=> [<li class="orange">Orange</li>]
  *
  * @param {string | Cheerio | Node} selector - Selector for element to stop at.
  * @param {string} [filterSelector] - If specified filter for siblings.
- *
  * @see {@link http://api.jquery.com/nextUntil/}
+ *
+ * @returns {Cheerio} The next nodes.
  */
 exports.nextUntil = function (selector, filterSelector) {
   if (!this[0]) {
@@ -365,16 +346,14 @@ exports.nextUntil = function (selector, filterSelector) {
  * Gets the previous sibling of the first selected element optionally filtered
  * by a selector.
  *
- * @returns {Cheerio} The previous nodes.
- *
  * @example
- *
- * $('.orange').prev().hasClass('apple')
- * //=> true
+ *   $('.orange').prev().hasClass('apple');
+ *   //=> true
  *
  * @param {string} [selector] - If specified filter for siblings.
- *
  * @see {@link http://api.jquery.com/prev/}
+ *
+ * @returns {Cheerio} The previous nodes.
  */
 exports.prev = function (selector) {
   if (!this[0]) {
@@ -400,18 +379,16 @@ exports.prev = function (selector) {
  * Gets all the preceding siblings of the first selected element, optionally
  * filtered by a selector.
  *
- * @returns {Cheerio} The previous nodes.
- *
  * @example
- *
- * $('.pear').prevAll()
- * //=> [<li class="orange">Orange</li>, <li class="apple">Apple</li>]
- * $('.pear').prevAll('.orange')
- * //=> [<li class="orange">Orange</li>]
+ *   $('.pear').prevAll();
+ *   //=> [<li class="orange">Orange</li>, <li class="apple">Apple</li>]
+ *   $('.pear').prevAll('.orange');
+ *   //=> [<li class="orange">Orange</li>]
  *
  * @param {string} [selector] - If specified filter for siblings.
- *
  * @see {@link http://api.jquery.com/prevAll/}
+ *
+ * @returns {Cheerio} The previous nodes.
  */
 exports.prevAll = function (selector) {
   if (!this[0]) {
@@ -436,17 +413,15 @@ exports.prevAll = function (selector) {
  * Gets all the preceding siblings up to but not including the element matched
  * by the selector, optionally filtered by another selector.
  *
- * @returns {Cheerio} The previous nodes.
- *
  * @example
- *
- * $('.pear').prevUntil('.apple')
- * //=> [<li class="orange">Orange</li>]
+ *   $('.pear').prevUntil('.apple');
+ *   //=> [<li class="orange">Orange</li>]
  *
  * @param {string | Cheerio | Node} selector - Selector for element to stop at.
  * @param {string} [filterSelector] - If specified filter for siblings.
- *
  * @see {@link http://api.jquery.com/prevUntil/}
+ *
+ * @returns {Cheerio} The previous nodes.
  */
 exports.prevUntil = function (selector, filterSelector) {
   if (!this[0]) {
@@ -488,19 +463,17 @@ exports.prevUntil = function (selector, filterSelector) {
 /**
  * Gets the first selected element's siblings, excluding itself.
  *
- * @returns {Cheerio} The siblings.
- *
  * @example
+ *   $('.pear').siblings().length;
+ *   //=> 2
  *
- * $('.pear').siblings().length
- * //=> 2
- *
- * $('.pear').siblings('.orange').length
- * //=> 1
+ *   $('.pear').siblings('.orange').length;
+ *   //=> 1
  *
  * @param {string} [selector] - If specified filter for siblings.
- *
  * @see {@link http://api.jquery.com/siblings/}
+ *
+ * @returns {Cheerio} The siblings.
  */
 exports.siblings = function (selector) {
   var parent = this.parent();
@@ -520,19 +493,17 @@ exports.siblings = function (selector) {
 /**
  * Gets the children of the first selected element.
  *
- * @returns {Cheerio} The children.
- *
  * @example
+ *   $('#fruits').children().length;
+ *   //=> 3
  *
- * $('#fruits').children().length
- * //=> 3
- *
- * $('#fruits').children('.pear').text()
- * //=> Pear
+ *   $('#fruits').children('.pear').text();
+ *   //=> Pear
  *
  * @param {string} [selector] - If specified filter for children.
- *
  * @see {@link http://api.jquery.com/children/}
+ *
+ * @returns {Cheerio} The children.
  */
 exports.children = function (selector) {
   var elems = this.toArray().reduce(function (newElems, elem) {
@@ -548,14 +519,13 @@ exports.children = function (selector) {
  * Gets the children of each element in the set of matched elements, including
  * text and comment nodes.
  *
- * @returns {Cheerio} The children.
- *
  * @example
- *
- * $('#fruits').contents().length
- * //=> 3
+ *   $('#fruits').contents().length;
+ *   //=> 3
  *
  * @see {@link http://api.jquery.com/contents/}
+ *
+ * @returns {Cheerio} The children.
  */
 exports.contents = function () {
   var elems = this.toArray().reduce(function (newElems, elem) {
@@ -571,22 +541,20 @@ exports.contents = function () {
  * equivalent to the function parameter `element`. To break out of the `each`
  * loop early, return with `false`.
  *
- * @returns {Cheerio} The instance itself, useful for chaining.
- *
  * @example
+ *   const fruits = [];
  *
- * const fruits = [];
+ *   $('li').each(function (i, elem) {
+ *     fruits[i] = $(this).text();
+ *   });
  *
- * $('li').each(function(i, elem) {
- *   fruits[i] = $(this).text();
- * });
- *
- * fruits.join(', ');
- * //=> Apple, Orange, Pear
+ *   fruits.join(', ');
+ *   //=> Apple, Orange, Pear
  *
  * @param {Function} fn - Function to execute.
- *
  * @see {@link http://api.jquery.com/each/}
+ *
+ * @returns {Cheerio} The instance itself, useful for chaining.
  */
 exports.each = function (fn) {
   var i = 0;
@@ -603,19 +571,20 @@ exports.each = function (fn) {
  * inserted into the set. If the function returns null or undefined, no element
  * will be inserted.
  *
- * @returns {Cheerio} The mapped elements, wrapped in a Cheerio collection.
- *
  * @example
- *
- * $('li').map(function(i, el) {
- *   // this === el
- *   return $(this).text();
- * }).get().join(' ');
- * //=> "apple orange pear"
+ *   $('li')
+ *     .map(function (i, el) {
+ *       // this === el
+ *       return $(this).text();
+ *     })
+ *     .get()
+ *     .join(' ');
+ *   //=> "apple orange pear"
  *
  * @param {Function} fn - Function to execute.
- *
  * @see {@link http://api.jquery.com/map/}
+ *
+ * @returns {Cheerio} The mapped elements, wrapped in a Cheerio collection.
  */
 exports.map = function (fn) {
   var elems = [];
@@ -651,26 +620,25 @@ function getFilterFn(match) {
  * function is executed in the context of the selected element, so `this`
  * refers to the current element.
  *
- * @returns {Cheerio} The filtered collection.
+ * @example <caption>Selector</caption>
+ *   $('li').filter('.orange').attr('class');
+ *   //=> orange
+ *
+ * @example <caption>Function</caption>
+ *   $('li')
+ *     .filter(function (i, el) {
+ *       // this === el
+ *       return $(this).attr('class') === 'orange';
+ *     })
+ *     .attr('class');
+ *   //=> orange
  *
  * @function
  * @param {string | Function} match - Value to look for, following the rules above.
  * @param {Node[]} container - Optional node to filter instead.
- *
- * @example <caption>Selector</caption>
- *
- * $('li').filter('.orange').attr('class');
- * //=> orange
- *
- * @example <caption>Function</caption>
- *
- * $('li').filter(function(i, el) {
- *   // this === el
- *   return $(this).attr('class') === 'orange';
- * }).attr('class')
- * //=> orange
- *
  * @see {@link http://api.jquery.com/filter/}
+ *
+ * @returns {Cheerio} The filtered collection.
  */
 exports.filter = function (match, container) {
   container = container || this;
@@ -695,26 +663,23 @@ exports.filter = function (match, container) {
  * function returns true are excluded from the filtered set; all other elements
  * are included.
  *
- * @returns {Cheerio} The filtered collection.
+ * @example <caption>Selector</caption>
+ *   $('li').not('.apple').length;
+ *   //=> 2
+ *
+ * @example <caption>Function</caption>
+ *   $('li').not(function (i, el) {
+ *     // this === el
+ *     return $(this).attr('class') === 'orange';
+ *   }).length;
+ *   //=> 2
  *
  * @function
  * @param {string | Function} match - Value to look for, following the rules above.
  * @param {Node[]} container - Optional node to filter instead.
- *
- * @example <caption>Selector</caption>
- *
- * $('li').not('.apple').length;
- * //=> 2
- *
- * @example <caption>Function</caption>
- *
- * $('li').not(function(i, el) {
- *   // this === el
- *   return $(this).attr('class') === 'orange';
- * }).length;
- * //=> 2
- *
  * @see {@link http://api.jquery.com/not/}
+ *
+ * @returns {Cheerio} The filtered collection.
  */
 exports.not = function (match, container) {
   container = container || this;
@@ -740,21 +705,18 @@ exports.not = function (match, container) {
  * element as a descendant or which have a descendant that matches the given
  * selector. Equivalent to `.filter(':has(selector)')`.
  *
- * @returns {Cheerio} The filtered collection.
- *
  * @example <caption>Selector</caption>
- *
- * $('ul').has('.pear').attr('id');
- * //=> fruits
+ *   $('ul').has('.pear').attr('id');
+ *   //=> fruits
  *
  * @example <caption>Element</caption>
- *
- * $('ul').has($('.pear')[0]).attr('id');
- * //=> fruits
+ *   $('ul').has($('.pear')[0]).attr('id');
+ *   //=> fruits
  *
  * @param {string | Cheerio | Node} selectorOrHaystack - Element to look for.
- *
  * @see {@link http://api.jquery.com/has/}
+ *
+ * @returns {Cheerio} The filtered collection.
  */
 exports.has = function (selectorOrHaystack) {
   var that = this;
@@ -766,14 +728,13 @@ exports.has = function (selectorOrHaystack) {
 /**
  * Will select the first element of a cheerio object.
  *
- * @returns {Cheerio} The first element.
- *
  * @example
- *
- * $('#fruits').children().first().text()
- * //=> Apple
+ *   $('#fruits').children().first().text();
+ *   //=> Apple
  *
  * @see {@link http://api.jquery.com/first/}
+ *
+ * @returns {Cheerio} The first element.
  */
 exports.first = function () {
   return this.length > 1 ? this._make(this[0]) : this;
@@ -782,14 +743,13 @@ exports.first = function () {
 /**
  * Will select the last element of a cheerio object.
  *
- * @returns {Cheerio} The last element.
- *
  * @example
- *
- * $('#fruits').children().last().text()
- * //=> Pear
+ *   $('#fruits').children().last().text();
+ *   //=> Pear
  *
  * @see {@link http://api.jquery.com/last/}
+ *
+ * @returns {Cheerio} The last element.
  */
 exports.last = function () {
   return this.length > 1 ? this._make(this[this.length - 1]) : this;
@@ -799,19 +759,17 @@ exports.last = function () {
  * Reduce the set of matched elements to the one at the specified index. Use
  * `.eq(-i)` to count backwards from the last selected element.
  *
- * @returns {Cheerio} The element at the `i`th position.
- *
  * @example
+ *   $('li').eq(0).text();
+ *   //=> Apple
  *
- * $('li').eq(0).text()
- * //=> Apple
- *
- * $('li').eq(-1).text()
- * //=> Pear
+ *   $('li').eq(-1).text();
+ *   //=> Pear
  *
  * @param {number} i - Index of the element to select.
- *
  * @see {@link http://api.jquery.com/eq/}
+ *
+ * @returns {Cheerio} The element at the `i`th position.
  */
 exports.eq = function (i) {
   i = +i;
@@ -827,23 +785,20 @@ exports.eq = function (i) {
  * Retrieve the DOM elements matched by the Cheerio object. If an index is
  * specified, retrieve one of the elements matched by the Cheerio object.
  *
- * @returns {Node} The node at the `i`th position.
+ * @example
+ *   $('li').get(0).tagName
+ *   //=> li
+ *
+ *   If no index is specified, retrieve all elements matched by the Cheerio object:
  *
  * @example
- *
- * $('li').get(0).tagName
- * //=> li
- *
- * If no index is specified, retrieve all elements matched by the Cheerio object:
- *
- * @example
- *
- * $('li').get().length
- * //=> 3
+ *   $('li').get().length;
+ *   //=> 3
  *
  * @param {number} [i] - Element to retrieve.
- *
  * @see {@link http://api.jquery.com/get/}
+ *
+ * @returns {Node} The node at the `i`th position.
  */
 exports.get = function (i) {
   if (i == null) {
@@ -856,19 +811,17 @@ exports.get = function (i) {
  * Search for a given element from among the matched elements.
  *
  * @example
- *
- * $('.pear').index()
- * //=> 2
- * $('.orange').index('li')
- * //=> 1
- * $('.apple').index($('#fruit, li'))
- * //=> 1
+ *   $('.pear').index();
+ *   //=> 2
+ *   $('.orange').index('li');
+ *   //=> 1
+ *   $('.apple').index($('#fruit, li'));
+ *   //=> 1
  *
  * @param {string | Cheerio | Node} [selectorOrNeedle] - Element to look for.
+ * @see {@link http://api.jquery.com/index/}
  *
  * @returns {number} The index of the element.
- *
- * @see {@link http://api.jquery.com/index/}
  */
 exports.index = function (selectorOrNeedle) {
   var $haystack;
@@ -891,17 +844,16 @@ exports.index = function (selectorOrNeedle) {
 /**
  * Gets the elements matching the specified range.
  *
- * @returns {Cheerio} The elements matching the specified range.
- *
  * @example
+ *   $('li').slice(1).eq(0).text();
+ *   //=> 'Orange'
  *
- * $('li').slice(1).eq(0).text()
- * //=> 'Orange'
- *
- * $('li').slice(1, 2).length
- * //=> 1
+ *   $('li').slice(1, 2).length;
+ *   //=> 1
  *
  * @see {@link http://api.jquery.com/slice/}
+ *
+ * @returns {Cheerio} The elements matching the specified range.
  */
 exports.slice = function () {
   return this._make([].slice.apply(this, arguments));
@@ -922,14 +874,13 @@ function traverseParents(self, elem, selector, limit) {
  * End the most recent filtering operation in the current chain and return the
  * set of matched elements to its previous state.
  *
- * @returns {Cheerio} The previous state of the set of matched elements.
- *
  * @example
- *
- * $('li').eq(0).end().length
- * //=> 3
+ *   $('li').eq(0).end().length;
+ *   //=> 3
  *
  * @see {@link http://api.jquery.com/end/}
+ *
+ * @returns {Cheerio} The previous state of the set of matched elements.
  */
 exports.end = function () {
   return this.prevObject || this._make([]);
@@ -938,17 +889,15 @@ exports.end = function () {
 /**
  * Add elements to the set of matched elements.
  *
- * @returns {Cheerio} The combined set.
- *
  * @example
- *
- * $('.apple').add('.orange').length
- * //=> 2
+ *   $('.apple').add('.orange').length;
+ *   //=> 2
  *
  * @param {string | Cheerio} other - Elements to add.
  * @param {Cheerio} [context] - Optionally the context of the new selection.
- *
  * @see {@link http://api.jquery.com/add/}
+ *
+ * @returns {Cheerio} The combined set.
  */
 exports.add = function (other, context) {
   var selection = this._make(other, context);
@@ -966,16 +915,14 @@ exports.add = function (other, context) {
  * Add the previous set of elements on the stack to the current set, optionally
  * filtered by a selector.
  *
- * @returns {Cheerio} The combined set.
- *
  * @example
- *
- * $('li').eq(0).addBack('.orange').length
- * //=> 2
+ *   $('li').eq(0).addBack('.orange').length;
+ *   //=> 2
  *
  * @param {string} selector - Selector for the elements to add.
- *
  * @see {@link http://api.jquery.com/addBack/}
+ *
+ * @returns {Cheerio} The combined set.
  */
 exports.addBack = function (selector) {
   return this.add(

--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -100,8 +100,8 @@ var Cheerio = (module.exports = function (selector, context, root, options) {
   return context.find(selector);
 });
 
-/*
- * Set a signature of the object
+/**
+ * Set a signature of the object.
  */
 Cheerio.prototype.cheerio = '[cheerio object]';
 
@@ -111,10 +111,13 @@ Cheerio.prototype.cheerio = '[cheerio object]';
 Cheerio.prototype.length = 0;
 Cheerio.prototype.splice = Array.prototype.splice;
 
-/*
- * Make a cheerio object
+/**
+ * Make a cheerio object.
  *
  * @private
+ * @param {Node[]} dom - The contents of the new object.
+ * @param {Node[]} [context] - The context of the new object.
+ * @returns {Cheerio} The new cheerio object.
  */
 Cheerio.prototype._make = function (dom, context) {
   var cheerio = new this.constructor(dom, context, this._root, this.options);
@@ -124,6 +127,8 @@ Cheerio.prototype._make = function (dom, context) {
 
 /**
  * Retrieve all the DOM elements contained in the jQuery set as an array.
+ *
+ *  @returns {Node[]} The contained items.
  *
  * @example
  * $('li').toArray()

--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -19,16 +19,15 @@ var api = [
 ];
 
 /**
- * Instance of cheerio. Methods are specified in the modules.
- * Usage of this constructor is not recommended. Please use $.load instead.
+ * Instance of cheerio. Methods are specified in the modules. Usage of this
+ * constructor is not recommended. Please use $.load instead.
  *
  * @class
- * @hideconstructor
  * @param {string | Cheerio | Node | Node[]} selector - The new selection.
  * @param {string | Cheerio | Node | Node[]} [context] - Context of the selection.
  * @param {string | Cheerio | Node | Node[]} [root] - Sets the root node.
  * @param {object} [options] - Options for the instance.
- *
+ * @hideconstructor
  * @mixes module:cheerio/attributes
  * @mixes module:cheerio/css
  * @mixes module:cheerio/forms
@@ -100,9 +99,7 @@ var Cheerio = (module.exports = function (selector, context, root, options) {
   return context.find(selector);
 });
 
-/**
- * Set a signature of the object.
- */
+/** Set a signature of the object. */
 Cheerio.prototype.cheerio = '[cheerio object]';
 
 /*
@@ -128,11 +125,10 @@ Cheerio.prototype._make = function (dom, context) {
 /**
  * Retrieve all the DOM elements contained in the jQuery set as an array.
  *
- *  @returns {Node[]} The contained items.
- *
  * @example
- * $('li').toArray()
- * //=> [ {...}, {...}, {...} ]
+ *   $('li').toArray(); //=> [ {...}, {...}, {...} ]
+ *
+ * @returns {Node[]} The contained items.
  */
 Cheerio.prototype.toArray = function () {
   return this.get();

--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -24,9 +24,9 @@ var api = [
  *
  * @class
  * @hideconstructor
- * @param {string|cheerio|node|node[]} selector - The new selection.
- * @param {string|cheerio|node|node[]} [context] - Context of the selection.
- * @param {string|cheerio|node|node[]} [root] - Sets the root node.
+ * @param {string | Cheerio | Node | Node[]} selector - The new selection.
+ * @param {string | Cheerio | Node | Node[]} [context] - Context of the selection.
+ * @param {string | Cheerio | Node | Node[]} [root] - Sets the root node.
  * @param {object} [options] - Options for the instance.
  *
  * @mixes module:cheerio/attributes

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,6 +1,4 @@
-/**
- * Cheerio default options.
- */
+/** Cheerio default options. */
 exports.default = {
   xml: false,
   decodeEntities: true,

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,7 +1,6 @@
-/*
- * Cheerio default options
+/**
+ * Cheerio default options.
  */
-
 exports.default = {
   xml: false,
   decodeEntities: true,

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -38,9 +38,13 @@ exports = module.exports = function parse(content, options, isDocument) {
   return root;
 };
 
-/*
-  Update the dom structure, for one changed layer
-*/
+/**
+ * Update the dom structure, for one changed layer.
+ *
+ * @param {Node[] | Node} arr - The new children.
+ * @param {Node} parent - The new parent.
+ * @returns {Node} The parent node.
+ */
 exports.update = function (arr, parent) {
   // normalize
   if (!Array.isArray(arr)) arr = [arr];

--- a/lib/static.js
+++ b/lib/static.js
@@ -20,7 +20,7 @@ var parse = require('./parse');
  * @param {string} content - Markup to be loaded.
  * @param {object} [options] - Options for the created instance.
  * @param {boolean} [isDocument] - Allows parser to be switched to fragment mode.
- *
+ * @returns {Cheerio} - The loaded document.
  */
 exports.load = function (content, options, isDocument) {
   if (content === null || content === undefined) {
@@ -66,10 +66,14 @@ exports.load = function (content, options, isDocument) {
   return initialize;
 };
 
-/*
- * Helper function
+/**
+ * Helper function to render a DOM.
+ *
+ * @param {Cheerio} that - Cheerio instance to render.
+ * @param {Node[] | undefined} dom - The DOM to render. Defaults to `that`'s root.
+ * @param {object} options - Options for rendering.
+ * @returns {string} The rendered document.
  */
-
 function render(that, dom, options) {
   if (!dom) {
     if (that._root && that._root.children) {
@@ -89,8 +93,9 @@ function render(that, dom, options) {
 /**
  * Renders the document.
  *
- * @param {string | Cheerio | Node} [dom] - Element to render.
+ * @param {string | Cheerio | Node| object} [dom] - Element to render.
  * @param {object} [options] - Options for the renderer.
+ * @returns {string} The rendered document.
  */
 exports.html = function (dom, options) {
   // be flexible about parameters, sometimes we call html(),
@@ -123,6 +128,7 @@ exports.html = function (dom, options) {
  * Render the document as XML.
  *
  * @param {string | Cheerio | Node} [dom] - Element to render.
+ * @returns {string} THe rendered document.
  */
 exports.xml = function (dom) {
   var options = Object.assign({}, this._options, { xmlMode: true });
@@ -134,6 +140,7 @@ exports.xml = function (dom) {
  * Render the document as text.
  *
  * @param {Cheerio | Node} [elems] - Elements to render.
+ * @returns {string} The rendered document.
  */
 exports.text = function (elems) {
   if (!elems) {
@@ -166,6 +173,7 @@ exports.text = function (elems) {
  * @param {string} data - Markup that will be parsed.
  * @param {any|boolean} [context] - Will be ignored. If it is a boolean it will be used as the value of `keepScripts`.
  * @param {boolean} [keepScripts] - If false all scripts will be removed.
+ * @returns {Node[]} The parsed DOM.
  *
  * @alias Cheerio.parseHTML
  * @see {@link https://api.jquery.com/jQuery.parseHTML/}
@@ -196,6 +204,7 @@ exports.parseHTML = function (data, context, keepScripts) {
  * Sometimes you need to work with the top-level root element. To query it, you
  * can use `$.root()`.
  *
+ * @returns {Cheerio} Cheerio instance wrapping the root node.
  * @alias Cheerio.root
  *
  * @example
@@ -212,7 +221,7 @@ exports.root = function () {
  *
  * @param {Node} container - Potential parent node.
  * @param {Node} contained - Potential child node.
- * @returns {boolean}
+ * @returns {boolean} Indicates if the nodes contain one another.
  *
  * @alias Cheerio.contains
  * @see {@link https://api.jquery.com/jQuery.contains}
@@ -240,6 +249,7 @@ exports.contains = function (container, contained) {
  *
  * @param {Array | Cheerio} arr1 - First array.
  * @param {Array | Cheerio} arr2 - Second array.
+ * @returns {Array|Cheerio} `arr1`, with elements of `arr2` inserted.
  *
  * @alias Cheerio.merge
  * @see {@link https://api.jquery.com/jQuery.merge}
@@ -256,6 +266,10 @@ exports.merge = function (arr1, arr2) {
   return arr1;
 };
 
+/**
+ * @param {*} item - Item to check.
+ * @returns {boolean} Indicates if the item is array-like.
+ */
 function isArrayLike(item) {
   if (Array.isArray(item)) {
     return true;

--- a/lib/static.js
+++ b/lib/static.js
@@ -89,7 +89,7 @@ function render(that, dom, options) {
 /**
  * Renders the document.
  *
- * @param {string|cheerio|node} [dom] - Element to render.
+ * @param {string | Cheerio | Node} [dom] - Element to render.
  * @param {object} [options] - Options for the renderer.
  */
 exports.html = function (dom, options) {
@@ -122,7 +122,7 @@ exports.html = function (dom, options) {
 /**
  * Render the document as XML.
  *
- * @param {string|cheerio|node} [dom] - Element to render.
+ * @param {string | Cheerio | Node} [dom] - Element to render.
  */
 exports.xml = function (dom) {
   var options = Object.assign({}, this._options, { xmlMode: true });
@@ -133,7 +133,7 @@ exports.xml = function (dom) {
 /**
  * Render the document as text.
  *
- * @param {cheerio|node} [elems] - Elements to render.
+ * @param {Cheerio | Node} [elems] - Elements to render.
  */
 exports.text = function (elems) {
   if (!elems) {
@@ -210,8 +210,8 @@ exports.root = function () {
  * Checks to see if the `contained` DOM element is a descendant of the
  * `container` DOM element.
  *
- * @param {node} container - Potential parent node.
- * @param {node} contained - Potential child node.
+ * @param {Node} container - Potential parent node.
+ * @param {Node} contained - Potential child node.
  * @returns {boolean}
  *
  * @alias Cheerio.contains
@@ -238,8 +238,8 @@ exports.contains = function (container, contained) {
 /**
  * $.merge().
  *
- * @param {Array|cheerio} arr1 - First array.
- * @param {Array|cheerio} arr2 - Second array.
+ * @param {Array | Cheerio} arr1 - First array.
+ * @param {Array | Cheerio} arr2 - Second array.
  *
  * @alias Cheerio.merge
  * @see {@link https://api.jquery.com/jQuery.merge}

--- a/lib/static.js
+++ b/lib/static.js
@@ -12,8 +12,8 @@ var parse = require('./parse');
 /**
  * Create a querying function, bound to a document created from the provided
  * markup. Note that similar to web browser contexts, this operation may
- * introduce `<html>`, `<head>`, and `<body>` elements; set `isDocument` to `false`
- * to switch to fragment mode and disable this.
+ * introduce `<html>`, `<head>`, and `<body>` elements; set `isDocument` to
+ * `false` to switch to fragment mode and disable this.
  *
  * See the README section titled "Loading" for additional usage information.
  *
@@ -93,7 +93,7 @@ function render(that, dom, options) {
 /**
  * Renders the document.
  *
- * @param {string | Cheerio | Node| object} [dom] - Element to render.
+ * @param {string | Cheerio | Node | object} [dom] - Element to render.
  * @param {object} [options] - Options for the renderer.
  * @returns {string} The rendered document.
  */
@@ -171,12 +171,13 @@ exports.text = function (elems) {
  * meaning for Cheerio, but it is maintained for API compatibility with jQuery.
  *
  * @param {string} data - Markup that will be parsed.
- * @param {any|boolean} [context] - Will be ignored. If it is a boolean it will be used as the value of `keepScripts`.
+ * @param {any | boolean} [context] - Will be ignored. If it is a boolean it
+ *     will be used as the value of `keepScripts`.
  * @param {boolean} [keepScripts] - If false all scripts will be removed.
- * @returns {Node[]} The parsed DOM.
+ * @see {@link https://api.jquery.com/jQuery.parseHTML/}
  *
  * @alias Cheerio.parseHTML
- * @see {@link https://api.jquery.com/jQuery.parseHTML/}
+ * @returns {Node[]} The parsed DOM.
  */
 exports.parseHTML = function (data, context, keepScripts) {
   if (!data || typeof data !== 'string') {
@@ -204,12 +205,12 @@ exports.parseHTML = function (data, context, keepScripts) {
  * Sometimes you need to work with the top-level root element. To query it, you
  * can use `$.root()`.
  *
- * @returns {Cheerio} Cheerio instance wrapping the root node.
- * @alias Cheerio.root
- *
  * @example
- * $.root().append('<ul id="vegetables"></ul>').html();
- * //=> <ul id="fruits">...</ul><ul id="vegetables"></ul>
+ *   $.root().append('<ul id="vegetables"></ul>').html();
+ *   //=> <ul id="fruits">...</ul><ul id="vegetables"></ul>
+ *
+ * @alias Cheerio.root
+ * @returns {Cheerio} Cheerio instance wrapping the root node.
  */
 exports.root = function () {
   return this(this._root);
@@ -221,10 +222,10 @@ exports.root = function () {
  *
  * @param {Node} container - Potential parent node.
  * @param {Node} contained - Potential child node.
- * @returns {boolean} Indicates if the nodes contain one another.
+ * @see {@link https://api.jquery.com/jQuery.contains}
  *
  * @alias Cheerio.contains
- * @see {@link https://api.jquery.com/jQuery.contains}
+ * @returns {boolean} Indicates if the nodes contain one another.
  */
 exports.contains = function (container, contained) {
   // According to the jQuery API, an element does not "contain" itself
@@ -249,10 +250,10 @@ exports.contains = function (container, contained) {
  *
  * @param {Array | Cheerio} arr1 - First array.
  * @param {Array | Cheerio} arr2 - Second array.
- * @returns {Array|Cheerio} `arr1`, with elements of `arr2` inserted.
+ * @see {@link https://api.jquery.com/jQuery.merge}
  *
  * @alias Cheerio.merge
- * @see {@link https://api.jquery.com/jQuery.merge}
+ * @returns {Array | Cheerio} `arr1`, with elements of `arr2` inserted.
  */
 exports.merge = function (arr1, arr2) {
   if (!isArrayLike(arr1) || !isArrayLike(arr2)) {
@@ -267,7 +268,7 @@ exports.merge = function (arr1, arr2) {
 };
 
 /**
- * @param {*} item - Item to check.
+ * @param {any} item - Item to check.
  * @returns {boolean} Indicates if the item is array-like.
  */
 function isArrayLike(item) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,20 +6,20 @@ var domhandler = require('domhandler');
  *
  * `isTag(type)` includes `<script>` and `<style>` tags.
  *
+ * @private
+ *
  * @param {Node} type - DOM node to check.
  * @returns {boolean}
- *
- * @private
  */
 exports.isTag = htmlparser2.DomUtils.isTag;
 
 /**
  * Convert a string to camel case notation.
  *
- * @param  {string} str - String to be converted.
- * @returns {string}      String in camel case notation.
- *
  * @private
+ *
+ * @param {string} str - String to be converted.
+ * @returns {string} String in camel case notation.
  */
 exports.camelCase = function (str) {
   return str.replace(/[_.-](\w|$)/g, function (_, x) {
@@ -31,18 +31,17 @@ exports.camelCase = function (str) {
  * Convert a string from camel case to "CSS case", where word boundaries are
  * described by hyphens ("-") and all characters are lower-case.
  *
- * @param  {string} str - String to be converted.
- * @returns {string}      String in "CSS case".
- *
  * @private
+ *
+ * @param {string} str - String to be converted.
+ * @returns {string} String in "CSS case".
  */
 exports.cssCase = function (str) {
   return str.replace(/[A-Z]/g, '-$&').toLowerCase();
 };
 
 /**
- * Iterate over each DOM element without creating intermediary Cheerio
- * instances.
+ * Iterate over each DOM element without creating intermediary Cheerio instances.
  *
  * This is indented for use internally to avoid otherwise unnecessary memory
  * pressure introduced by _make.
@@ -59,12 +58,13 @@ exports.domEach = function (cheerio, fn) {
 };
 
 /**
- * Create a deep copy of the given DOM structure.
- * Sets the parents of the copies of the passed nodes to `null`.
+ * Create a deep copy of the given DOM structure. Sets the parents of the copies
+ * of the passed nodes to `null`.
+ *
+ * @private
  *
  * @param {Node | Node[]} dom - The htmlparser2-compliant DOM structure.
  * @returns {Node[]} - The cloned DOM.
- * @private
  */
 exports.cloneDom = function (dom) {
   var clone =
@@ -83,17 +83,16 @@ exports.cloneDom = function (dom) {
   return clone;
 };
 
-/**
- * A simple way to check for HTML strings or ID strings.
- */
+/** A simple way to check for HTML strings or ID strings. */
 var quickExpr = /^(?:[^#<]*(<[\w\W]+>)[^>]*$|#([\w-]*)$)/;
 
 /**
  * Check if string is HTML.
  *
+ * @private
+ *
  * @param {string} str - String to check.
  * @returns {boolean} Indicates if `str` is HTML.
- * @private
  */
 exports.isHtml = function (str) {
   // Faster than running regex, if str starts with `<` and ends with `>`, assume it's HTML

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -49,6 +49,7 @@ exports.cssCase = function (str) {
  *
  * @param {Cheerio} cheerio - Cheerio object.
  * @param {Function} fn - Function to call.
+ * @returns {void}
  */
 exports.domEach = function (cheerio, fn) {
   var i = 0;
@@ -61,7 +62,8 @@ exports.domEach = function (cheerio, fn) {
  * Create a deep copy of the given DOM structure.
  * Sets the parents of the copies of the passed nodes to `null`.
  *
- * @param {object} dom - The htmlparser2-compliant DOM structure.
+ * @param {Node | Node[]} dom - The htmlparser2-compliant DOM structure.
+ * @returns {Node[]} - The cloned DOM.
  * @private
  */
 exports.cloneDom = function (dom) {
@@ -81,8 +83,8 @@ exports.cloneDom = function (dom) {
   return clone;
 };
 
-/*
- * A simple way to check for HTML strings or ID strings
+/**
+ * A simple way to check for HTML strings or ID strings.
  */
 var quickExpr = /^(?:[^#<]*(<[\w\W]+>)[^>]*$|#([\w-]*)$)/;
 
@@ -90,7 +92,7 @@ var quickExpr = /^(?:[^#<]*(<[\w\W]+>)[^>]*$|#([\w-]*)$)/;
  * Check if string is HTML.
  *
  * @param {string} str - String to check.
- *
+ * @returns {boolean} Indicates if `str` is HTML.
  * @private
  */
 exports.isHtml = function (str) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,7 +6,7 @@ var domhandler = require('domhandler');
  *
  * `isTag(type)` includes `<script>` and `<style>` tags.
  *
- * @param {node} type - DOM node to check.
+ * @param {Node} type - DOM node to check.
  * @returns {boolean}
  *
  * @private
@@ -47,7 +47,7 @@ exports.cssCase = function (str) {
  * This is indented for use internally to avoid otherwise unnecessary memory
  * pressure introduced by _make.
  *
- * @param {cheerio} cheerio - Cheerio object.
+ * @param {Cheerio} cheerio - Cheerio object.
  * @param {Function} fn - Function to call.
  */
 exports.domEach = function (cheerio, fn) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2792,6 +2792,12 @@
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
+    "linguist-languages": {
+      "version": "7.12.2",
+      "resolved": "https://registry.npmjs.org/linguist-languages/-/linguist-languages-7.12.2.tgz",
+      "integrity": "sha512-xRtwDRdTLNff0/8Gr65rJBC/lXdQwDH1/UIKFK9UvpXBEFhsgT5J7jEJMGT+IbsA3WGKJSjxuEZxakuYoToqRg==",
+      "dev": true
+    },
     "linkify-it": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
@@ -3630,6 +3636,16 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
       "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
       "dev": true
+    },
+    "prettier-plugin-jsdoc": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-jsdoc/-/prettier-plugin-jsdoc-0.2.9.tgz",
+      "integrity": "sha512-l0Y7b166PqBXwu7Xouq+aY6R3sv6YmfI6sw0welssaFR9ZeTHEwUSkRf2h/F2b6aedHZiXAlpKqhurDenqC0zA==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "^0.7.6",
+        "linguist-languages": "^7.11.1"
+      }
     },
     "process-on-spawn": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "mocha": "^8.1.1",
     "nyc": "^15.0.1",
     "prettier": "^2.1.1",
+    "prettier-plugin-jsdoc": "^0.2.9",
     "tsd": "^0.14.0",
     "xyz": "~4.0.0"
   },

--- a/test/api/deprecated.js
+++ b/test/api/deprecated.js
@@ -16,9 +16,8 @@ describe('deprecated APIs', function () {
    * defined on the "loaded" Cheerio factory function.
    *
    * @example
-   *
-   *     var $ = cheerio.load('');
-   *     $.parseHTML('<b>markup</b>');
+   *   var $ = cheerio.load('');
+   *   $.parseHTML('<b>markup</b>');
    */
   describe('cheerio module', function () {
     describe('.parseHTML', function () {
@@ -35,8 +34,8 @@ describe('deprecated APIs', function () {
      * encouraged to instead use the static method of the same name.
      *
      * @example
-     *     var $ = cheerio.load('');
-     *     $.merge([1, 2], [3, 4]) // [1, 2, 3, 4]
+     *   var $ = cheerio.load('');
+     *   $.merge([1, 2], [3, 4]); // [1, 2, 3, 4]
      */
     describe('.merge', function () {
       var arr1;
@@ -136,9 +135,9 @@ describe('deprecated APIs', function () {
      * encouraged to instead use the static method of the same name.
      *
      * @example
-     *     var $ = cheerio.load('<div><p></p></div>');
-     *     $.contains($('div').get(0), $('p').get(0)); // true
-     *     $.contains($('p').get(0), $('div').get(0)); // false
+     *   var $ = cheerio.load('<div><p></p></div>');
+     *   $.contains($('div').get(0), $('p').get(0)); // true
+     *   $.contains($('p').get(0), $('div').get(0)); // false
      */
     describe('.contains', function () {
       var $;
@@ -178,8 +177,8 @@ describe('deprecated APIs', function () {
      * instead use the `root` static method of a "loaded" Cheerio function.
      *
      * @example
-     *     var $ = cheerio.load('');
-     *     $.root();
+     *   var $ = cheerio.load('');
+     *   $.root();
      */
     describe('.root', function () {
       it('returns an empty selection', function () {
@@ -196,7 +195,7 @@ describe('deprecated APIs', function () {
      * function exported by the Cheerio module.
      *
      * @example
-     *     var $ = cheerio.load('<h1>Hello, <span>world</span>.</h1>');
+     *   var $ = cheerio.load('<h1>Hello, <span>world</span>.</h1>');
      */
     it('.load', function () {
       var $1 = cheerio.load(fixtures.fruits);
@@ -206,20 +205,19 @@ describe('deprecated APIs', function () {
     });
 
     /**
-     * The `.html` static method defined on the "loaded" Cheerio factory function
-     * is deprecated.
+     * The `.html` static method defined on the "loaded" Cheerio factory
+     * function is deprecated.
      *
      * In order to promote consistency with the jQuery library, users are
      * encouraged to instead use the instance method of the same name.
      *
      * @example
-     *     var $ = cheerio.load('<h1>Hello, <span>world</span>.</h1>');
-     *     $('h1').html(); // '<h1>Hello, <span>world</span>.'.
+     *   var $ = cheerio.load('<h1>Hello, <span>world</span>.</h1>');
+     *   $('h1').html(); // '<h1>Hello, <span>world</span>.'
      *
      * @example <caption>To render the markup of an entire document, invoke the `html` function
      * exported by the Cheerio module with a "root" selection.</caption>
-     *
-     *     cheerio.html($.root()); // '<html><head></head><body><h1>Hello, <span>world</span>.</h1></body></html>'.
+     *   cheerio.html($.root()); // '<html><head></head><body><h1>Hello, <span>world</span>.</h1></body></html>'
      */
     describe('.html - deprecated API', function () {
       it('() : of empty cheerio object should return null', function () {
@@ -241,7 +239,7 @@ describe('deprecated APIs', function () {
      * exported by the Cheerio module.
      *
      * @example
-     *     cheerio.xml($.root());
+     *   cheerio.xml($.root());
      */
     describe('.xml  - deprecated API', function () {
       it('() :  renders XML', function () {
@@ -251,20 +249,19 @@ describe('deprecated APIs', function () {
     });
 
     /**
-     * The `.text` static method defined on the "loaded" Cheerio factory function
-     * is deprecated.
+     * The `.text` static method defined on the "loaded" Cheerio factory
+     * function is deprecated.
      *
      * In order to promote consistency with the jQuery library, users are
-     * encouraged to instead use the instance method of the same name. For
-     * example:
+     * encouraged to instead use the instance method of the same name.
      *
-     *     var $ = cheerio.load('<h1>Hello, <span>world</span>.</h1>');
-     *     $('h1').text(); // 'Hello, world.'.
+     * @example
+     *   var $ = cheerio.load('<h1>Hello, <span>world</span>.</h1>');
+     *   $('h1').text(); // 'Hello, world.'
      *
-     * To render the text content of an entire document, invoke the `text`
-     * function exported by the Cheerio module with a "root" selection, e.g.
-     *
-     *     Cheerio.text($.root()); // 'Hello, world.'.
+     * @example <caption>To render the text content of an entire document, invoke the `text`
+     * function exported by the Cheerio module with a "root" selection. </caption>
+     *   cheerio.text($.root()); // 'Hello, world.'
      */
     describe('.text  - deprecated API', function () {
       it('(cheerio object) : should return the text contents of the specified elements', function () {

--- a/test/api/traversing.js
+++ b/test/api/traversing.js
@@ -1293,8 +1293,7 @@ describe('$(...)', function () {
     });
 
     /**
-     * Element order is undefined in this case, so it should not be asserted
-     * here.
+     * Element order is undefined in this case, so it should not be asserted here.
      *
      * > If the collection consists of elements from different documents or ones
      * > not in any document, the sort order is undefined.

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -68,18 +68,14 @@ $ = cheerio.load(html, {
   },
 });
 
-/**
- * Selectors
- */
+/** Selectors */
 var $el = $('.class');
 var $multiEl = $('selector', 'selector', 'selector');
 var $emptyEl = $('.not-existing-class');
 
 $el.cheerio;
 
-/**
- * Attributes
- */
+/** Attributes */
 
 // attr
 $el.attr();
@@ -121,16 +117,12 @@ $el.is(() => {
   return true;
 });
 
-/**
- * Forms
- */
+/** Forms */
 // serializeArray
 $('<form><input name="foo" value="bar" /></form>').serializeArray();
 $('<form><input name="foo" value="bar" /></form>').serialize();
 
-/**
- * Traversing
- */
+/** Traversing */
 // find
 $el.find('li').length;
 $el.find($('.apple')).length;
@@ -259,9 +251,7 @@ $el.add('.class').length;
 $el.eq(0).addBack().length;
 $el.eq(0).addBack('.class').length;
 
-/**
- * Manipulation
- */
+/** Manipulation */
 
 $('<li class="plum">Plum</li>').appendTo($el);
 $el.prependTo($('<li class="plum">Plum</li>'));
@@ -314,24 +304,18 @@ $el.css('width');
 $el.css(['width', 'height']);
 $el.css('width', '50px');
 
-/**
- * Rendering
- */
+/** Rendering */
 $.html();
 $.html('.class');
 $.xml();
 $.xml($el);
 
-/**
- * Miscellaneous
- */
+/** Miscellaneous */
 
 // .clone() ####
 $el.clone().html();
 
-/**
- * Utilities
- */
+/** Utilities */
 
 // $.root
 $.root().append('<ul id="vegetables"></ul>').html();
@@ -343,9 +327,7 @@ $.contains($el[0], $el[0]);
 $.parseHTML(html);
 $.parseHTML(html, undefined, true);
 
-/**
- * Not in doc
- */
+/** Not in doc */
 $el.toArray();
 
 cheerio.html($el);


### PR DESCRIPTION
Adds JSDoc comments for a couple of methods, `@returns` everywhere it was missing and introduces some additional lints. Also introduces a Prettier plugin to automatically format all JSDoc comments.