### PR TITLE
child finding fix

### DIFF
--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -410,23 +410,27 @@ exports.wrapAll = function (wrapper) {
       wrapper = wrapper.call(this[0]);
     }
 
-    var wrap = this._make(wrapper);
+    // trim whitespace
+    if (typeof wrapper === 'string') {
+      wrapper = wrapper.trim();
+    }
+
+    var wrap = this._make(wrapper).eq(0).clone();
 
     if (this[0].parent) {
       wrap = wrap.insertBefore(this[0]);
     }
 
-    // if html is given as wrapper, wrap may contain text elements
-    var elInsertLocation = { children: wrap };
+    var elInsertLocation = wrap[0];
     var j = 0;
 
     // Find the deepest child. Only consider the first tag child of each node
     // (ignore text); stop if no children are found.
-    while (
-      elInsertLocation &&
-      elInsertLocation.children &&
-      j >= elInsertLocation.children.length
-    ) {
+    while (elInsertLocation && elInsertLocation.children) {
+      if (j >= elInsertLocation.children.length) {
+        break;
+      }
+
       if (elInsertLocation.children[j].type === 'tag') {
         elInsertLocation = elInsertLocation.children[j];
         j = 0;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,6 +4,12 @@ import { ParserOptions } from 'htmlparser2';
 declare namespace cheerio {
   type AttrFunction = (el: Element, i: number, currentValue: string) => any;
 
+  /** A Selector is used to select DOM elements from document. */
+  type selectorString = string;
+
+  /** A string representing html fragment or document */
+  type htmlString = string;
+
   interface Cheerio {
     // Document References
     // Cheerio https://github.com/cheeriojs/cheerio
@@ -193,6 +199,10 @@ declare namespace cheerio {
     wrap(content: Document): Cheerio;
     wrap(content: Cheerio): Cheerio;
 
+    wrapAll(
+      wrapper: cheerio.htmlString | cheerio.selectorString | Cheerio | Element
+    ): Cheerio;
+
     css(propertyName: string): string;
     css(propertyNames: string[]): string[];
     css(propertyName: string, value: string): Cheerio;
@@ -270,7 +280,7 @@ declare namespace cheerio {
       options?: CheerioParserOptions | null,
       isDocument?: boolean
     ): Root;
-    load(element: Element, options?: CheerioParserOptions): Root;
+    load(element: Element | Element[], options?: CheerioParserOptions): Root;
   }
 }
 


### PR DESCRIPTION
* child finding got broken (it add elements on root element, when it should add them on last branch element)
* updated types (added `wrapAll` function)
* it clones wrapping element taken from DOM (jQuery acts same way)
* trims string white space (preventing first DOM element to be text)