### PR TITLE
test: Migrate to Jest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
 npm-debug.log
 .DS_Store
-.nyc_output
+/coverage
 /docs/out/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,3 @@
 node_modules
-.nyc_output
+/coverage
 docs

--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,12 @@ subl:
 	@subl lib/ test/ package.json index.js
 
 test-cov:
-	@./node_modules/.bin/nyc node_modules/.bin/_mocha -- --recursive --reporter $(REPORTER)
+	@./node_modules/.bin/jest --coverage
 
 # Due to occasional unavailability of the code coverage reporting service, the
 # exit status of the command in this recipe may optionally be ignored.
 report-cov: test-cov
-	@./node_modules/.bin/nyc report --reporter=text-lcov | ./node_modules/.bin/coveralls || [ "$(OPTIONAL)" = "true" ]
+	cat coverage/lcov.info | ./node_modules/.bin/coveralls || [ "$(OPTIONAL)" = "true" ]
 
 travis-test: OPTIONAL = true
 travis-test: lint types report-cov

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -246,11 +246,11 @@ function _wrap(insert) {
       // (ignore text); stop if no children are found.
       var j = 0;
 
-      while (elInsertLocation && elInsertLocation.children) {
-        if (j >= elInsertLocation.children.length) {
-          break;
-        }
-
+      while (
+        elInsertLocation &&
+        elInsertLocation.children &&
+        j < elInsertLocation.children.length
+      ) {
         if (elInsertLocation.children[j].type === 'tag') {
           elInsertLocation = elInsertLocation.children[j];
           j = 0;
@@ -425,7 +425,7 @@ exports.wrapAll = function (wrapper) {
     while (
       elInsertLocation &&
       elInsertLocation.children &&
-      j >= elInsertLocation.children.length
+      j < elInsertLocation.children.length
     ) {
       if (elInsertLocation.children[j].type === 'tag') {
         elInsertLocation = elInsertLocation.children[j];

--- a/package-lock.json
+++ b/package-lock.json
@@ -133,6 +133,12 @@
         "@babel/types": "^7.12.10"
       }
     },
+    "@babel/helper-plugin-utils": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+      "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+      "dev": true
+    },
     "@babel/helper-replace-supers": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
@@ -210,6 +216,114 @@
       "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
       "dev": true
     },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-class-properties": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.1.tgz",
+      "integrity": "sha512-U40A76x5gTwmESz+qiqssqmeEsKvcSyvtgktrm0uzcARAmM9I1jR221f6Oq+GmHrcD+LvZDag1UTOTe2fL3TeA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-top-level-await": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.1.tgz",
+      "integrity": "sha512-i7ooMZFS+a/Om0crxZodrTzNEPJHZrlMVGMTEpFAj6rYY/bKCddB0Dk/YxfPuYXOopuhKk/e1jV6h+WUU9XN3A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
     "@babel/template": {
       "version": "7.12.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
@@ -257,6 +371,22 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
+    },
+    "@cnakazawa/watch": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
+      "integrity": "sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==",
+      "dev": true,
+      "requires": {
+        "exec-sh": "^0.3.2",
+        "minimist": "^1.2.0"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.2.tgz",
@@ -302,6 +432,198 @@
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
     },
+    "@jest/console": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.6.2.tgz",
+      "integrity": "sha512-IY1R2i2aLsLr7Id3S6p2BA82GNWryt4oSvEXLAKc+L2zdi89dSkE8xC1C+0kpATG4JhBJREnQOH7/zmccM2B0g==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "slash": "^3.0.0"
+      }
+    },
+    "@jest/core": {
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.6.3.tgz",
+      "integrity": "sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^26.6.2",
+        "@jest/reporters": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/transform": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.4",
+        "jest-changed-files": "^26.6.2",
+        "jest-config": "^26.6.3",
+        "jest-haste-map": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-regex-util": "^26.0.0",
+        "jest-resolve": "^26.6.2",
+        "jest-resolve-dependencies": "^26.6.3",
+        "jest-runner": "^26.6.3",
+        "jest-runtime": "^26.6.3",
+        "jest-snapshot": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jest-validate": "^26.6.2",
+        "jest-watcher": "^26.6.2",
+        "micromatch": "^4.0.2",
+        "p-each-series": "^2.1.0",
+        "rimraf": "^3.0.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "@jest/environment": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.6.2.tgz",
+      "integrity": "sha512-nFy+fHl28zUrRsCeMB61VDThV1pVTtlEokBRgqPrcT1JNq4yRNIyTHfyht6PqtUvY9IsuLGTrbG8kPXjSZIZwA==",
+      "dev": true,
+      "requires": {
+        "@jest/fake-timers": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "jest-mock": "^26.6.2"
+      }
+    },
+    "@jest/fake-timers": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.6.2.tgz",
+      "integrity": "sha512-14Uleatt7jdzefLPYM3KLcnUl1ZNikaKq34enpb5XG9i81JpppDb5muZvonvKyrl7ftEHkKS5L5/eB/kxJ+bvA==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@types/node": "*",
+        "jest-message-util": "^26.6.2",
+        "jest-mock": "^26.6.2",
+        "jest-util": "^26.6.2"
+      }
+    },
+    "@jest/globals": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.6.2.tgz",
+      "integrity": "sha512-85Ltnm7HlB/KesBUuALwQ68YTU72w9H2xW9FjZ1eL1U3lhtefjjl5c2MiUbpXt/i6LaPRvoOFJ22yCBSfQ0JIA==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "expect": "^26.6.2"
+      }
+    },
+    "@jest/reporters": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.6.2.tgz",
+      "integrity": "sha512-h2bW53APG4HvkOnVMo8q3QXa6pcaNt1HkwVsOPMBV6LD/q9oSpxNSYZQYkAnjdMjrJ86UuYeLo+aEZClV6opnw==",
+      "dev": true,
+      "requires": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/transform": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.2.4",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^4.0.3",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.0.2",
+        "jest-haste-map": "^26.6.2",
+        "jest-resolve": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jest-worker": "^26.6.2",
+        "node-notifier": "^8.0.0",
+        "slash": "^3.0.0",
+        "source-map": "^0.6.0",
+        "string-length": "^4.0.1",
+        "terminal-link": "^2.0.0",
+        "v8-to-istanbul": "^7.0.0"
+      }
+    },
+    "@jest/source-map": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.6.2.tgz",
+      "integrity": "sha512-YwYcCwAnNmOVsZ8mr3GfnzdXDAl4LaenZP5z+G0c8bzC9/dugL8zRmxZzdoTl4IaS3CryS1uWnROLPFmb6lVvA==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.4",
+        "source-map": "^0.6.0"
+      }
+    },
+    "@jest/test-result": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.6.2.tgz",
+      "integrity": "sha512-5O7H5c/7YlojphYNrK02LlDIV2GNPYisKwHm2QTKjNZeEzezCbwYs9swJySv2UfPMyZ0VdsmMv7jIlD/IKYQpQ==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      }
+    },
+    "@jest/test-sequencer": {
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.6.3.tgz",
+      "integrity": "sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==",
+      "dev": true,
+      "requires": {
+        "@jest/test-result": "^26.6.2",
+        "graceful-fs": "^4.2.4",
+        "jest-haste-map": "^26.6.2",
+        "jest-runner": "^26.6.3",
+        "jest-runtime": "^26.6.3"
+      }
+    },
+    "@jest/transform": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.2.tgz",
+      "integrity": "sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.1.0",
+        "@jest/types": "^26.6.2",
+        "babel-plugin-istanbul": "^6.0.0",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^1.4.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graceful-fs": "^4.2.4",
+        "jest-haste-map": "^26.6.2",
+        "jest-regex-util": "^26.0.0",
+        "jest-util": "^26.6.2",
+        "micromatch": "^4.0.2",
+        "pirates": "^4.0.1",
+        "slash": "^3.0.0",
+        "source-map": "^0.6.1",
+        "write-file-atomic": "^3.0.0"
+      }
+    },
+    "@jest/types": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+      "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^15.0.0",
+        "chalk": "^4.0.0"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -334,6 +656,24 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true
     },
+    "@sinonjs/commons": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -341,6 +681,80 @@
       "dev": true,
       "requires": {
         "defer-to-connect": "^1.0.1"
+      }
+    },
+    "@types/babel__core": {
+      "version": "7.1.12",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",
+      "integrity": "sha512-wMTHiiTiBAAPebqaPiPDLFA4LYPKr6Ph0Xq/6rq1Ur3v66HXyG+clfR9CNETkD7MQS8ZHvpQOtA53DLws5WAEQ==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "@types/babel__generator": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
+      "integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__template": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.0.tgz",
+      "integrity": "sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__traverse": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.11.0.tgz",
+      "integrity": "sha512-kSjgDMZONiIfSH1Nxcr5JIRMwUetDki63FSQfpTCz8ogF3Ulqm8+mr5f78dUYs6vMiB6gBusQqfQmBvHZj/lwg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.3.0"
+      }
+    },
+    "@types/graceful-fs": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.4.tgz",
+      "integrity": "sha512-mWA/4zFQhfvOA8zWkXobwJvBD7vzcxgrOQ0J5CH1votGqdq9m7+FwtGaqyCZqC3NyyBkc9z4m+iry4LlqcMWJg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
+      "dev": true
+    },
+    "@types/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+      "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-report": "*"
       }
     },
     "@types/minimist": {
@@ -367,10 +781,31 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
-    "@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+    "@types/prettier": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.6.tgz",
+      "integrity": "sha512-6gOkRe7OIioWAXfnO/2lFiv+SJichKVSys1mSsgyrYHSEjk8Ctv4tSR/Odvnu+HWlH2C8j53dahU03XmQdd5fA==",
+      "dev": true
+    },
+    "@types/stack-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
+      "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+      "dev": true
+    },
+    "@types/yargs": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.12.tgz",
+      "integrity": "sha512-f+fD/fQAo3BCbCDlrUpznF1A5Zp9rB0noS5vnoormHSIPFKL0Z2DcUJ3Gxp5ytH4uLRNxy7AwYUC9exZzqGMAw==",
+      "dev": true,
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "20.2.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
+      "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
       "dev": true
     },
     "abab": {
@@ -526,21 +961,6 @@
         "picomatch": "^2.0.4"
       }
     },
-    "append-transform": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
-      "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
-      "dev": true,
-      "requires": {
-        "default-require-extensions": "^3.0.0"
-      }
-    },
-    "archy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
-      "dev": true
-    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -550,10 +970,34 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
     "arrify": {
@@ -577,6 +1021,12 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
     "astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -587,6 +1037,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
     "aws-sign2": {
@@ -601,11 +1057,137 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
+    "babel-jest": {
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.3.tgz",
+      "integrity": "sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==",
+      "dev": true,
+      "requires": {
+        "@jest/transform": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/babel__core": "^7.1.7",
+        "babel-plugin-istanbul": "^6.0.0",
+        "babel-preset-jest": "^26.6.2",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "slash": "^3.0.0"
+      }
+    },
+    "babel-plugin-istanbul": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
+      "integrity": "sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^4.0.0",
+        "test-exclude": "^6.0.0"
+      }
+    },
+    "babel-plugin-jest-hoist": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.6.2.tgz",
+      "integrity": "sha512-PO9t0697lNTmcEHH69mdtYiOIkkOlj9fySqfO3K1eCcdISevLAE0xY59VLLUj0SoiPiTX/JU2CYFpILydUa5Lw==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.0.0",
+        "@types/babel__traverse": "^7.0.6"
+      }
+    },
+    "babel-preset-current-node-syntax": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
+      "integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.8.3",
+        "@babel/plugin-syntax-import-meta": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-top-level-await": "^7.8.3"
+      }
+    },
+    "babel-preset-jest": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.6.2.tgz",
+      "integrity": "sha512-YvdtlVm9t3k777c5NPQIv6cxFFFapys25HiUmuSgHwIZhfifweR5c5Sf5nwE3MAbfu327CYSvps8Yx6ANLyleQ==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-jest-hoist": "^26.6.2",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -625,12 +1207,6 @@
         "lodash": "^4.17.4",
         "platform": "^1.3.3"
       }
-    },
-    "binary-extensions": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
-      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
-      "dev": true
     },
     "bluebird": {
       "version": "3.7.2",
@@ -735,11 +1311,37 @@
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
       "dev": true
     },
-    "browser-stdout": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+    "bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "requires": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      }
     },
     "cacheable-request": {
       "version": "6.1.0",
@@ -764,18 +1366,6 @@
         }
       }
     },
-    "caching-transform": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
-      "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
-      "dev": true,
-      "requires": {
-        "hasha": "^5.0.0",
-        "make-dir": "^3.0.0",
-        "package-hash": "^4.0.0",
-        "write-file-atomic": "^3.0.0"
-      }
-    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -797,6 +1387,15 @@
         "camelcase": "^5.3.1",
         "map-obj": "^4.0.0",
         "quick-lru": "^4.0.1"
+      }
+    },
+    "capture-exit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
+      "integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
+      "dev": true,
+      "requires": {
+        "rsvp": "^4.8.4"
       }
     },
     "caseless": {
@@ -865,6 +1464,12 @@
         }
       }
     },
+    "char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true
+    },
     "cheerio-select": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.0.0.tgz",
@@ -877,27 +1482,40 @@
         "domutils": "^2.4.4"
       }
     },
-    "chokidar": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
-      "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
-      "dev": true,
-      "requires": {
-        "anymatch": "~3.1.1",
-        "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
-        "glob-parent": "~5.1.0",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
-      }
-    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
+    },
+    "cjs-module-lexer": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz",
+      "integrity": "sha512-uc2Vix1frTfnuzxxu1Hp4ktSvM3QaI4oXl4ZUqL1wjTu/BGki9TrCWoqLTg/drR1KwAEarXuRFCG2Svr1GxPFw==",
+      "dev": true
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -968,65 +1586,14 @@
       }
     },
     "cliui": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
       "dev": true,
       "requires": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "string-width": "^3.0.0",
-            "strip-ansi": "^5.0.0"
-          }
-        }
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
       }
     },
     "clone-response": {
@@ -1036,6 +1603,28 @@
       "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "collect-v8-coverage": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
+      "integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
+      "dev": true
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "color-convert": {
@@ -1074,16 +1663,16 @@
       "integrity": "sha512-GKNxVA7/iuTnAqGADlTWX4tkhzxZKXp5fLJqKTlQLHkE65XDUKutZ3BHaJC5IGcper2tT3QRD1xr4o3jNpgXXg==",
       "dev": true
     },
-    "commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-      "dev": true
-    },
     "compare-versions": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
       "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
+      "dev": true
+    },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
     "concat-map": {
@@ -1122,6 +1711,12 @@
           "dev": true
         }
       }
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1271,6 +1866,12 @@
       "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
       "dev": true
     },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
     "decompress-response": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
@@ -1298,14 +1899,11 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
-    "default-require-extensions": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz",
-      "integrity": "sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==",
-      "dev": true,
-      "requires": {
-        "strip-bom": "^4.0.0"
-      }
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "dev": true
     },
     "defer-to-connect": {
       "version": "1.1.3",
@@ -1313,16 +1911,63 @@
       "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
       "dev": true
     },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
-    "diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+    "detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true
+    },
+    "diff-sequences": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
+      "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
       "dev": true
     },
     "dir-glob": {
@@ -1426,6 +2071,12 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "emittery": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.2.tgz",
+      "integrity": "sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==",
+      "dev": true
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -1463,12 +2114,6 @@
       "requires": {
         "is-arrayish": "^0.2.1"
       }
-    },
-    "es6-error": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true
     },
     "escape-goat": {
       "version": "2.1.1",
@@ -1727,6 +2372,12 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "exec-sh": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz",
+      "integrity": "sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==",
+      "dev": true
+    },
     "execa": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
@@ -1744,17 +2395,193 @@
         "strip-final-newline": "^2.0.0"
       }
     },
-    "expect.js": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/expect.js/-/expect.js-0.3.1.tgz",
-      "integrity": "sha1-sKWaDS7/VDdUTr8M6qYBWEHQm1s=",
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
+    },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "expect": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-26.6.2.tgz",
+      "integrity": "sha512-9/hlOBkQl2l/PLHJx6JjoDF6xPKcJEsUlWKb23rKE7KzeDqUZKXKNMW27KIue5JMdBV9HgmoJPcc8HtO85t9IA==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "ansi-styles": "^4.0.0",
+        "jest-get-type": "^26.3.0",
+        "jest-matcher-utils": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-regex-util": "^26.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
+      }
     },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "requires": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
     },
     "extsprintf": {
       "version": "1.3.0",
@@ -1803,6 +2630,15 @@
         "reusify": "^1.0.4"
       }
     },
+    "fb-watchman": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
+      "integrity": "sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==",
+      "dev": true,
+      "requires": {
+        "bser": "2.1.1"
+      }
+    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -1830,17 +2666,6 @@
         "to-regex-range": "^5.0.1"
       }
     },
-    "find-cache-dir": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
-      "dev": true,
-      "requires": {
-        "commondir": "^1.0.1",
-        "make-dir": "^3.0.2",
-        "pkg-dir": "^4.1.0"
-      }
-    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -1860,12 +2685,6 @@
         "semver-regex": "^2.0.0"
       }
     },
-    "flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "dev": true
-    },
     "flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -1882,15 +2701,11 @@
       "integrity": "sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==",
       "dev": true
     },
-    "foreground-child": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
-      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^7.0.0",
-        "signal-exit": "^3.0.2"
-      }
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -1909,11 +2724,14 @@
         "mime-types": "^2.1.12"
       }
     },
-    "fromentries": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
-      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
-      "dev": true
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -1922,9 +2740,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.2.1.tgz",
+      "integrity": "sha512-bTLYHSeC0UH/EFXS9KqWnXuOl/wHK5Z/d+ghd5AsFMYN7wIGkUCOJyzy88+wJKkZPGON8u4Z9f6U4FdgURE9qA==",
       "dev": true,
       "optional": true
     },
@@ -1972,6 +2790,12 @@
       "requires": {
         "pump": "^3.0.0"
       }
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
     },
     "getpass": {
       "version": "0.1.7",
@@ -2081,11 +2905,12 @@
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
     },
-    "growl": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-      "dev": true
+    "growly": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "dev": true,
+      "optional": true
     },
     "har-schema": {
       "version": "2.0.0",
@@ -2124,26 +2949,62 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "has-yarn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
-      "dev": true
-    },
-    "hasha": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
-      "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
-      "dev": true,
-      "requires": {
-        "is-stream": "^2.0.0",
-        "type-fest": "^0.8.0"
-      }
-    },
-    "he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
     "hosted-git-info": {
@@ -2250,6 +3111,16 @@
       "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
       "dev": true
     },
+    "import-local": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+      "integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+      "dev": true,
+      "requires": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      }
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -2296,20 +3167,37 @@
       "integrity": "sha512-YqTdPLfwP7YFN0SsD3QUVCkm9ZG2VzOXv3DOrw5G5mkMbVwptTwVcFv7/C0vOpBmgTxAeTG19XpUs1E522LW9Q==",
       "dev": true
     },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
-    "is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
-      "requires": {
-        "binary-extensions": "^2.0.0"
-      }
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "is-ci": {
       "version": "2.0.0",
@@ -2329,6 +3217,58 @@
         "has": "^1.0.3"
       }
     },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "is-docker": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
+      "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
+      "dev": true,
+      "optional": true
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2339,6 +3279,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
+    "is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
     },
     "is-glob": {
@@ -2384,11 +3330,14 @@
       "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
       "dev": true
     },
-    "is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "dev": true
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
     },
     "is-potential-custom-element-name": {
       "version": "1.0.0",
@@ -2420,16 +3369,38 @@
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
+    },
     "is-yarn-global": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
       "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
       "dev": true
     },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
     "isstream": {
@@ -2443,15 +3414,6 @@
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
       "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
       "dev": true
-    },
-    "istanbul-lib-hook": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
-      "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
-      "dev": true,
-      "requires": {
-        "append-transform": "^2.0.0"
-      }
     },
     "istanbul-lib-instrument": {
       "version": "4.0.3",
@@ -2470,32 +3432,6 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
-        }
-      }
-    },
-    "istanbul-lib-processinfo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
-      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
-      "dev": true,
-      "requires": {
-        "archy": "^1.0.0",
-        "cross-spawn": "^7.0.0",
-        "istanbul-lib-coverage": "^3.0.0-alpha.1",
-        "make-dir": "^3.0.0",
-        "p-map": "^3.0.0",
-        "rimraf": "^3.0.0",
-        "uuid": "^3.3.3"
-      },
-      "dependencies": {
-        "p-map": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-          "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
-          "dev": true,
-          "requires": {
-            "aggregate-error": "^3.0.0"
-          }
         }
       }
     },
@@ -2546,6 +3482,458 @@
       "requires": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
+      }
+    },
+    "jest": {
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-26.6.3.tgz",
+      "integrity": "sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==",
+      "dev": true,
+      "requires": {
+        "@jest/core": "^26.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^26.6.3"
+      },
+      "dependencies": {
+        "jest-cli": {
+          "version": "26.6.3",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
+          "integrity": "sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==",
+          "dev": true,
+          "requires": {
+            "@jest/core": "^26.6.3",
+            "@jest/test-result": "^26.6.2",
+            "@jest/types": "^26.6.2",
+            "chalk": "^4.0.0",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.2.4",
+            "import-local": "^3.0.2",
+            "is-ci": "^2.0.0",
+            "jest-config": "^26.6.3",
+            "jest-util": "^26.6.2",
+            "jest-validate": "^26.6.2",
+            "prompts": "^2.0.1",
+            "yargs": "^15.4.1"
+          }
+        }
+      }
+    },
+    "jest-changed-files": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.2.tgz",
+      "integrity": "sha512-fDS7szLcY9sCtIip8Fjry9oGf3I2ht/QT21bAHm5Dmf0mD4X3ReNUf17y+bO6fR8WgbIZTlbyG1ak/53cbRzKQ==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "execa": "^4.0.0",
+        "throat": "^5.0.0"
+      }
+    },
+    "jest-config": {
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.6.3.tgz",
+      "integrity": "sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.1.0",
+        "@jest/test-sequencer": "^26.6.3",
+        "@jest/types": "^26.6.2",
+        "babel-jest": "^26.6.3",
+        "chalk": "^4.0.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.2.4",
+        "jest-environment-jsdom": "^26.6.2",
+        "jest-environment-node": "^26.6.2",
+        "jest-get-type": "^26.3.0",
+        "jest-jasmine2": "^26.6.3",
+        "jest-regex-util": "^26.0.0",
+        "jest-resolve": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jest-validate": "^26.6.2",
+        "micromatch": "^4.0.2",
+        "pretty-format": "^26.6.2"
+      }
+    },
+    "jest-diff": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
+      "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^26.6.2",
+        "jest-get-type": "^26.3.0",
+        "pretty-format": "^26.6.2"
+      }
+    },
+    "jest-docblock": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-26.0.0.tgz",
+      "integrity": "sha512-RDZ4Iz3QbtRWycd8bUEPxQsTlYazfYn/h5R65Fc6gOfwozFhoImx+affzky/FFBuqISPTqjXomoIGJVKBWoo0w==",
+      "dev": true,
+      "requires": {
+        "detect-newline": "^3.0.0"
+      }
+    },
+    "jest-each": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.6.2.tgz",
+      "integrity": "sha512-Mer/f0KaATbjl8MCJ+0GEpNdqmnVmDYqCTJYTvoo7rqmRiDllmp2AYN+06F93nXcY3ur9ShIjS+CO/uD+BbH4A==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^26.3.0",
+        "jest-util": "^26.6.2",
+        "pretty-format": "^26.6.2"
+      }
+    },
+    "jest-environment-jsdom": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.6.2.tgz",
+      "integrity": "sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^26.6.2",
+        "@jest/fake-timers": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "jest-mock": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jsdom": "^16.4.0"
+      }
+    },
+    "jest-environment-node": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.6.2.tgz",
+      "integrity": "sha512-zhtMio3Exty18dy8ee8eJ9kjnRyZC1N4C1Nt/VShN1apyXc8rWGtJ9lI7vqiWcyyXS4BVSEn9lxAM2D+07/Tag==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^26.6.2",
+        "@jest/fake-timers": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "jest-mock": "^26.6.2",
+        "jest-util": "^26.6.2"
+      }
+    },
+    "jest-get-type": {
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+      "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
+      "dev": true
+    },
+    "jest-haste-map": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.2.tgz",
+      "integrity": "sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "@types/graceful-fs": "^4.1.2",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
+        "graceful-fs": "^4.2.4",
+        "jest-regex-util": "^26.0.0",
+        "jest-serializer": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jest-worker": "^26.6.2",
+        "micromatch": "^4.0.2",
+        "sane": "^4.0.3",
+        "walker": "^1.0.7"
+      }
+    },
+    "jest-jasmine2": {
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.6.3.tgz",
+      "integrity": "sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "^7.1.0",
+        "@jest/environment": "^26.6.2",
+        "@jest/source-map": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "expect": "^26.6.2",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^26.6.2",
+        "jest-matcher-utils": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-runtime": "^26.6.3",
+        "jest-snapshot": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "pretty-format": "^26.6.2",
+        "throat": "^5.0.0"
+      }
+    },
+    "jest-leak-detector": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.6.2.tgz",
+      "integrity": "sha512-i4xlXpsVSMeKvg2cEKdfhh0H39qlJlP5Ex1yQxwF9ubahboQYMgTtz5oML35AVA3B4Eu+YsmwaiKVev9KCvLxg==",
+      "dev": true,
+      "requires": {
+        "jest-get-type": "^26.3.0",
+        "pretty-format": "^26.6.2"
+      }
+    },
+    "jest-matcher-utils": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz",
+      "integrity": "sha512-llnc8vQgYcNqDrqRDXWwMr9i7rS5XFiCwvh6DTP7Jqa2mqpcCBBlpCbn+trkG0KNhPu/h8rzyBkriOtBstvWhw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^26.6.2",
+        "jest-get-type": "^26.3.0",
+        "pretty-format": "^26.6.2"
+      }
+    },
+    "jest-message-util": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.2.tgz",
+      "integrity": "sha512-rGiLePzQ3AzwUshu2+Rn+UMFk0pHN58sOG+IaJbk5Jxuqo3NYO1U2/MIR4S1sKgsoYSXSzdtSa0TgrmtUwEbmA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@jest/types": "^26.6.2",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "micromatch": "^4.0.2",
+        "pretty-format": "^26.6.2",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.2"
+      }
+    },
+    "jest-mock": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.6.2.tgz",
+      "integrity": "sha512-YyFjePHHp1LzpzYcmgqkJ0nm0gg/lJx2aZFzFy1S6eUqNjXsOqTK10zNRff2dNfssgokjkG65OlWNcIlgd3zew==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "@types/node": "*"
+      }
+    },
+    "jest-pnp-resolver": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
+      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
+      "dev": true
+    },
+    "jest-regex-util": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
+      "integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==",
+      "dev": true
+    },
+    "jest-resolve": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.6.2.tgz",
+      "integrity": "sha512-sOxsZOq25mT1wRsfHcbtkInS+Ek7Q8jCHUB0ZUTP0tc/c41QHriU/NunqMfCUWsL4H3MHpvQD4QR9kSYhS7UvQ==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^26.6.2",
+        "read-pkg-up": "^7.0.1",
+        "resolve": "^1.18.1",
+        "slash": "^3.0.0"
+      }
+    },
+    "jest-resolve-dependencies": {
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.3.tgz",
+      "integrity": "sha512-pVwUjJkxbhe4RY8QEWzN3vns2kqyuldKpxlxJlzEYfKSvY6/bMvxoFrYYzUO1Gx28yKWN37qyV7rIoIp2h8fTg==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "jest-regex-util": "^26.0.0",
+        "jest-snapshot": "^26.6.2"
+      }
+    },
+    "jest-runner": {
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.6.3.tgz",
+      "integrity": "sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^26.6.2",
+        "@jest/environment": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.7.1",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.4",
+        "jest-config": "^26.6.3",
+        "jest-docblock": "^26.0.0",
+        "jest-haste-map": "^26.6.2",
+        "jest-leak-detector": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-resolve": "^26.6.2",
+        "jest-runtime": "^26.6.3",
+        "jest-util": "^26.6.2",
+        "jest-worker": "^26.6.2",
+        "source-map-support": "^0.5.6",
+        "throat": "^5.0.0"
+      }
+    },
+    "jest-runtime": {
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.3.tgz",
+      "integrity": "sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^26.6.2",
+        "@jest/environment": "^26.6.2",
+        "@jest/fake-timers": "^26.6.2",
+        "@jest/globals": "^26.6.2",
+        "@jest/source-map": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/transform": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/yargs": "^15.0.0",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^0.6.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.4",
+        "jest-config": "^26.6.3",
+        "jest-haste-map": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-mock": "^26.6.2",
+        "jest-regex-util": "^26.0.0",
+        "jest-resolve": "^26.6.2",
+        "jest-snapshot": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jest-validate": "^26.6.2",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0",
+        "yargs": "^15.4.1"
+      }
+    },
+    "jest-serializer": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.6.2.tgz",
+      "integrity": "sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "graceful-fs": "^4.2.4"
+      }
+    },
+    "jest-snapshot": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.2.tgz",
+      "integrity": "sha512-OLhxz05EzUtsAmOMzuupt1lHYXCNib0ECyuZ/PZOx9TrZcC8vL0x+DUG3TL+GLX3yHG45e6YGjIm0XwDc3q3og==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0",
+        "@jest/types": "^26.6.2",
+        "@types/babel__traverse": "^7.0.4",
+        "@types/prettier": "^2.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^26.6.2",
+        "graceful-fs": "^4.2.4",
+        "jest-diff": "^26.6.2",
+        "jest-get-type": "^26.3.0",
+        "jest-haste-map": "^26.6.2",
+        "jest-matcher-utils": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-resolve": "^26.6.2",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^26.6.2",
+        "semver": "^7.3.2"
+      }
+    },
+    "jest-util": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+      "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "is-ci": "^2.0.0",
+        "micromatch": "^4.0.2"
+      }
+    },
+    "jest-validate": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.6.2.tgz",
+      "integrity": "sha512-NEYZ9Aeyj0i5rQqbq+tpIOom0YS1u2MVu6+euBsvpgIme+FOfRmoC4R5p0JiAUpaFvFy24xgrpMknarR/93XjQ==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "camelcase": "^6.0.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^26.3.0",
+        "leven": "^3.1.0",
+        "pretty-format": "^26.6.2"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+          "dev": true
+        }
+      }
+    },
+    "jest-watcher": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.6.2.tgz",
+      "integrity": "sha512-WKJob0P/Em2csiVthsI68p6aGKTIcsfjH9Gsx1f0A3Italz43e3ho0geSAVsmj09RWOELP1AZ/DXyJgOgDKxXQ==",
+      "dev": true,
+      "requires": {
+        "@jest/test-result": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "jest-util": "^26.6.2",
+        "string-length": "^4.0.1"
+      }
+    },
+    "jest-worker": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+      "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "jquery": {
@@ -2761,6 +4149,12 @@
         "graceful-fs": "^4.1.9"
       }
     },
+    "kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true
+    },
     "latest-version": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
@@ -2774,6 +4168,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
       "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
+      "dev": true
+    },
+    "leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "dev": true
     },
     "levn": {
@@ -2861,12 +4261,6 @@
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
-    "lodash.flattendeep": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
-      "dev": true
-    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -2932,11 +4326,35 @@
         }
       }
     },
+    "makeerror": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+      "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+      "dev": true,
+      "requires": {
+        "tmpl": "1.0.x"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
     "map-obj": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
       "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
       "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
     },
     "markdown-it": {
       "version": "10.0.0",
@@ -3103,123 +4521,32 @@
         }
       }
     },
+    "mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
     "mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
-    },
-    "mocha": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.2.1.tgz",
-      "integrity": "sha512-cuLBVfyFfFqbNR0uUKbDGXKGk+UDFe6aR4os78XIrMQpZl/nv7JYHcvP5MFIAb374b2zFXsdgEGwmzMtP0Xg8w==",
-      "dev": true,
-      "requires": {
-        "@ungap/promise-all-settled": "1.1.2",
-        "ansi-colors": "4.1.1",
-        "browser-stdout": "1.3.1",
-        "chokidar": "3.4.3",
-        "debug": "4.2.0",
-        "diff": "4.0.2",
-        "escape-string-regexp": "4.0.0",
-        "find-up": "5.0.0",
-        "glob": "7.1.6",
-        "growl": "1.10.5",
-        "he": "1.2.0",
-        "js-yaml": "3.14.0",
-        "log-symbols": "4.0.0",
-        "minimatch": "3.0.4",
-        "ms": "2.1.2",
-        "nanoid": "3.1.12",
-        "serialize-javascript": "5.0.1",
-        "strip-json-comments": "3.1.1",
-        "supports-color": "7.2.0",
-        "which": "2.0.2",
-        "wide-align": "1.1.3",
-        "workerpool": "6.0.2",
-        "yargs": "13.3.2",
-        "yargs-parser": "13.1.2",
-        "yargs-unparser": "2.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-          "dev": true
-        },
-        "find-up": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^6.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-          "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^5.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-          "dev": true,
-          "requires": {
-            "yocto-queue": "^0.1.0"
-          }
-        },
-        "p-locate": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^3.0.2"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
     },
     "ms": {
       "version": "2.1.2",
@@ -3227,11 +4554,24 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "nanoid": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
-      "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==",
-      "dev": true
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      }
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -3239,13 +4579,46 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "node-preload": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
-      "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+      "dev": true
+    },
+    "node-modules-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+      "dev": true
+    },
+    "node-notifier": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
+      "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
-        "process-on-spawn": "^1.0.0"
+        "growly": "^1.3.0",
+        "is-wsl": "^2.2.0",
+        "semver": "^7.3.2",
+        "shellwords": "^0.1.1",
+        "uuid": "^8.3.0",
+        "which": "^2.0.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "normalize-package-data": {
@@ -3303,103 +4676,60 @@
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
       "dev": true
     },
-    "nyc": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
-      "integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
-      "dev": true,
-      "requires": {
-        "@istanbuljs/load-nyc-config": "^1.0.0",
-        "@istanbuljs/schema": "^0.1.2",
-        "caching-transform": "^4.0.0",
-        "convert-source-map": "^1.7.0",
-        "decamelize": "^1.2.0",
-        "find-cache-dir": "^3.2.0",
-        "find-up": "^4.1.0",
-        "foreground-child": "^2.0.0",
-        "get-package-type": "^0.1.0",
-        "glob": "^7.1.6",
-        "istanbul-lib-coverage": "^3.0.0",
-        "istanbul-lib-hook": "^3.0.0",
-        "istanbul-lib-instrument": "^4.0.0",
-        "istanbul-lib-processinfo": "^2.0.2",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-lib-source-maps": "^4.0.0",
-        "istanbul-reports": "^3.0.2",
-        "make-dir": "^3.0.0",
-        "node-preload": "^0.2.1",
-        "p-map": "^3.0.0",
-        "process-on-spawn": "^1.0.0",
-        "resolve-from": "^5.0.0",
-        "rimraf": "^3.0.0",
-        "signal-exit": "^3.0.2",
-        "spawn-wrap": "^2.0.0",
-        "test-exclude": "^6.0.0",
-        "yargs": "^15.0.2"
-      },
-      "dependencies": {
-        "cliui": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^6.2.0"
-          }
-        },
-        "p-map": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-          "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
-          "dev": true,
-          "requires": {
-            "aggregate-error": "^3.0.0"
-          }
-        },
-        "resolve-from": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-          "dev": true
-        },
-        "yargs": {
-          "version": "15.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-          "dev": true,
-          "requires": {
-            "cliui": "^6.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^4.1.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^4.2.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^18.1.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
-        }
-      }
-    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -3445,6 +4775,18 @@
       "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
       "dev": true
     },
+    "p-each-series": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+      "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
     "p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -3477,18 +4819,6 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
-    },
-    "package-hash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
-      "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.15",
-        "hasha": "^5.0.0",
-        "lodash.flattendeep": "^4.4.0",
-        "release-zalgo": "^1.0.0"
-      }
     },
     "package-json": {
       "version": "6.5.0",
@@ -3544,6 +4874,12 @@
         "parse5": "^6.0.1"
       }
     },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3586,6 +4922,15 @@
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
+    "pirates": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+      "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+      "dev": true,
+      "requires": {
+        "node-modules-regexp": "^1.0.0"
+      }
+    },
     "pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -3619,6 +4964,12 @@
         "irregular-plurals": "^3.2.0"
       }
     },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3647,13 +4998,42 @@
         "linguist-languages": "^7.11.1"
       }
     },
-    "process-on-spawn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
-      "integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
+    "pretty-format": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+      "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
       "dev": true,
       "requires": {
-        "fromentries": "^1.2.0"
+        "@jest/types": "^26.6.2",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^4.0.0",
+        "react-is": "^17.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
       }
     },
     "progress": {
@@ -3661,6 +5041,16 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
+    },
+    "prompts": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
+      "integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
+      "dev": true,
+      "requires": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      }
     },
     "psl": {
       "version": "1.8.0",
@@ -3705,15 +5095,6 @@
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
       "dev": true
     },
-    "randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -3733,6 +5114,12 @@
           "dev": true
         }
       }
+    },
+    "react-is": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+      "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
+      "dev": true
     },
     "read-pkg": {
       "version": "5.2.0",
@@ -3765,15 +5152,6 @@
         "type-fest": "^0.8.1"
       }
     },
-    "readdirp": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
-      "dev": true,
-      "requires": {
-        "picomatch": "^2.2.1"
-      }
-    },
     "redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -3782,6 +5160,16 @@
       "requires": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "regexpp": {
@@ -3814,14 +5202,23 @@
         "rc": "^1.2.8"
       }
     },
-    "release-zalgo": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
-      "dev": true,
-      "requires": {
-        "es6-error": "^4.0.1"
-      }
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "repeat-element": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
     },
     "request": {
       "version": "2.88.2",
@@ -3902,10 +5299,33 @@
         "path-parse": "^1.0.6"
       }
     },
+    "resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
+    },
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
     "responselike": {
@@ -3927,6 +5347,12 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -3941,6 +5367,12 @@
       "requires": {
         "glob": "^7.1.3"
       }
+    },
+    "rsvp": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "dev": true
     },
     "run-parallel": {
       "version": "1.1.10",
@@ -3963,11 +5395,249 @@
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true
     },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "sane": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
+      "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
+      "dev": true,
+      "requires": {
+        "@cnakazawa/watch": "^1.0.3",
+        "anymatch": "^2.0.0",
+        "capture-exit": "^2.0.0",
+        "exec-sh": "^0.3.2",
+        "execa": "^1.0.0",
+        "fb-watchman": "^2.0.0",
+        "micromatch": "^3.1.4",
+        "minimist": "^1.1.1",
+        "walker": "~1.0.5"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+          "dev": true,
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          }
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "dev": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
     },
     "saxes": {
       "version": "5.0.1",
@@ -4016,20 +5686,34 @@
       "integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==",
       "dev": true
     },
-    "serialize-javascript": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
-      "dev": true,
-      "requires": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
+    },
+    "set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -4046,10 +5730,23 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "shellwords": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+      "dev": true,
+      "optional": true
+    },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
+    },
+    "sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
     },
     "slash": {
@@ -4101,25 +5798,168 @@
         }
       }
     },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
     },
-    "spawn-wrap": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
-      "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
+    "source-map-resolve": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
       "dev": true,
       "requires": {
-        "foreground-child": "^2.0.0",
-        "is-windows": "^1.0.2",
-        "make-dir": "^3.0.0",
-        "rimraf": "^3.0.0",
-        "signal-exit": "^3.0.2",
-        "which": "^2.0.1"
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
+    },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
     },
     "spdx-correct": {
       "version": "3.1.1",
@@ -4153,6 +5993,15 @@
       "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
       "dev": true
     },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -4176,6 +6025,44 @@
         "tweetnacl": "~0.14.0"
       }
     },
+    "stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "dev": true
+        }
+      }
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
@@ -4187,6 +6074,16 @@
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
       "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
       "dev": true
+    },
+    "string-length": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.1.tgz",
+      "integrity": "sha512-PKyXUd0LK0ePjSOnWn34V2uD6acUWev9uy0Ft05k0E8xRW+SKcA0F7eMr7h5xlzfn+4O3N+55rduYyet3Jk+jw==",
+      "dev": true,
+      "requires": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      }
     },
     "string-width": {
       "version": "4.2.0",
@@ -4223,6 +6120,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
       "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
     "strip-final-newline": {
@@ -4337,6 +6240,16 @@
       "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
       "dev": true
     },
+    "terminal-link": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
+      "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "supports-hyperlinks": "^2.0.0"
+      }
+    },
     "test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -4354,10 +6267,22 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "throat": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+      "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
+      "dev": true
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmpl": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
       "dev": true
     },
     "to-fast-properties": {
@@ -4366,11 +6291,43 @@
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "to-readable-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
       "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
       "dev": true
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -4450,6 +6407,12 @@
         "prelude-ls": "^1.2.1"
       }
     },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
     "type-fest": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
@@ -4477,6 +6440,18 @@
       "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==",
       "dev": true
     },
+    "union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      }
+    },
     "unique-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
@@ -4484,6 +6459,46 @@
       "dev": true,
       "requires": {
         "crypto-random-string": "^2.0.0"
+      }
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        }
       }
     },
     "update-notifier": {
@@ -4567,6 +6582,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
     "url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
@@ -4575,6 +6596,12 @@
       "requires": {
         "prepend-http": "^2.0.0"
       }
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
     },
     "uuid": {
       "version": "3.4.0",
@@ -4587,6 +6614,25 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
       "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
       "dev": true
+    },
+    "v8-to-istanbul": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-7.1.0.tgz",
+      "integrity": "sha512-uXUVqNUCLa0AH1vuVxzi+MI4RfxEOKt9pBgKwHbgH7st8Kv2P1m+jvWNnektzBh5QShF3ODgKmUFCf38LnVz1g==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^1.6.0",
+        "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        }
+      }
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -4625,6 +6671,15 @@
       "dev": true,
       "requires": {
         "xml-name-validator": "^3.0.0"
+      }
+    },
+    "walker": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+      "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+      "dev": true,
+      "requires": {
+        "makeerror": "1.0.x"
       }
     },
     "webidl-conversions": {
@@ -4680,48 +6735,6 @@
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "dev": true
     },
-    "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "requires": {
-        "string-width": "^1.0.2 || 2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
-      }
-    },
     "widest-line": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
@@ -4735,12 +6748,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true
-    },
-    "workerpool": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.2.tgz",
-      "integrity": "sha512-DSNyvOpFKrNusaaUwk+ej6cBj1bmhLcBfj80elGk+ZIo5JSkq+unB1dLKEOcNfJDZgjGICfhQ0Q5TbP0PvF4+Q==",
       "dev": true
     },
     "wrap-ansi": {
@@ -4853,138 +6860,33 @@
       "dev": true
     },
     "yargs": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
       "dev": true,
       "requires": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
         "get-caller-file": "^2.0.1",
         "require-directory": "^2.1.1",
         "require-main-filename": "^2.0.0",
         "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
+        "string-width": "^4.2.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
-        },
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
+        "yargs-parser": "^18.1.2"
       }
     },
     "yargs-parser": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
-    },
-    "yargs-unparser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^6.0.0",
-        "decamelize": "^4.0.0",
-        "flat": "^5.0.2",
-        "is-plain-obj": "^2.1.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
-          "dev": true
-        },
-        "decamelize": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-          "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-          "dev": true
-        }
-      }
-    },
-    "yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,22 +42,20 @@
     "eslint": "^7.10.0",
     "eslint-config-prettier": "^7.0.0",
     "eslint-plugin-jsdoc": "^30.6.2",
-    "expect.js": "~0.3.1",
     "husky": "^4.2.5",
+    "jest": "^26.6.3",
     "jquery": "^3.0.0",
     "jsdoc": "^3.6.6",
     "jsdom": "^16.2.2",
     "lint-staged": "^10.2.2",
-    "mocha": "^8.1.1",
-    "nyc": "^15.0.1",
     "prettier": "^2.1.1",
     "prettier-plugin-jsdoc": "^0.2.9",
     "tsd": "^0.14.0",
     "xyz": "~4.0.0"
   },
   "scripts": {
-    "test": "npm run lint && npm run test:mocha && npm run test:types",
-    "test:mocha": "mocha --recursive --reporter dot --parallel",
+    "test": "npm run lint && npm run test:jest && npm run test:types",
+    "test:jest": "jest",
     "test:types": "tsd",
     "lint": "npm run lint:es && npm run lint:prettier",
     "lint:es": "eslint --ignore-path .prettierignore .",
@@ -80,6 +78,15 @@
     ],
     "*.{json,md,ts,yml}": [
       "prettier --write"
+    ]
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "testMatch": [
+      "<rootDir>/test/**/*.js"
+    ],
+    "testPathIgnorePatterns": [
+      "/__fixtures__/"
     ]
   }
 }

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,5 +1,5 @@
 {
   "env": {
-    "mocha": true
+    "jest": true
   }
 }

--- a/test/__fixtures__/fixtures.js
+++ b/test/__fixtures__/fixtures.js
@@ -1,4 +1,3 @@
-/* jshint indent: false */
 exports.fruits = [
   '<ul id="fruits">',
   '<li class="apple">Apple</li>',

--- a/test/api/attributes.js
+++ b/test/api/attributes.js
@@ -1,12 +1,9 @@
-var expect = require('expect.js');
-
 var cheerio = require('../..');
-var fruits = require('../fixtures').fruits;
-var vegetables = require('../fixtures').vegetables;
-var food = require('../fixtures').food;
-var chocolates = require('../fixtures').chocolates;
-var inputs = require('../fixtures').inputs;
-var toArray = Function.call.bind(Array.prototype.slice);
+var fruits = require('../__fixtures__/fixtures').fruits;
+var vegetables = require('../__fixtures__/fixtures').vegetables;
+var food = require('../__fixtures__/fixtures').food;
+var chocolates = require('../__fixtures__/fixtures').chocolates;
+var inputs = require('../__fixtures__/fixtures').inputs;
 
 describe('$(...)', function () {
   var $;
@@ -18,42 +15,42 @@ describe('$(...)', function () {
   describe('.attr', function () {
     it('() : should get all the attributes', function () {
       var attrs = $('ul').attr();
-      expect(attrs.id).to.equal('fruits');
+      expect(attrs.id).toBe('fruits');
     });
 
     it('(invalid key) : invalid attr should get undefined', function () {
       var attr = $('.apple').attr('lol');
-      expect(attr).to.be(undefined);
+      expect(attr).toBe(undefined);
     });
 
     it('(valid key) : valid attr should get value', function () {
       var cls = $('.apple').attr('class');
-      expect(cls).to.equal('apple');
+      expect(cls).toBe('apple');
     });
 
     it('(valid key) : valid attr should get name when boolean', function () {
       var attr = $('<input name=email autofocus>').attr('autofocus');
-      expect(attr).to.equal('autofocus');
+      expect(attr).toBe('autofocus');
     });
 
     it('(key, value) : should set attr', function () {
       var $pear = $('.pear').attr('id', 'pear');
-      expect($('#pear')).to.have.length(1);
-      expect($pear).to.be.a($);
+      expect($('#pear')).toHaveLength(1);
+      expect($pear).toBeInstanceOf($);
     });
 
     it('(key, value) : should set attr', function () {
       var $el = cheerio('<div></div> <div></div>').attr('class', 'pear');
 
-      expect($el[0].attribs['class']).to.equal('pear');
-      expect($el[1].attribs).to.equal(undefined);
-      expect($el[2].attribs['class']).to.equal('pear');
+      expect($el[0].attribs['class']).toBe('pear');
+      expect($el[1].attribs).toBe(undefined);
+      expect($el[2].attribs['class']).toBe('pear');
     });
 
     it('(key, value) : should return an empty object for an empty object', function () {
       var $src = $().attr('key', 'value');
-      expect($src.length).to.equal(0);
-      expect($src[0]).to.be(undefined);
+      expect($src.length).toBe(0);
+      expect($src[0]).toBe(undefined);
     });
 
     it('(map) : object map should set multiple attributes', function () {
@@ -63,20 +60,20 @@ describe('$(...)', function () {
         'data-url': 'http://apple.com',
       });
       var attrs = $('.apple').attr();
-      expect(attrs.id).to.equal('apple');
-      expect(attrs.style).to.equal('color:red;');
-      expect(attrs['data-url']).to.equal('http://apple.com');
+      expect(attrs.id).toBe('apple');
+      expect(attrs.style).toBe('color:red;');
+      expect(attrs['data-url']).toBe('http://apple.com');
     });
 
     it('(key, function) : should call the function and update the attribute with the return value', function () {
       var $fruits = $('#fruits');
       $fruits.attr('id', function (index, value) {
-        expect(index).to.equal(0);
-        expect(value).to.equal('fruits');
+        expect(index).toBe(0);
+        expect(value).toBe('fruits');
         return 'ninja';
       });
       var attrs = $fruits.attr();
-      expect(attrs.id).to.equal('ninja');
+      expect(attrs.id).toBe('ninja');
     });
 
     it('(key, value) : should correctly encode then decode unsafe values', function () {
@@ -85,7 +82,7 @@ describe('$(...)', function () {
         'href',
         'http://github.com/"><script>alert("XSS!")</script><br'
       );
-      expect($apple.attr('href')).to.equal(
+      expect($apple.attr('href')).toBe(
         'http://github.com/"><script>alert("XSS!")</script><br'
       );
 
@@ -93,37 +90,37 @@ describe('$(...)', function () {
         'href',
         'http://github.com/"><script>alert("XSS!")</script><br'
       );
-      expect($apple.html()).to.not.contain('<script>alert("XSS!")</script>');
+      expect($apple.html()).not.toContain('<script>alert("XSS!")</script>');
     });
 
     it('(key, value) : should coerce values to a string', function () {
       var $apple = $('.apple');
       $apple.attr('data-test', 1);
-      expect($apple[0].attribs['data-test']).to.equal('1');
-      expect($apple.attr('data-test')).to.equal('1');
+      expect($apple[0].attribs['data-test']).toBe('1');
+      expect($apple.attr('data-test')).toBe('1');
     });
 
     it('(key, value) : handle removed boolean attributes', function () {
       var $apple = $('.apple');
       $apple.attr('autofocus', 'autofocus');
-      expect($apple.attr('autofocus')).to.equal('autofocus');
+      expect($apple.attr('autofocus')).toBe('autofocus');
       $apple.removeAttr('autofocus');
-      expect($apple.attr('autofocus')).to.be(undefined);
+      expect($apple.attr('autofocus')).toBe(undefined);
     });
 
     it('(key, value) : should remove non-boolean attributes with names or values similar to boolean ones', function () {
       var $apple = $('.apple');
       $apple.attr('data-autofocus', 'autofocus');
-      expect($apple.attr('data-autofocus')).to.equal('autofocus');
+      expect($apple.attr('data-autofocus')).toBe('autofocus');
       $apple.removeAttr('data-autofocus');
-      expect($apple.attr('data-autofocus')).to.be(undefined);
+      expect($apple.attr('data-autofocus')).toBe(undefined);
     });
 
     it('(key, value) : should remove attributes when called with null value', function () {
       var $pear = $('.pear').attr('autofocus', 'autofocus');
-      expect($pear.attr('autofocus')).to.equal('autofocus');
+      expect($pear.attr('autofocus')).toBe('autofocus');
       $pear.attr('autofocus', null);
-      expect($pear.attr('autofocus')).to.be(undefined);
+      expect($pear.attr('autofocus')).toBe(undefined);
     });
 
     it('(map) : should remove attributes with null values', function () {
@@ -131,28 +128,28 @@ describe('$(...)', function () {
         autofocus: 'autofocus',
         style: 'color:red',
       });
-      expect($pear.attr('autofocus')).to.equal('autofocus');
-      expect($pear.attr('style')).to.equal('color:red');
+      expect($pear.attr('autofocus')).toBe('autofocus');
+      expect($pear.attr('style')).toBe('color:red');
       $pear.attr({ autofocus: null, style: 'color:blue' });
-      expect($pear.attr('autofocus')).to.be(undefined);
-      expect($pear.attr('style')).to.equal('color:blue');
+      expect($pear.attr('autofocus')).toBe(undefined);
+      expect($pear.attr('style')).toBe('color:blue');
     });
 
     it('(chaining) setting value and calling attr returns result', function () {
       var pearAttr = $('.pear').attr('foo', 'bar').attr('foo');
-      expect(pearAttr).to.equal('bar');
+      expect(pearAttr).toBe('bar');
     });
 
     it('(chaining) setting attr to null returns a $', function () {
       var $pear = $('.pear').attr('foo', null);
-      expect($pear).to.be.a($);
+      expect($pear).toBeInstanceOf($);
     });
 
     it('(chaining) setting attr to undefined returns a $', function () {
       var $pear = $('.pear').attr('foo', undefined);
-      expect($('.pear')).to.have.length(1);
-      expect($('.pear').attr('foo')).to.be('undefined');
-      expect($pear).to.be.a($);
+      expect($('.pear')).toHaveLength(1);
+      expect($('.pear').attr('foo')).toBe('undefined');
+      expect($pear).toBeInstanceOf($);
     });
   });
 
@@ -167,37 +164,37 @@ describe('$(...)', function () {
     });
 
     it('(valid key) : valid prop should get value', function () {
-      expect(checkbox.prop('checked')).to.equal(true);
+      expect(checkbox.prop('checked')).toBe(true);
       checkbox.css('display', 'none');
-      expect(checkbox.prop('style').display).to.equal('none');
-      expect(checkbox.prop('style')).to.have.length(1);
-      expect(checkbox.prop('style')).to.contain('display');
-      expect(checkbox.prop('tagName')).to.equal('INPUT');
-      expect(checkbox.prop('nodeName')).to.equal('INPUT');
+      expect(checkbox.prop('style').display).toBe('none');
+      expect(checkbox.prop('style')).toHaveLength(1);
+      expect(checkbox.prop('style')).toContain('display');
+      expect(checkbox.prop('tagName')).toBe('INPUT');
+      expect(checkbox.prop('nodeName')).toBe('INPUT');
     });
 
     it('(invalid key) : invalid prop should get undefined', function () {
       var attr = checkbox.prop('lol');
-      expect(attr).to.be(undefined);
+      expect(attr).toBe(undefined);
     });
 
     it('(key, value) : should set prop', function () {
-      expect(checkbox.prop('checked')).to.equal(true);
+      expect(checkbox.prop('checked')).toBe(true);
       checkbox.prop('checked', false);
-      expect(checkbox.prop('checked')).to.equal(false);
+      expect(checkbox.prop('checked')).toBe(false);
       checkbox.prop('checked', true);
-      expect(checkbox.prop('checked')).to.equal(true);
+      expect(checkbox.prop('checked')).toBe(true);
     });
 
     it('(key, value) : should update attribute', function () {
-      expect(checkbox.prop('checked')).to.equal(true);
-      expect(checkbox.attr('checked')).to.equal('checked');
+      expect(checkbox.prop('checked')).toBe(true);
+      expect(checkbox.attr('checked')).toBe('checked');
       checkbox.prop('checked', false);
-      expect(checkbox.prop('checked')).to.equal(false);
-      expect(checkbox.attr('checked')).to.equal(undefined);
+      expect(checkbox.prop('checked')).toBe(false);
+      expect(checkbox.attr('checked')).toBe(undefined);
       checkbox.prop('checked', true);
-      expect(checkbox.prop('checked')).to.equal(true);
-      expect(checkbox.attr('checked')).to.equal('checked');
+      expect(checkbox.prop('checked')).toBe(true);
+      expect(checkbox.attr('checked')).toBe('checked');
     });
 
     it('(map) : object map should set multiple props', function () {
@@ -205,43 +202,43 @@ describe('$(...)', function () {
         id: 'check',
         checked: false,
       });
-      expect(checkbox.prop('id')).to.equal('check');
-      expect(checkbox.prop('checked')).to.equal(false);
+      expect(checkbox.prop('id')).toBe('check');
+      expect(checkbox.prop('checked')).toBe(false);
     });
 
     it('(key, function) : should call the function and update the prop with the return value', function () {
       checkbox.prop('checked', function (index, value) {
-        expect(index).to.equal(0);
-        expect(value).to.equal(true);
+        expect(index).toBe(0);
+        expect(value).toBe(true);
         return false;
       });
-      expect(checkbox.prop('checked')).to.equal(false);
+      expect(checkbox.prop('checked')).toBe(false);
     });
 
     it('(key, value) : should support chaining after setting props', function () {
-      expect(checkbox.prop('checked', false)).to.equal(checkbox);
+      expect(checkbox.prop('checked', false)).toBe(checkbox);
     });
 
     it('(invalid element/tag) : prop should return undefined', function () {
-      expect($(undefined).prop('prop')).to.be(undefined);
-      expect($(null).prop('prop')).to.be(undefined);
+      expect($(undefined).prop('prop')).toBe(undefined);
+      expect($(null).prop('prop')).toBe(undefined);
     });
 
     it('("outerHTML") : should render properly', function () {
       var outerHtml = '<div><a></a></div>';
       var $a = $(outerHtml);
 
-      expect($a.prop('outerHTML')).to.be(outerHtml);
+      expect($a.prop('outerHTML')).toBe(outerHtml);
     });
 
     it('("innerHTML") : should render properly', function () {
       var $a = $('<div><a></a></div>');
 
-      expect($a.prop('innerHTML')).to.be('<a></a>');
+      expect($a.prop('innerHTML')).toBe('<a></a>');
     });
 
     it('(inherited properties) : prop should support inherited properties', function () {
-      expect(selectMenu.prop('childNodes')).to.equal(selectMenu[0].childNodes);
+      expect(selectMenu.prop('childNodes')).toBe(selectMenu[0].childNodes);
     });
   });
 
@@ -252,7 +249,7 @@ describe('$(...)', function () {
 
     it('() : should get all data attributes initially declared in the markup', function () {
       var data = $('.linth').data();
-      expect(data).to.eql({
+      expect(data).toStrictEqual({
         highlight: 'Lindor',
         origin: 'swiss',
       });
@@ -263,7 +260,7 @@ describe('$(...)', function () {
       $el.data('a', 1);
       $el.data('b', 2);
 
-      expect($el.data()).to.eql({
+      expect($el.data()).toStrictEqual({
         a: 1,
         b: 2,
       });
@@ -274,7 +271,7 @@ describe('$(...)', function () {
       $el.data('b', 'b-modified');
       $el.data('c', 'c');
 
-      expect($el.data()).to.eql({
+      expect($el.data()).toStrictEqual({
         a: 'a',
         b: 'b-modified',
         c: 'c',
@@ -283,20 +280,20 @@ describe('$(...)', function () {
 
     it('() : no data attribute should return an empty object', function () {
       var data = $('.cailler').data();
-      expect(data).to.be.empty();
+      expect(Object.keys(data)).toHaveLength(0);
     });
 
     it('(invalid key) : invalid data attribute should return `undefined` ', function () {
       var data = $('.frey').data('lol');
-      expect(data).to.be(undefined);
+      expect(data).toBe(undefined);
     });
 
     it('(valid key) : valid data attribute should get value', function () {
       var highlight = $('.linth').data('highlight');
       var origin = $('.linth').data('origin');
 
-      expect(highlight).to.equal('Lindor');
-      expect(origin).to.equal('swiss');
+      expect(highlight).toBe('Lindor');
+      expect(origin).toBe('swiss');
     });
 
     it('(key) : should translate camel-cased key values to hyphen-separated versions', function () {
@@ -304,8 +301,8 @@ describe('$(...)', function () {
         '<div data--three-word-attribute="a" data-foo-Bar_BAZ-="b">'
       );
 
-      expect($el.data('ThreeWordAttribute')).to.be('a');
-      expect($el.data('fooBar_baz-')).to.be('b');
+      expect($el.data('ThreeWordAttribute')).toBe('a');
+      expect($el.data('fooBar_baz-')).toBe('b');
     });
 
     it('(key) : should retrieve object values', function () {
@@ -314,42 +311,42 @@ describe('$(...)', function () {
 
       $el.data('test', data);
 
-      expect($el.data('test')).to.be(data);
+      expect($el.data('test')).toBe(data);
     });
 
     it('(key) : should parse JSON data derived from the markup', function () {
       var $el = cheerio('<div data-json="[1, 2, 3]">');
 
-      expect($el.data('json')).to.eql([1, 2, 3]);
+      expect($el.data('json')).toStrictEqual([1, 2, 3]);
     });
 
     it('(key) : should not parse JSON data set via the `data` API', function () {
       var $el = cheerio('<div>');
       $el.data('json', '[1, 2, 3]');
 
-      expect($el.data('json')).to.be('[1, 2, 3]');
+      expect($el.data('json')).toBe('[1, 2, 3]');
     });
 
     // See http://api.jquery.com/data/ and http://bugs.jquery.com/ticket/14523
     it('(key) : should ignore the markup value after the first access', function () {
       var $el = cheerio('<div data-test="a">');
 
-      expect($el.data('test')).to.be('a');
+      expect($el.data('test')).toBe('a');
 
       $el.attr('data-test', 'b');
 
-      expect($el.data('test')).to.be('a');
+      expect($el.data('test')).toBe('a');
     });
 
     it('(key) : should recover from malformed JSON', function () {
       var $el = cheerio('<div data-custom="{{templatevar}}">');
 
-      expect($el.data('custom')).to.be('{{templatevar}}');
+      expect($el.data('custom')).toBe('{{templatevar}}');
     });
 
     it('(hyphen key) : data addribute with hyphen should be camelized ;-)', function () {
       var data = $('.frey').data();
-      expect(data).to.eql({
+      expect(data).toStrictEqual({
         taste: 'sweet',
         bestCollection: 'Mahony',
       });
@@ -363,16 +360,16 @@ describe('$(...)', function () {
       // Adding as string.
       var b = $('.linth').data('snack', 'chocoletti');
 
-      expect(a.data('balls')).to.eql('giandor');
-      expect(b.data('snack')).to.eql('chocoletti');
+      expect(a.data('balls')).toStrictEqual('giandor');
+      expect(b.data('snack')).toStrictEqual('chocoletti');
     });
 
     it('(key, value) : should set data for all elements in the selection', function () {
       $('li').data('foo', 'bar');
 
-      expect($('li').eq(0).data('foo')).to.eql('bar');
-      expect($('li').eq(1).data('foo')).to.eql('bar');
-      expect($('li').eq(2).data('foo')).to.eql('bar');
+      expect($('li').eq(0).data('foo')).toStrictEqual('bar');
+      expect($('li').eq(1).data('foo')).toStrictEqual('bar');
+      expect($('li').eq(2).data('foo')).toStrictEqual('bar');
     });
 
     it('(map) : object map should set multiple data attributes', function () {
@@ -383,41 +380,41 @@ describe('$(...)', function () {
         url: 'http://www.cailler.ch/',
       })['0'].data;
 
-      expect(data.id).to.equal('Cailler');
-      expect(data.flop).to.equal('Pippilotti Rist');
-      expect(data.top).to.equal('Frigor');
-      expect(data.url).to.equal('http://www.cailler.ch/');
+      expect(data.id).toBe('Cailler');
+      expect(data.flop).toBe('Pippilotti Rist');
+      expect(data.top).toBe('Frigor');
+      expect(data.url).toBe('http://www.cailler.ch/');
     });
 
     describe('(attr) : data-* attribute type coercion :', function () {
       it('boolean', function () {
         var $el = cheerio('<div data-bool="true">');
-        expect($el.data('bool')).to.be(true);
+        expect($el.data('bool')).toBe(true);
       });
 
       it('number', function () {
         var $el = cheerio('<div data-number="23">');
-        expect($el.data('number')).to.be(23);
+        expect($el.data('number')).toBe(23);
       });
 
       it('number (scientific notation is not coerced)', function () {
         var $el = cheerio('<div data-sci="1E10">');
-        expect($el.data('sci')).to.be('1E10');
+        expect($el.data('sci')).toBe('1E10');
       });
 
       it('null', function () {
         var $el = cheerio('<div data-null="null">');
-        expect($el.data('null')).to.be(null);
+        expect($el.data('null')).toBe(null);
       });
 
       it('object', function () {
         var $el = cheerio('<div data-obj=\'{ "a": 45 }\'>');
-        expect($el.data('obj')).to.eql({ a: 45 });
+        expect($el.data('obj')).toStrictEqual({ a: 45 });
       });
 
       it('array', function () {
         var $el = cheerio('<div data-array="[1, 2, 3]">');
-        expect($el.data('array')).to.eql([1, 2, 3]);
+        expect($el.data('array')).toStrictEqual([1, 2, 3]);
       });
     });
   });
@@ -429,96 +426,96 @@ describe('$(...)', function () {
 
     it('(): on select should get value', function () {
       var val = $('select#one').val();
-      expect(val).to.equal('option_selected');
+      expect(val).toBe('option_selected');
     });
     it('(): on select with no value should get text', function () {
       var val = $('select#one-valueless').val();
-      expect(val).to.equal('Option selected');
+      expect(val).toBe('Option selected');
     });
     it('(): on select with no value should get converted HTML', function () {
       var val = $('select#one-html-entity').val();
-      expect(val).to.equal('Option <selected>');
+      expect(val).toBe('Option <selected>');
     });
     it('(): on select with no value should get text content', function () {
       var val = $('select#one-nested').val();
-      expect(val).to.equal('Option selected');
+      expect(val).toBe('Option selected');
     });
     it('(): on option should get value', function () {
       var val = $('select#one option').eq(0).val();
-      expect(val).to.equal('option_not_selected');
+      expect(val).toBe('option_not_selected');
     });
     it('(): on text input should get value', function () {
       var val = $('input[type="text"]').val();
-      expect(val).to.equal('input_text');
+      expect(val).toBe('input_text');
     });
     it('(): on checked checkbox should get value', function () {
       var val = $('input[name="checkbox_on"]').val();
-      expect(val).to.equal('on');
+      expect(val).toBe('on');
     });
     it('(): on unchecked checkbox should get value', function () {
       var val = $('input[name="checkbox_off"]').val();
-      expect(val).to.equal('off');
+      expect(val).toBe('off');
     });
     it('(): on valueless checkbox should get value', function () {
       var val = $('input[name="checkbox_valueless"]').val();
-      expect(val).to.equal('on');
+      expect(val).toBe('on');
     });
     it('(): on radio should get value', function () {
       var val = $('input[type="radio"]').val();
-      expect(val).to.equal('off');
+      expect(val).toBe('off');
     });
     it('(): on valueless radio should get value', function () {
       var val = $('input[name="radio_valueless"]').val();
-      expect(val).to.equal('on');
+      expect(val).toBe('on');
     });
     it('(): on multiple select should get an array of values', function () {
       var val = $('select#multi').val();
-      expect(val).to.eql(['2', '3']);
+      expect(val).toStrictEqual(['2', '3']);
     });
     it('(): on multiple select with no value attribute should get an array of text content', function () {
       var val = $('select#multi-valueless').val();
-      expect(val).to.eql(['2', '3']);
+      expect(val).toStrictEqual(['2', '3']);
     });
     it('(): with no selector matches should return nothing', function () {
       var val = $('.nasty').val();
-      expect(val).to.equal(undefined);
+      expect(val).toBe(undefined);
     });
     it('(invalid value): should only handle arrays when it has the attribute multiple', function () {
       var val = $('select#one').val([]);
-      expect(val).not.to.equal(undefined);
+      expect(val).not.toBe(undefined);
     });
     it('(value): on input text should set value', function () {
       var element = $('input[type="text"]').val('test');
-      expect(element.val()).to.equal('test');
+      expect(element.val()).toBe('test');
     });
     it('(value): on select should set value', function () {
       var element = $('select#one').val('option_not_selected');
-      expect(element.val()).to.equal('option_not_selected');
+      expect(element.val()).toBe('option_not_selected');
     });
     it('(value): on option should set value', function () {
       var element = $('select#one option').eq(0).val('option_changed');
-      expect(element.val()).to.equal('option_changed');
+      expect(element.val()).toBe('option_changed');
     });
     it('(value): on radio should set value', function () {
       var element = $('input[name="radio"]').val('off');
-      expect(element.val()).to.equal('off');
+      expect(element.val()).toBe('off');
     });
     it('(value): on radio with special characters should set value', function () {
       var element = $('input[name="radio[brackets]"]').val('off');
-      expect(element.val()).to.equal('off');
+      expect(element.val()).toBe('off');
     });
     it('(values): on multiple select should set multiple values', function () {
       var element = $('select#multi').val(['1', '3', '4']);
-      expect(element.val()).to.have.length(3);
+      expect(element.val()).toHaveLength(3);
     });
   });
 
   describe('.removeAttr', function () {
     it('(key) : should remove a single attr', function () {
       var $fruits = $('#fruits');
-      expect($fruits.attr('id')).to.not.be(undefined);
+      expect($fruits.attr('id')).not.toBe(undefined);
       $fruits.removeAttr('id');
-      expect($fruits.attr('id')).to.be(undefined);
+      expect($fruits.attr('id')).toBe(undefined);
     });
 
     it('(key key): should remove multiple attrs', function () {
@@ -526,18 +523,18 @@ describe('$(...)', function () {
       $apple.attr('id', 'favorite');
       $apple.attr('size', 'small');
 
-      expect($apple.attr('id')).to.equal('favorite');
-      expect($apple.attr('class')).to.equal('apple');
-      expect($apple.attr('size')).to.equal('small');
+      expect($apple.attr('id')).toBe('favorite');
+      expect($apple.attr('class')).toBe('apple');
+      expect($apple.attr('size')).toBe('small');
       $apple.removeAttr('id class');
-      expect($apple.attr('id')).to.be(undefined);
-      expect($apple.attr('class')).to.be(undefined);
-      expect($apple.attr('size')).to.equal('small');
+      expect($apple.attr('id')).toBe(undefined);
+      expect($apple.attr('class')).toBe(undefined);
+      expect($apple.attr('size')).toBe('small');
     });
 
     it('should return cheerio object', function () {
       var obj = $('ul').removeAttr('id');
-      expect(obj).to.be.a($);
+      expect(obj).toBeInstanceOf($);
     });
   });
 
@@ -548,38 +545,37 @@ describe('$(...)', function () {
 
     it('(valid class) : should return true', function () {
       var cls = $('.apple').hasClass('apple');
-      expect(cls).to.be.ok();
+      expect(cls).toBeTruthy();
 
-      expect(test('foo').hasClass('foo')).to.be.ok();
-      expect(test('foo bar').hasClass('foo')).to.be.ok();
-      expect(test('bar foo').hasClass('foo')).to.be.ok();
-      expect(test('bar foo bar').hasClass('foo')).to.be.ok();
+      expect(test('foo').hasClass('foo')).toBeTruthy();
+      expect(test('foo bar').hasClass('foo')).toBeTruthy();
+      expect(test('bar foo').hasClass('foo')).toBeTruthy();
+      expect(test('bar foo bar').hasClass('foo')).toBeTruthy();
     });
 
     it('(invalid class) : should return false', function () {
       var cls = $('#fruits').hasClass('fruits');
-      expect(cls).to.not.be.ok();
-      expect(test('foo-bar').hasClass('foo')).to.not.be.ok();
-      expect(test('foo-bar').hasClass('foo')).to.not.be.ok();
-      expect(test('foo-bar').hasClass('foo-ba')).to.not.be.ok();
+      expect(cls).toBeFalsy();
+      expect(test('foo-bar').hasClass('foo')).toBeFalsy();
+      expect(test('foo-bar').hasClass('foo')).toBeFalsy();
+      expect(test('foo-bar').hasClass('foo-ba')).toBeFalsy();
     });
 
     it('should check multiple classes', function () {
       // Add a class
       $('.apple').addClass('red');
-      expect($('.apple').hasClass('apple')).to.be.ok();
-      expect($('.apple').hasClass('red')).to.be.ok();
+      expect($('.apple').hasClass('apple')).toBeTruthy();
+      expect($('.apple').hasClass('red')).toBeTruthy();
 
       // Remove one and test again
       $('.apple').removeClass('apple');
-      expect($('li').eq(0).hasClass('apple')).to.not.be.ok();
-      // expect($('li', $fruits).eq(0).hasClass('red')).to.be.ok();
+      expect($('li').eq(0).hasClass('apple')).toBeFalsy();
     });
 
     it('(empty string argument) : should return false', function () {
-      expect(test('foo').hasClass('')).to.not.be.ok();
-      expect(test('foo bar').hasClass('')).to.not.be.ok();
-      expect(test('foo bar').removeClass('foo').hasClass('')).to.not.be.ok();
+      expect(test('foo').hasClass('')).toBeFalsy();
+      expect(test('foo bar').hasClass('')).toBeFalsy();
+      expect(test('foo bar').removeClass('foo').hasClass('')).toBeFalsy();
     });
   });
 
@@ -588,28 +584,28 @@ describe('$(...)', function () {
       var $fruits = $('#fruits');
       $fruits.addClass('fruits');
       var cls = $fruits.hasClass('fruits');
-      expect(cls).to.be.ok();
+      expect(cls).toBeTruthy();
     });
 
     it('(single class) : should add the class to the element', function () {
       $('.apple').addClass('fruit');
       var cls = $('.apple').hasClass('fruit');
-      expect(cls).to.be.ok();
+      expect(cls).toBeTruthy();
     });
 
     it('(class): adds classes to many selected items', function () {
       $('li').addClass('fruit');
-      expect($('.apple').hasClass('fruit')).to.be.ok();
-      expect($('.orange').hasClass('fruit')).to.be.ok();
-      expect($('.pear').hasClass('fruit')).to.be.ok();
+      expect($('.apple').hasClass('fruit')).toBeTruthy();
+      expect($('.orange').hasClass('fruit')).toBeTruthy();
+      expect($('.pear').hasClass('fruit')).toBeTruthy();
     });
 
     it('(class class class) : should add multiple classes to the element', function () {
       $('.apple').addClass('fruit red tasty');
-      expect($('.apple').hasClass('apple')).to.be.ok();
-      expect($('.apple').hasClass('fruit')).to.be.ok();
-      expect($('.apple').hasClass('red')).to.be.ok();
-      expect($('.apple').hasClass('tasty')).to.be.ok();
+      expect($('.apple').hasClass('apple')).toBeTruthy();
+      expect($('.apple').hasClass('fruit')).toBeTruthy();
+      expect($('.apple').hasClass('red')).toBeTruthy();
+      expect($('.apple').hasClass('tasty')).toBeTruthy();
     });
 
     it('(fn) : should add classes returned from the function', function () {
@@ -619,21 +615,21 @@ describe('$(...)', function () {
       var toAdd = ['apple red', '', undefined];
 
       $fruits.addClass(function (idx) {
-        args.push(toArray(arguments));
+        args.push(Array.from(arguments));
         thisVals.push(this);
         return toAdd[idx];
       });
 
-      expect(args).to.eql([
+      expect(args).toStrictEqual([
         [0, 'apple'],
         [1, 'orange'],
         [2, 'pear'],
       ]);
-      expect(thisVals).to.eql([$fruits[0], $fruits[1], $fruits[2]]);
-      expect($fruits.eq(0).hasClass('apple')).to.be.ok();
-      expect($fruits.eq(0).hasClass('red')).to.be.ok();
-      expect($fruits.eq(1).hasClass('orange')).to.be.ok();
-      expect($fruits.eq(2).hasClass('pear')).to.be.ok();
+      expect(thisVals).toStrictEqual([$fruits[0], $fruits[1], $fruits[2]]);
+      expect($fruits.eq(0).hasClass('apple')).toBeTruthy();
+      expect($fruits.eq(0).hasClass('red')).toBeTruthy();
+      expect($fruits.eq(1).hasClass('orange')).toBeTruthy();
+      expect($fruits.eq(2).hasClass('pear')).toBeTruthy();
     });
   });
 
@@ -641,18 +637,18 @@ describe('$(...)', function () {
     it('() : should remove all the classes', function () {
       $('.pear').addClass('fruit');
       $('.pear').removeClass();
-      expect($('.pear').attr('class')).to.be(undefined);
+      expect($('.pear').attr('class')).toBe(undefined);
     });
 
     it('("") : should not modify class list', function () {
       var $fruits = $('#fruits');
       $fruits.children().removeClass('');
-      expect($('.apple')).to.have.length(1);
+      expect($('.apple')).toHaveLength(1);
     });
 
     it('(invalid class) : should not remove anything', function () {
       $('.pear').removeClass('fruit');
-      expect($('.pear').hasClass('pear')).to.be.ok();
+      expect($('.pear').hasClass('pear')).toBeTruthy();
     });
 
     it('(no class attribute) : should not throw an exception', function () {
@@ -660,46 +656,46 @@ describe('$(...)', function () {
 
       expect(function () {
         $('li', $vegetables).removeClass('vegetable');
-      }).to.not.throwException();
+      }).not.toThrow();
     });
 
     it('(single class) : should remove a single class from the element', function () {
       $('.pear').addClass('fruit');
-      expect($('.pear').hasClass('fruit')).to.be.ok();
+      expect($('.pear').hasClass('fruit')).toBeTruthy();
       $('.pear').removeClass('fruit');
-      expect($('.pear').hasClass('fruit')).to.not.be.ok();
-      expect($('.pear').hasClass('pear')).to.be.ok();
+      expect($('.pear').hasClass('fruit')).toBeFalsy();
+      expect($('.pear').hasClass('pear')).toBeTruthy();
     });
 
     it('(single class) : should remove a single class from multiple classes on the element', function () {
       $('.pear').addClass('fruit green tasty');
-      expect($('.pear').hasClass('fruit')).to.be.ok();
-      expect($('.pear').hasClass('green')).to.be.ok();
-      expect($('.pear').hasClass('tasty')).to.be.ok();
+      expect($('.pear').hasClass('fruit')).toBeTruthy();
+      expect($('.pear').hasClass('green')).toBeTruthy();
+      expect($('.pear').hasClass('tasty')).toBeTruthy();
 
       $('.pear').removeClass('green');
-      expect($('.pear').hasClass('fruit')).to.be.ok();
-      expect($('.pear').hasClass('green')).to.not.be.ok();
-      expect($('.pear').hasClass('tasty')).to.be.ok();
+      expect($('.pear').hasClass('fruit')).toBeTruthy();
+      expect($('.pear').hasClass('green')).toBeFalsy();
+      expect($('.pear').hasClass('tasty')).toBeTruthy();
     });
 
     it('(class class class) : should remove multiple classes from the element', function () {
       $('.apple').addClass('fruit red tasty');
-      expect($('.apple').hasClass('apple')).to.be.ok();
-      expect($('.apple').hasClass('fruit')).to.be.ok();
-      expect($('.apple').hasClass('red')).to.be.ok();
-      expect($('.apple').hasClass('tasty')).to.be.ok();
+      expect($('.apple').hasClass('apple')).toBeTruthy();
+      expect($('.apple').hasClass('fruit')).toBeTruthy();
+      expect($('.apple').hasClass('red')).toBeTruthy();
+      expect($('.apple').hasClass('tasty')).toBeTruthy();
 
       $('.apple').removeClass('apple red tasty');
-      expect($('.fruit').hasClass('apple')).to.not.be.ok();
-      expect($('.fruit').hasClass('red')).to.not.be.ok();
-      expect($('.fruit').hasClass('tasty')).to.not.be.ok();
-      expect($('.fruit').hasClass('fruit')).to.be.ok();
+      expect($('.fruit').hasClass('apple')).toBeFalsy();
+      expect($('.fruit').hasClass('red')).toBeFalsy();
+      expect($('.fruit').hasClass('tasty')).toBeFalsy();
+      expect($('.fruit').hasClass('fruit')).toBeTruthy();
     });
 
     it('(class) : should remove all occurrences of a class name', function () {
       var $div = cheerio('<div class="x x y x z"></div>');
-      expect($div.removeClass('x').hasClass('x')).to.be(false);
+      expect($div.removeClass('x').hasClass('x')).toBe(false);
     });
 
     it('(fn) : should remove classes returned from the function', function () {
@@ -709,21 +705,21 @@ describe('$(...)', function () {
       var toAdd = ['apple red', '', undefined];
 
       $fruits.removeClass(function (idx) {
-        args.push(toArray(arguments));
+        args.push(Array.from(arguments));
         thisVals.push(this);
         return toAdd[idx];
       });
 
-      expect(args).to.eql([
+      expect(args).toStrictEqual([
         [0, 'apple'],
         [1, 'orange'],
         [2, 'pear'],
       ]);
-      expect(thisVals).to.eql([$fruits[0], $fruits[1], $fruits[2]]);
-      expect($fruits.eq(0).hasClass('apple')).to.not.be.ok();
-      expect($fruits.eq(0).hasClass('red')).to.not.be.ok();
-      expect($fruits.eq(1).hasClass('orange')).to.be.ok();
-      expect($fruits.eq(2).hasClass('pear')).to.be.ok();
+      expect(thisVals).toStrictEqual([$fruits[0], $fruits[1], $fruits[2]]);
+      expect($fruits.eq(0).hasClass('apple')).toBeFalsy();
+      expect($fruits.eq(0).hasClass('red')).toBeFalsy();
+      expect($fruits.eq(1).hasClass('orange')).toBeTruthy();
+      expect($fruits.eq(2).hasClass('pear')).toBeTruthy();
     });
 
     it('(fn) : should no op elements without attributes', function () {
@@ -731,51 +727,51 @@ describe('$(...)', function () {
       var val = $inputs.removeClass(function () {
         return 'tasty';
       });
-      expect(val).to.have.length(15);
+      expect(val).toHaveLength(15);
     });
   });
 
   describe('.toggleClass', function () {
     it('(class class) : should toggle multiple classes from the element', function () {
       $('.apple').addClass('fruit');
-      expect($('.apple').hasClass('apple')).to.be.ok();
-      expect($('.apple').hasClass('fruit')).to.be.ok();
-      expect($('.apple').hasClass('red')).to.not.be.ok();
+      expect($('.apple').hasClass('apple')).toBeTruthy();
+      expect($('.apple').hasClass('fruit')).toBeTruthy();
+      expect($('.apple').hasClass('red')).toBeFalsy();
 
       $('.apple').toggleClass('apple red');
-      expect($('.fruit').hasClass('apple')).to.not.be.ok();
-      expect($('.fruit').hasClass('red')).to.be.ok();
-      expect($('.fruit').hasClass('fruit')).to.be.ok();
+      expect($('.fruit').hasClass('apple')).toBeFalsy();
+      expect($('.fruit').hasClass('red')).toBeTruthy();
+      expect($('.fruit').hasClass('fruit')).toBeTruthy();
     });
 
     it('(class class, true) : should add multiple classes to the element', function () {
       $('.apple').addClass('fruit');
-      expect($('.apple').hasClass('apple')).to.be.ok();
-      expect($('.apple').hasClass('fruit')).to.be.ok();
-      expect($('.apple').hasClass('red')).to.not.be.ok();
+      expect($('.apple').hasClass('apple')).toBeTruthy();
+      expect($('.apple').hasClass('fruit')).toBeTruthy();
+      expect($('.apple').hasClass('red')).toBeFalsy();
 
       $('.apple').toggleClass('apple red', true);
-      expect($('.fruit').hasClass('apple')).to.be.ok();
-      expect($('.fruit').hasClass('red')).to.be.ok();
-      expect($('.fruit').hasClass('fruit')).to.be.ok();
+      expect($('.fruit').hasClass('apple')).toBeTruthy();
+      expect($('.fruit').hasClass('red')).toBeTruthy();
+      expect($('.fruit').hasClass('fruit')).toBeTruthy();
     });
 
     it('(class true) : should add only one instance of class', function () {
       $('.apple').toggleClass('tasty', true);
       $('.apple').toggleClass('tasty', true);
-      expect($('.apple').attr('class').match(/tasty/g).length).to.equal(1);
+      expect($('.apple').attr('class').match(/tasty/g).length).toBe(1);
     });
 
     it('(class class, false) : should remove multiple classes from the element', function () {
       $('.apple').addClass('fruit');
-      expect($('.apple').hasClass('apple')).to.be.ok();
-      expect($('.apple').hasClass('fruit')).to.be.ok();
-      expect($('.apple').hasClass('red')).to.not.be.ok();
+      expect($('.apple').hasClass('apple')).toBeTruthy();
+      expect($('.apple').hasClass('fruit')).toBeTruthy();
+      expect($('.apple').hasClass('red')).toBeFalsy();
 
       $('.apple').toggleClass('apple red', false);
-      expect($('.fruit').hasClass('apple')).to.not.be.ok();
-      expect($('.fruit').hasClass('red')).to.not.be.ok();
-      expect($('.fruit').hasClass('fruit')).to.be.ok();
+      expect($('.fruit').hasClass('apple')).toBeFalsy();
+      expect($('.fruit').hasClass('red')).toBeFalsy();
+      expect($('.fruit').hasClass('fruit')).toBeTruthy();
     });
 
     it('(fn) : should toggle classes returned from the function', function () {
@@ -783,26 +779,26 @@ describe('$(...)', function () {
 
       $('.apple').addClass('fruit');
       $('.carrot').addClass('vegetable');
-      expect($('.apple').hasClass('fruit')).to.be.ok();
-      expect($('.apple').hasClass('vegetable')).to.not.be.ok();
-      expect($('.orange').hasClass('fruit')).to.not.be.ok();
-      expect($('.orange').hasClass('vegetable')).to.not.be.ok();
-      expect($('.carrot').hasClass('fruit')).to.not.be.ok();
-      expect($('.carrot').hasClass('vegetable')).to.be.ok();
-      expect($('.sweetcorn').hasClass('fruit')).to.not.be.ok();
-      expect($('.sweetcorn').hasClass('vegetable')).to.not.be.ok();
+      expect($('.apple').hasClass('fruit')).toBeTruthy();
+      expect($('.apple').hasClass('vegetable')).toBeFalsy();
+      expect($('.orange').hasClass('fruit')).toBeFalsy();
+      expect($('.orange').hasClass('vegetable')).toBeFalsy();
+      expect($('.carrot').hasClass('fruit')).toBeFalsy();
+      expect($('.carrot').hasClass('vegetable')).toBeTruthy();
+      expect($('.sweetcorn').hasClass('fruit')).toBeFalsy();
+      expect($('.sweetcorn').hasClass('vegetable')).toBeFalsy();
 
       $('li').toggleClass(function () {
         return $(this).parent().is('#fruits') ? 'fruit' : 'vegetable';
       });
-      expect($('.apple').hasClass('fruit')).to.not.be.ok();
-      expect($('.apple').hasClass('vegetable')).to.not.be.ok();
-      expect($('.orange').hasClass('fruit')).to.be.ok();
-      expect($('.orange').hasClass('vegetable')).to.not.be.ok();
-      expect($('.carrot').hasClass('fruit')).to.not.be.ok();
-      expect($('.carrot').hasClass('vegetable')).to.not.be.ok();
-      expect($('.sweetcorn').hasClass('fruit')).to.not.be.ok();
-      expect($('.sweetcorn').hasClass('vegetable')).to.be.ok();
+      expect($('.apple').hasClass('fruit')).toBeFalsy();
+      expect($('.apple').hasClass('vegetable')).toBeFalsy();
+      expect($('.orange').hasClass('fruit')).toBeTruthy();
+      expect($('.orange').hasClass('vegetable')).toBeFalsy();
+      expect($('.carrot').hasClass('fruit')).toBeFalsy();
+      expect($('.carrot').hasClass('vegetable')).toBeFalsy();
+      expect($('.sweetcorn').hasClass('fruit')).toBeFalsy();
+      expect($('.sweetcorn').hasClass('vegetable')).toBeTruthy();
     });
 
     it('(fn) : should work with no initial class attribute', function () {
@@ -812,63 +808,69 @@ describe('$(...)', function () {
           ? 'selectable'
           : 'inputable';
       });
-      expect($inputs('.selectable')).to.have.length(6);
-      expect($inputs('.inputable')).to.have.length(9);
+      expect($inputs('.selectable')).toHaveLength(6);
+      expect($inputs('.inputable')).toHaveLength(9);
     });
 
     it('(invalid) : should be a no-op for invalid inputs', function () {
       var original = $('.apple');
       var testAgainst = original.attr('class');
-      expect(original.toggleClass().attr('class')).to.be.eql(testAgainst);
-      expect(original.toggleClass(true).attr('class')).to.be.eql(testAgainst);
-      expect(original.toggleClass(false).attr('class')).to.be.eql(testAgainst);
-      expect(original.toggleClass(null).attr('class')).to.be.eql(testAgainst);
-      expect(original.toggleClass(0).attr('class')).to.be.eql(testAgainst);
-      expect(original.toggleClass(1).attr('class')).to.be.eql(testAgainst);
-      expect(original.toggleClass({}).attr('class')).to.be.eql(testAgainst);
+      expect(original.toggleClass().attr('class')).toStrictEqual(testAgainst);
+      expect(original.toggleClass(true).attr('class')).toStrictEqual(
+        testAgainst
+      );
+      expect(original.toggleClass(false).attr('class')).toStrictEqual(
+        testAgainst
+      );
+      expect(original.toggleClass(null).attr('class')).toStrictEqual(
+        testAgainst
+      );
+      expect(original.toggleClass(0).attr('class')).toStrictEqual(testAgainst);
+      expect(original.toggleClass(1).attr('class')).toStrictEqual(testAgainst);
+      expect(original.toggleClass({}).attr('class')).toStrictEqual(testAgainst);
     });
   });
 
   describe('.is', function () {
     it('() : should return false', function () {
-      expect($('li.apple').is()).to.be(false);
+      expect($('li.apple').is()).toBe(false);
     });
 
     it('(true selector) : should return true', function () {
-      expect(cheerio('#vegetables', vegetables).is('ul')).to.be(true);
+      expect(cheerio('#vegetables', vegetables).is('ul')).toBe(true);
     });
 
     it('(false selector) : should return false', function () {
-      expect(cheerio('#vegetables', vegetables).is('div')).to.be(false);
+      expect(cheerio('#vegetables', vegetables).is('div')).toBe(false);
     });
 
     it('(true selection) : should return true', function () {
       var $vegetables = cheerio('li', vegetables);
-      expect($vegetables.is($vegetables.eq(1))).to.be(true);
+      expect($vegetables.is($vegetables.eq(1))).toBe(true);
     });
 
     it('(false selection) : should return false', function () {
       var $vegetableList = cheerio(vegetables);
       var $vegetables = $vegetableList.find('li');
-      expect($vegetables.is($vegetableList)).to.be(false);
+      expect($vegetables.is($vegetableList)).toBe(false);
     });
 
     it('(true element) : should return true', function () {
       var $vegetables = cheerio('li', vegetables);
-      expect($vegetables.is($vegetables[0])).to.be(true);
+      expect($vegetables.is($vegetables[0])).toBe(true);
     });
 
     it('(false element) : should return false', function () {
       var $vegetableList = cheerio(vegetables);
       var $vegetables = $vegetableList.find('li');
-      expect($vegetables.is($vegetableList[0])).to.be(false);
+      expect($vegetables.is($vegetableList[0])).toBe(false);
     });
 
     it('(true predicate) : should return true', function () {
       var result = $('li').is(function () {
         return this.tagName === 'li' && $(this).hasClass('pear');
       });
-      expect(result).to.be(true);
+      expect(result).toBe(true);
     });
 
     it('(false predicate) : should return false', function () {
@@ -877,7 +879,7 @@ describe('$(...)', function () {
         .is(function () {
           return this.tagName === 'ul';
         });
-      expect(result).to.be(false);
+      expect(result).toBe(false);
     });
   });
 });

--- a/test/api/css.js
+++ b/test/api/css.js
@@ -1,16 +1,15 @@
-var expect = require('expect.js');
 var cheerio = require('../..');
 
 describe('$(...)', function () {
   describe('.css', function () {
     it('(prop): should return a css property value', function () {
       var el = cheerio('<li style="hai: there">');
-      expect(el.css('hai')).to.equal('there');
+      expect(el.css('hai')).toBe('there');
     });
 
     it('([prop1, prop2]): should return the specified property values as an object', function () {
       var el = cheerio('<li style="margin: 1px; padding: 2px; color: blue;">');
-      expect(el.css(['margin', 'color'])).to.eql({
+      expect(el.css(['margin', 'color'])).toStrictEqual({
         margin: '1px',
         color: 'blue',
       });
@@ -19,86 +18,86 @@ describe('$(...)', function () {
     it('(prop, val): should set a css property', function () {
       var el = cheerio('<li style="margin: 0;"></li><li></li>');
       el.css('color', 'red');
-      expect(el.attr('style')).to.equal('margin: 0; color: red;');
-      expect(el.eq(1).attr('style')).to.equal('color: red;');
+      expect(el.attr('style')).toBe('margin: 0; color: red;');
+      expect(el.eq(1).attr('style')).toBe('color: red;');
     });
 
     it('(prop, ""): should unset a css property', function () {
       var el = cheerio('<li style="padding: 1px; margin: 0;">');
       el.css('padding', '');
-      expect(el.attr('style')).to.equal('margin: 0;');
+      expect(el.attr('style')).toBe('margin: 0;');
     });
 
     it('(prop): should not mangle embedded urls', function () {
       var el = cheerio(
         '<li style="background-image:url(http://example.com/img.png);">'
       );
-      expect(el.css('background-image')).to.equal(
+      expect(el.css('background-image')).toBe(
         'url(http://example.com/img.png)'
       );
     });
 
     it('(prop): should ignore blank properties', function () {
       var el = cheerio('<li style=":#ccc;color:#aaa;">');
-      expect(el.css()).to.eql({ color: '#aaa' });
+      expect(el.css()).toStrictEqual({ color: '#aaa' });
     });
 
     it('(prop): should ignore blank values', function () {
       var el = cheerio('<li style="color:;position:absolute;">');
-      expect(el.css()).to.eql({ position: 'absolute' });
+      expect(el.css()).toStrictEqual({ position: 'absolute' });
     });
 
     it('(prop): should return undefined for unmatched elements', function () {
       var $ = cheerio.load('<li style="color:;position:absolute;">');
-      expect($('ul').css('background-image')).to.eql(undefined);
+      expect($('ul').css('background-image')).toStrictEqual(undefined);
     });
 
     it('(prop): should return undefined for unmatched styles', function () {
       var el = cheerio('<li style="color:;position:absolute;">');
-      expect(el.css('margin')).to.eql(undefined);
+      expect(el.css('margin')).toStrictEqual(undefined);
     });
 
     describe('(prop, function):', function () {
+      var $el;
       beforeEach(function () {
-        this.$el = cheerio(
+        $el = cheerio(
           '<div style="margin: 0px;"></div><div style="margin: 1px;"></div><div style="margin: 2px;">'
         );
       });
 
       it('should iterate over the selection', function () {
         var count = 0;
-        var $el = this.$el;
-        this.$el.css('margin', function (idx, value) {
-          expect(idx).to.equal(count);
-          expect(value).to.equal(count + 'px');
-          expect(this).to.equal($el[count]);
+        $el.css('margin', function (idx, value) {
+          expect(idx).toBe(count);
+          expect(value).toBe(count + 'px');
+          expect(this).toBe($el[count]);
           count++;
         });
-        expect(count).to.equal(3);
+        expect(count).toBe(3);
       });
 
       it('should set each attribute independently', function () {
         var values = ['4px', '', undefined];
-        this.$el.css('margin', function (idx) {
+        $el.css('margin', function (idx) {
           return values[idx];
         });
-        expect(this.$el.eq(0).attr('style')).to.equal('margin: 4px;');
-        expect(this.$el.eq(1).attr('style')).to.equal('');
-        expect(this.$el.eq(2).attr('style')).to.equal('margin: 2px;');
+        expect($el.eq(0).attr('style')).toBe('margin: 4px;');
+        expect($el.eq(1).attr('style')).toBe('');
+        expect($el.eq(2).attr('style')).toBe('margin: 2px;');
       });
     });
 
     it('(obj): should set each key and val', function () {
       var el = cheerio('<li style="padding: 0;"></li><li></li>');
       el.css({ foo: 0 });
-      expect(el.eq(0).attr('style')).to.equal('padding: 0; foo: 0;');
-      expect(el.eq(1).attr('style')).to.equal('foo: 0;');
+      expect(el.eq(0).attr('style')).toBe('padding: 0; foo: 0;');
+      expect(el.eq(1).attr('style')).toBe('foo: 0;');
     });
 
     describe('parser', function () {
       it('should allow any whitespace between declarations', function () {
         var el = cheerio('<li style="one \t:\n 0;\n two \f\r:\v 1">');
-        expect(el.css(['one', 'two'])).to.eql({ one: 0, two: 1 });
+        expect(el.css(['one', 'two'])).toStrictEqual({ one: '0', two: '1' });
       });
     });
   });

--- a/test/api/deprecated.js
+++ b/test/api/deprecated.js
@@ -3,8 +3,7 @@
  * removed in the next major release of Cheerio, but their stability should be
  * maintained until that time.
  */
-var expect = require('expect.js');
-var fixtures = require('../fixtures');
+var fixtures = require('../__fixtures__/fixtures');
 var cheerio = require('../..');
 
 describe('deprecated APIs', function () {
@@ -23,7 +22,7 @@ describe('deprecated APIs', function () {
     describe('.parseHTML', function () {
       it('(html) : should preserve content', function () {
         var html = '<div>test div</div>';
-        expect(cheerio(cheerio.parseHTML(html)[0]).html()).to.equal('test div');
+        expect(cheerio(cheerio.parseHTML(html)[0]).html()).toBe('test div');
       });
     });
 
@@ -46,23 +45,23 @@ describe('deprecated APIs', function () {
       });
 
       it('should be a function', function () {
-        expect(typeof cheerio.merge).to.equal('function');
+        expect(typeof cheerio.merge).toBe('function');
       });
 
       it('(arraylike, arraylike) : should return an array', function () {
         var ret = cheerio.merge(arr1, arr2);
-        expect(typeof ret).to.equal('object');
-        expect(ret instanceof Array).to.be.ok();
+        expect(typeof ret).toBe('object');
+        expect(ret instanceof Array).toBeTruthy();
       });
 
       it('(arraylike, arraylike) : should modify the first array', function () {
         cheerio.merge(arr1, arr2);
-        expect(arr1).to.have.length(6);
+        expect(arr1).toHaveLength(6);
       });
 
       it('(arraylike, arraylike) : should not modify the second array', function () {
         cheerio.merge(arr1, arr2);
-        expect(arr2).to.have.length(3);
+        expect(arr2).toHaveLength(3);
       });
 
       it('(arraylike, arraylike) : should handle objects that arent arrays, but are arraylike', function () {
@@ -77,37 +76,37 @@ describe('deprecated APIs', function () {
         arr2[1] = 'e';
         arr2[2] = 'f';
         cheerio.merge(arr1, arr2);
-        expect(arr1).to.have.length(6);
-        expect(arr1[3]).to.equal('d');
-        expect(arr1[4]).to.equal('e');
-        expect(arr1[5]).to.equal('f');
-        expect(arr2).to.have.length(3);
+        expect(arr1).toHaveLength(6);
+        expect(arr1[3]).toBe('d');
+        expect(arr1[4]).toBe('e');
+        expect(arr1[5]).toBe('f');
+        expect(arr2).toHaveLength(3);
       });
 
       it('(?, ?) : should gracefully reject invalid inputs', function () {
         var ret = cheerio.merge([4], 3);
-        expect(ret).to.not.be.ok();
+        expect(ret).toBeFalsy();
         ret = cheerio.merge({}, {});
-        expect(ret).to.not.be.ok();
+        expect(ret).toBeFalsy();
         ret = cheerio.merge([], {});
-        expect(ret).to.not.be.ok();
+        expect(ret).toBeFalsy();
         ret = cheerio.merge({}, []);
-        expect(ret).to.not.be.ok();
+        expect(ret).toBeFalsy();
         var fakeArray1 = { length: 3 };
         fakeArray1[0] = 'a';
         fakeArray1[1] = 'b';
         fakeArray1[3] = 'd';
         ret = cheerio.merge(fakeArray1, []);
-        expect(ret).to.not.be.ok();
+        expect(ret).toBeFalsy();
         ret = cheerio.merge([], fakeArray1);
-        expect(ret).to.not.be.ok();
+        expect(ret).toBeFalsy();
         fakeArray1 = {};
         fakeArray1.length = '7';
         ret = cheerio.merge(fakeArray1, []);
-        expect(ret).to.not.be.ok();
+        expect(ret).toBeFalsy();
         fakeArray1.length = -1;
         ret = cheerio.merge(fakeArray1, []);
-        expect(ret).to.not.be.ok();
+        expect(ret).toBeFalsy();
       });
 
       it('(?, ?) : should no-op on invalid inputs', function () {
@@ -116,15 +115,15 @@ describe('deprecated APIs', function () {
         fakeArray1[1] = 'b';
         fakeArray1[3] = 'd';
         cheerio.merge(fakeArray1, []);
-        expect(fakeArray1).to.have.length(3);
-        expect(fakeArray1[0]).to.equal('a');
-        expect(fakeArray1[1]).to.equal('b');
-        expect(fakeArray1[3]).to.equal('d');
+        expect(fakeArray1).toHaveLength(3);
+        expect(fakeArray1[0]).toBe('a');
+        expect(fakeArray1[1]).toBe('b');
+        expect(fakeArray1[3]).toBe('d');
         cheerio.merge([], fakeArray1);
-        expect(fakeArray1).to.have.length(3);
-        expect(fakeArray1[0]).to.equal('a');
-        expect(fakeArray1[1]).to.equal('b');
-        expect(fakeArray1[3]).to.equal('d');
+        expect(fakeArray1).toHaveLength(3);
+        expect(fakeArray1[0]).toBe('a');
+        expect(fakeArray1[1]).toBe('b');
+        expect(fakeArray1[3]).toBe('d');
       });
     });
 
@@ -151,8 +150,8 @@ describe('deprecated APIs', function () {
         var $fruits = $('#fruits');
         var $apple = $('.apple');
 
-        expect(cheerio.contains($food[0], $fruits[0])).to.equal(true);
-        expect(cheerio.contains($food[0], $apple[0])).to.equal(true);
+        expect(cheerio.contains($food[0], $fruits[0])).toBe(true);
+        expect(cheerio.contains($food[0], $apple[0])).toBe(true);
       });
 
       it('(container, other) : should not detect elements that are not contained', function () {
@@ -160,13 +159,11 @@ describe('deprecated APIs', function () {
         var $vegetables = $('#vegetables');
         var $apple = $('.apple');
 
-        expect(cheerio.contains($vegetables[0], $apple[0])).to.equal(false);
-        expect(cheerio.contains($fruits[0], $vegetables[0])).to.equal(false);
-        expect(cheerio.contains($vegetables[0], $fruits[0])).to.equal(false);
-        expect(cheerio.contains($fruits[0], $fruits[0])).to.equal(false);
-        expect(cheerio.contains($vegetables[0], $vegetables[0])).to.equal(
-          false
-        );
+        expect(cheerio.contains($vegetables[0], $apple[0])).toBe(false);
+        expect(cheerio.contains($fruits[0], $vegetables[0])).toBe(false);
+        expect(cheerio.contains($vegetables[0], $fruits[0])).toBe(false);
+        expect(cheerio.contains($fruits[0], $fruits[0])).toBe(false);
+        expect(cheerio.contains($vegetables[0], $vegetables[0])).toBe(false);
       });
     });
 
@@ -183,7 +180,7 @@ describe('deprecated APIs', function () {
     describe('.root', function () {
       it('returns an empty selection', function () {
         var $empty = cheerio.root();
-        expect($empty).to.have.length(0);
+        expect($empty).toHaveLength(0);
       });
     });
   });
@@ -201,7 +198,7 @@ describe('deprecated APIs', function () {
       var $1 = cheerio.load(fixtures.fruits);
       var $2 = $1.load('<div><p>Some <a>text</a>.</p></div>');
 
-      expect($2('a')).to.have.length(1);
+      expect($2('a')).toHaveLength(1);
     });
 
     /**
@@ -224,12 +221,12 @@ describe('deprecated APIs', function () {
         // Note: the direct invocation of the Cheerio constructor function is
         // also deprecated.
         var $ = cheerio();
-        expect($.html()).to.be(null);
+        expect($.html()).toBe(null);
       });
 
       it('(selector) : should return the outerHTML of the selected element', function () {
         var $ = cheerio.load(fixtures.fruits);
-        expect($.html('.pear')).to.equal('<li class="pear">Pear</li>');
+        expect($.html('.pear')).toBe('<li class="pear">Pear</li>');
       });
     });
 
@@ -244,7 +241,7 @@ describe('deprecated APIs', function () {
     describe('.xml  - deprecated API', function () {
       it('() :  renders XML', function () {
         var $ = cheerio.load('<foo></foo>', { xmlMode: true });
-        expect($.xml()).to.equal('<foo/>');
+        expect($.xml()).toBe('<foo/>');
       });
     });
 
@@ -266,21 +263,21 @@ describe('deprecated APIs', function () {
     describe('.text  - deprecated API', function () {
       it('(cheerio object) : should return the text contents of the specified elements', function () {
         var $ = cheerio.load('<a>This is <em>content</em>.</a>');
-        expect($.text($('a'))).to.equal('This is content.');
+        expect($.text($('a'))).toBe('This is content.');
       });
 
       it('(cheerio object) : should omit comment nodes', function () {
         var $ = cheerio.load(
           '<a>This is <!-- a comment --> not a comment.</a>'
         );
-        expect($.text($('a'))).to.equal('This is  not a comment.');
+        expect($.text($('a'))).toBe('This is  not a comment.');
       });
 
       it('(cheerio object) : should include text contents of children recursively', function () {
         var $ = cheerio.load(
           '<a>This is <div>a child with <span>another child and <!-- a comment --> not a comment</span> followed by <em>one last child</em> and some final</div> text.</a>'
         );
-        expect($.text($('a'))).to.equal(
+        expect($.text($('a'))).toBe(
           'This is a child with another child and  not a comment followed by one last child and some final text.'
         );
       });
@@ -289,28 +286,28 @@ describe('deprecated APIs', function () {
         var $ = cheerio.load(
           '<a>This is <div>a child with <span>another child and <!-- a comment --> not a comment</span> followed by <em>one last child</em> and some final</div> text.</a>'
         );
-        expect($.text()).to.equal(
+        expect($.text()).toBe(
           'This is a child with another child and  not a comment followed by one last child and some final text.'
         );
       });
 
       it('(cheerio object) : should omit script tags', function () {
         var $ = cheerio.load('<script>console.log("test")</script>');
-        expect($.text()).to.equal('');
+        expect($.text()).toBe('');
       });
 
       it('(cheerio object) : should omit style tags', function () {
         var $ = cheerio.load(
           '<style type="text/css">.cf-hidden { display: none; } .cf-invisible { visibility: hidden; }</style>'
         );
-        expect($.text()).to.equal('');
+        expect($.text()).toBe('');
       });
 
       it('(cheerio object) : should include text contents of children omiting style and script tags', function () {
         var $ = cheerio.load(
           '<body>Welcome <div>Hello, testing text function,<script>console.log("hello")</script></div><style type="text/css">.cf-hidden { display: none; }</style>End of messege</body>'
         );
-        expect($.text()).to.equal(
+        expect($.text()).toBe(
           'Welcome Hello, testing text function,End of messege'
         );
       });

--- a/test/api/forms.js
+++ b/test/api/forms.js
@@ -1,6 +1,5 @@
-var expect = require('expect.js');
 var cheerio = require('../..');
-var forms = require('../fixtures').forms;
+var forms = require('../__fixtures__/fixtures').forms;
 
 describe('$(...)', function () {
   var $;
@@ -11,7 +10,7 @@ describe('$(...)', function () {
 
   describe('.serializeArray', function () {
     it('() : should get form controls', function () {
-      expect($('form#simple').serializeArray()).to.eql([
+      expect($('form#simple').serializeArray()).toStrictEqual([
         {
           name: 'fruit',
           value: 'Apple',
@@ -20,12 +19,12 @@ describe('$(...)', function () {
     });
 
     it('() : should get nested form controls', function () {
-      expect($('form#nested').serializeArray()).to.have.length(2);
+      expect($('form#nested').serializeArray()).toHaveLength(2);
       var data = $('form#nested').serializeArray();
       data.sort(function (a, b) {
         return a.value - b.value;
       });
-      expect(data).to.eql([
+      expect(data).toStrictEqual([
         {
           name: 'fruit',
           value: 'Apple',
@@ -38,11 +37,11 @@ describe('$(...)', function () {
     });
 
     it('() : should not get disabled form controls', function () {
-      expect($('form#disabled').serializeArray()).to.eql([]);
+      expect($('form#disabled').serializeArray()).toStrictEqual([]);
     });
 
     it('() : should not get form controls with the wrong type', function () {
-      expect($('form#submit').serializeArray()).to.eql([
+      expect($('form#submit').serializeArray()).toStrictEqual([
         {
           name: 'fruit',
           value: 'Apple',
@@ -51,7 +50,7 @@ describe('$(...)', function () {
     });
 
     it('() : should get selected options', function () {
-      expect($('form#select').serializeArray()).to.eql([
+      expect($('form#select').serializeArray()).toStrictEqual([
         {
           name: 'fruit',
           value: 'Orange',
@@ -60,7 +59,7 @@ describe('$(...)', function () {
     });
 
     it('() : should not get unnamed form controls', function () {
-      expect($('form#unnamed').serializeArray()).to.eql([
+      expect($('form#unnamed').serializeArray()).toStrictEqual([
         {
           name: 'fruit',
           value: 'Apple',
@@ -69,12 +68,12 @@ describe('$(...)', function () {
     });
 
     it('() : should get multiple selected options', function () {
-      expect($('form#multiple').serializeArray()).to.have.length(2);
+      expect($('form#multiple').serializeArray()).toHaveLength(2);
       var data = $('form#multiple').serializeArray();
       data.sort(function (a, b) {
         return a.value - b.value;
       });
-      expect(data).to.eql([
+      expect(data).toStrictEqual([
         {
           name: 'fruit',
           value: 'Apple',
@@ -91,7 +90,7 @@ describe('$(...)', function () {
       data.sort(function (a, b) {
         return a.value - b.value;
       });
-      expect(data).to.eql([
+      expect(data).toStrictEqual([
         {
           name: 'fruit',
           value: 'Apple',
@@ -104,7 +103,7 @@ describe('$(...)', function () {
     });
 
     it('() : should standardize line breaks', function () {
-      expect($('form#textarea').serializeArray()).to.eql([
+      expect($('form#textarea').serializeArray()).toStrictEqual([
         {
           name: 'fruits',
           value: 'Apple\r\nOrange',
@@ -113,20 +112,22 @@ describe('$(...)', function () {
     });
 
     it("() : shouldn't serialize the empty string", function () {
-      expect($('<input value=pineapple>').serializeArray()).to.eql([]);
-      expect($('<input name="" value=pineapple>').serializeArray()).to.eql([]);
-      expect($('<input name="fruit" value=pineapple>').serializeArray()).to.eql(
-        [
-          {
-            name: 'fruit',
-            value: 'pineapple',
-          },
-        ]
-      );
+      expect($('<input value=pineapple>').serializeArray()).toStrictEqual([]);
+      expect(
+        $('<input name="" value=pineapple>').serializeArray()
+      ).toStrictEqual([]);
+      expect(
+        $('<input name="fruit" value=pineapple>').serializeArray()
+      ).toStrictEqual([
+        {
+          name: 'fruit',
+          value: 'pineapple',
+        },
+      ]);
     });
 
     it('() : should serialize inputs without value attributes', function () {
-      expect($('<input name="fruit">').serializeArray()).to.eql([
+      expect($('<input name="fruit">').serializeArray()).toStrictEqual([
         {
           name: 'fruit',
           value: '',
@@ -137,27 +138,23 @@ describe('$(...)', function () {
 
   describe('.serialize', function () {
     it('() : should get form controls', function () {
-      expect($('form#simple').serialize()).to.equal('fruit=Apple');
+      expect($('form#simple').serialize()).toBe('fruit=Apple');
     });
 
     it('() : should get nested form controls', function () {
-      expect($('form#nested').serialize()).to.equal(
-        'fruit=Apple&vegetable=Carrot'
-      );
+      expect($('form#nested').serialize()).toBe('fruit=Apple&vegetable=Carrot');
     });
 
     it('() : should not get disabled form controls', function () {
-      expect($('form#disabled').serialize()).to.equal('');
+      expect($('form#disabled').serialize()).toBe('');
     });
 
     it('() : should get multiple selected options', function () {
-      expect($('form#multiple').serialize()).to.equal(
-        'fruit=Apple&fruit=Orange'
-      );
+      expect($('form#multiple').serialize()).toBe('fruit=Apple&fruit=Orange');
     });
 
     it("() : should encode spaces as +'s", function () {
-      expect($('form#spaces').serialize()).to.equal('fruit=Blood+orange');
+      expect($('form#spaces').serialize()).toBe('fruit=Blood+orange');
     });
   });
 });

--- a/test/api/manipulation.js
+++ b/test/api/manipulation.js
@@ -1,8 +1,6 @@
-var expect = require('expect.js');
 var cheerio = require('../..');
-var fruits = require('../fixtures').fruits;
-var divcontainers = require('../fixtures').divcontainers;
-var toArray = Function.call.bind(Array.prototype.slice);
+var fruits = require('../__fixtures__/fixtures').fruits;
+var divcontainers = require('../__fixtures__/fixtures').divcontainers;
 
 describe('$(...)', function () {
   var $;
@@ -18,39 +16,39 @@ describe('$(...)', function () {
       var $redFruits = $('<div class="red-fruits"></div>');
       $('.apple').wrap($redFruits);
 
-      expect($fruits.children().eq(0).hasClass('red-fruits')).to.be.ok();
-      expect($('.red-fruits').children().eq(0).hasClass('apple')).to.be.ok();
-      expect($fruits.children().eq(1).hasClass('orange')).to.be.ok();
-      expect($redFruits.children()).to.have.length(1);
+      expect($fruits.children().eq(0).hasClass('red-fruits')).toBeTruthy();
+      expect($('.red-fruits').children().eq(0).hasClass('apple')).toBeTruthy();
+      expect($fruits.children().eq(1).hasClass('orange')).toBeTruthy();
+      expect($redFruits.children()).toHaveLength(1);
     });
 
     it('(element) : should wrap the base element correctly', function () {
       $('ul').wrap('<a></a>');
-      expect($('body').children()[0].tagName).to.equal('a');
+      expect($('body').children()[0].tagName).toBe('a');
     });
 
     it('(element) : should insert the element and add selected element(s) as its child', function () {
       var $redFruits = $('<div class="red-fruits"></div>');
       $('.apple').wrap($redFruits[0]);
 
-      expect($fruits.children()[0]).to.be($redFruits[0]);
-      expect($redFruits.children()).to.have.length(1);
-      expect($redFruits.children()[0]).to.be($('.apple')[0]);
-      expect($fruits.children()[1]).to.be($('.orange')[0]);
+      expect($fruits.children()[0]).toBe($redFruits[0]);
+      expect($redFruits.children()).toHaveLength(1);
+      expect($redFruits.children()[0]).toBe($('.apple')[0]);
+      expect($fruits.children()[1]).toBe($('.orange')[0]);
     });
 
     it('(html) : should insert the markup and add selected element(s) as its child', function () {
       $('.apple').wrap('<div class="red-fruits"> </div>');
-      expect($fruits.children().eq(0).hasClass('red-fruits')).to.be.ok();
-      expect($('.red-fruits').children().eq(0).hasClass('apple')).to.be.ok();
-      expect($fruits.children().eq(1).hasClass('orange')).to.be.ok();
-      expect($('.red-fruits').children()).to.have.length(1);
+      expect($fruits.children().eq(0).hasClass('red-fruits')).toBeTruthy();
+      expect($('.red-fruits').children().eq(0).hasClass('apple')).toBeTruthy();
+      expect($fruits.children().eq(1).hasClass('orange')).toBeTruthy();
+      expect($('.red-fruits').children()).toHaveLength(1);
     });
 
     it('(html) : discards extraneous markup', function () {
       $('.apple').wrap('<div></div><p></p>');
-      expect($('div')).to.have.length(1);
-      expect($('p')).to.have.length(0);
+      expect($('div')).toHaveLength(1);
+      expect($('p')).toHaveLength(0);
     });
 
     it('(html) : wraps with nested elements', function () {
@@ -59,31 +57,31 @@ describe('$(...)', function () {
       );
       $('.orange').wrap($orangeFruits);
 
-      expect($fruits.children().eq(1).hasClass('orange-fruits')).to.be.ok();
+      expect($fruits.children().eq(1).hasClass('orange-fruits')).toBeTruthy();
       expect(
         $('.orange-fruits').children().eq(0).hasClass('and-stuff')
-      ).to.be.ok();
-      expect($fruits.children().eq(2).hasClass('pear')).to.be.ok();
-      expect($('.orange-fruits').children()).to.have.length(1);
+      ).toBeTruthy();
+      expect($fruits.children().eq(2).hasClass('pear')).toBeTruthy();
+      expect($('.orange-fruits').children()).toHaveLength(1);
     });
 
     it('(html) : should only worry about the first tag children', function () {
       var delicious = '<span> This guy is delicious: <b></b></span>';
       $('.apple').wrap(delicious);
-      expect($('b>.apple')).to.have.length(1);
+      expect($('b>.apple')).toHaveLength(1);
     });
 
     it('(selector) : wraps the content with a copy of the first matched element', function () {
       $('.apple').wrap('.orange, .pear');
 
       var $oranges = $('.orange');
-      expect($('.pear')).to.have.length(1);
-      expect($oranges).to.have.length(2);
-      expect($oranges.eq(0).parent()[0]).to.be($fruits[0]);
-      expect($oranges.eq(0).children()).to.have.length(1);
-      expect($oranges.eq(0).children()[0]).to.be($('.apple')[0]);
-      expect($('.apple').parent()[0]).to.be($oranges[0]);
-      expect($oranges.eq(1).children()).to.have.length(0);
+      expect($('.pear')).toHaveLength(1);
+      expect($oranges).toHaveLength(2);
+      expect($oranges.eq(0).parent()[0]).toBe($fruits[0]);
+      expect($oranges.eq(0).children()).toHaveLength(1);
+      expect($oranges.eq(0).children()[0]).toBe($('.apple')[0]);
+      expect($('.apple').parent()[0]).toBe($oranges[0]);
+      expect($oranges.eq(1).children()).toHaveLength(0);
     });
 
     it('(fn) : should invoke the provided function with the correct arguments and context', function () {
@@ -92,12 +90,16 @@ describe('$(...)', function () {
       var thisValues = [];
 
       $children.wrap(function () {
-        args.push(toArray(arguments));
+        args.push(Array.from(arguments));
         thisValues.push(this);
       });
 
-      expect(args).to.eql([[0], [1], [2]]);
-      expect(thisValues).to.eql([$children[0], $children[1], $children[2]]);
+      expect(args).toStrictEqual([[0], [1], [2]]);
+      expect(thisValues).toStrictEqual([
+        $children[0],
+        $children[1],
+        $children[2],
+      ]);
     });
 
     it('(fn) : should use the returned HTML to wrap each element', function () {
@@ -108,22 +110,20 @@ describe('$(...)', function () {
         return '<' + tagNames.shift() + '>';
       });
 
-      expect($fruits.find('div')).to.have.length(1);
-      expect($fruits.find('div')[0]).to.be($fruits.children()[0]);
-      expect($fruits.find('.apple')).to.have.length(1);
-      expect($fruits.find('.apple').parent()[0]).to.be($fruits.find('div')[0]);
+      expect($fruits.find('div')).toHaveLength(1);
+      expect($fruits.find('div')[0]).toBe($fruits.children()[0]);
+      expect($fruits.find('.apple')).toHaveLength(1);
+      expect($fruits.find('.apple').parent()[0]).toBe($fruits.find('div')[0]);
 
-      expect($fruits.find('span')).to.have.length(1);
-      expect($fruits.find('span')[0]).to.be($fruits.children()[1]);
-      expect($fruits.find('.orange')).to.have.length(1);
-      expect($fruits.find('.orange').parent()[0]).to.be(
-        $fruits.find('span')[0]
-      );
+      expect($fruits.find('span')).toHaveLength(1);
+      expect($fruits.find('span')[0]).toBe($fruits.children()[1]);
+      expect($fruits.find('.orange')).toHaveLength(1);
+      expect($fruits.find('.orange').parent()[0]).toBe($fruits.find('span')[0]);
 
-      expect($fruits.find('p')).to.have.length(1);
-      expect($fruits.find('p')[0]).to.be($fruits.children()[2]);
-      expect($fruits.find('.pear')).to.have.length(1);
-      expect($fruits.find('.pear').parent()[0]).to.be($fruits.find('p')[0]);
+      expect($fruits.find('p')).toHaveLength(1);
+      expect($fruits.find('p')[0]).toBe($fruits.children()[2]);
+      expect($fruits.find('.pear')).toHaveLength(1);
+      expect($fruits.find('.pear').parent()[0]).toBe($fruits.find('p')[0]);
     });
 
     it('(fn) : should use the returned Cheerio object to wrap each element', function () {
@@ -134,37 +134,37 @@ describe('$(...)', function () {
         return $('<' + tagNames.shift() + '>');
       });
 
-      expect($fruits.find('span')).to.have.length(1);
-      expect($fruits.find('span')[0]).to.be($fruits.children()[0]);
-      expect($fruits.find('.apple')).to.have.length(1);
-      expect($fruits.find('.apple').parent()[0]).to.be($fruits.find('span')[0]);
+      expect($fruits.find('span')).toHaveLength(1);
+      expect($fruits.find('span')[0]).toBe($fruits.children()[0]);
+      expect($fruits.find('.apple')).toHaveLength(1);
+      expect($fruits.find('.apple').parent()[0]).toBe($fruits.find('span')[0]);
 
-      expect($fruits.find('p')).to.have.length(1);
-      expect($fruits.find('p')[0]).to.be($fruits.children()[1]);
-      expect($fruits.find('.orange')).to.have.length(1);
-      expect($fruits.find('.orange').parent()[0]).to.be($fruits.find('p')[0]);
+      expect($fruits.find('p')).toHaveLength(1);
+      expect($fruits.find('p')[0]).toBe($fruits.children()[1]);
+      expect($fruits.find('.orange')).toHaveLength(1);
+      expect($fruits.find('.orange').parent()[0]).toBe($fruits.find('p')[0]);
 
-      expect($fruits.find('div')).to.have.length(1);
-      expect($fruits.find('div')[0]).to.be($fruits.children()[2]);
-      expect($fruits.find('.pear')).to.have.length(1);
-      expect($fruits.find('.pear').parent()[0]).to.be($fruits.find('div')[0]);
+      expect($fruits.find('div')).toHaveLength(1);
+      expect($fruits.find('div')[0]).toBe($fruits.children()[2]);
+      expect($fruits.find('.pear')).toHaveLength(1);
+      expect($fruits.find('.pear').parent()[0]).toBe($fruits.find('div')[0]);
     });
 
     it('($(...)) : for each element it should add a wrapper elment and add the selected element as its child', function () {
       var $fruitDecorator = $('<div class="fruit-decorator"></div>');
       $('li').wrap($fruitDecorator);
-      expect($fruits.children().eq(0).hasClass('fruit-decorator')).to.be.ok();
+      expect($fruits.children().eq(0).hasClass('fruit-decorator')).toBeTruthy();
       expect(
         $fruits.children().eq(0).children().eq(0).hasClass('apple')
-      ).to.be.ok();
-      expect($fruits.children().eq(1).hasClass('fruit-decorator')).to.be.ok();
+      ).toBeTruthy();
+      expect($fruits.children().eq(1).hasClass('fruit-decorator')).toBeTruthy();
       expect(
         $fruits.children().eq(1).children().eq(0).hasClass('orange')
-      ).to.be.ok();
-      expect($fruits.children().eq(2).hasClass('fruit-decorator')).to.be.ok();
+      ).toBeTruthy();
+      expect($fruits.children().eq(2).hasClass('fruit-decorator')).toBeTruthy();
       expect(
         $fruits.children().eq(2).children().eq(0).hasClass('pear')
-      ).to.be.ok();
+      ).toBeTruthy();
     });
   });
 
@@ -173,50 +173,50 @@ describe('$(...)', function () {
       var $container = $('<div class="container"></div>');
       $fruits.wrapInner($container);
 
-      expect($fruits.children()[0]).to.be($container[0]);
-      expect($container[0].parent).to.be($fruits[0]);
-      expect($container[0].children[0]).to.be($('.apple')[0]);
-      expect($container[0].children[1]).to.be($('.orange')[0]);
-      expect($('.apple')[0].parent).to.be($container[0]);
-      expect($fruits.children()).to.have.length(1);
-      expect($container.children()).to.have.length(3);
+      expect($fruits.children()[0]).toBe($container[0]);
+      expect($container[0].parent).toBe($fruits[0]);
+      expect($container[0].children[0]).toBe($('.apple')[0]);
+      expect($container[0].children[1]).toBe($('.orange')[0]);
+      expect($('.apple')[0].parent).toBe($container[0]);
+      expect($fruits.children()).toHaveLength(1);
+      expect($container.children()).toHaveLength(3);
     });
 
     it('(element) : should insert the element and add selected element(s) as its parent', function () {
       var $container = $('<div class="container"></div>');
       $fruits.wrapInner($container[0]);
 
-      expect($fruits.children()[0]).to.be($container[0]);
-      expect($container[0].parent).to.be($fruits[0]);
-      expect($container[0].children[0]).to.be($('.apple')[0]);
-      expect($container[0].children[1]).to.be($('.orange')[0]);
-      expect($('.apple')[0].parent).to.be($container[0]);
-      expect($fruits.children()).to.have.length(1);
-      expect($container.children()).to.have.length(3);
+      expect($fruits.children()[0]).toBe($container[0]);
+      expect($container[0].parent).toBe($fruits[0]);
+      expect($container[0].children[0]).toBe($('.apple')[0]);
+      expect($container[0].children[1]).toBe($('.orange')[0]);
+      expect($('.apple')[0].parent).toBe($container[0]);
+      expect($fruits.children()).toHaveLength(1);
+      expect($container.children()).toHaveLength(3);
     });
 
     it('(html) : should insert the element and add selected element(s) as its parent', function () {
       $fruits.wrapInner('<div class="container"></div>');
 
-      expect($fruits.children()[0]).to.be($('.container')[0]);
-      expect($('.container')[0].parent).to.be($fruits[0]);
-      expect($('.container')[0].children[0]).to.be($('.apple')[0]);
-      expect($('.container')[0].children[1]).to.be($('.orange')[0]);
-      expect($('.apple')[0].parent).to.be($('.container')[0]);
-      expect($fruits.children()).to.have.length(1);
-      expect($('.container').children()).to.have.length(3);
+      expect($fruits.children()[0]).toBe($('.container')[0]);
+      expect($('.container')[0].parent).toBe($fruits[0]);
+      expect($('.container')[0].children[0]).toBe($('.apple')[0]);
+      expect($('.container')[0].children[1]).toBe($('.orange')[0]);
+      expect($('.apple')[0].parent).toBe($('.container')[0]);
+      expect($fruits.children()).toHaveLength(1);
+      expect($('.container').children()).toHaveLength(3);
     });
 
     it("(selector) : should wrap the html of the element with the selector's first match", function () {
       $('.apple').wrapInner('.orange, .pear');
       var $oranges = $('.orange');
-      expect($('.pear')).to.have.length(1);
-      expect($oranges).to.have.length(2);
-      expect($oranges.eq(0).parent()[0]).to.be($('.apple')[0]);
-      expect($oranges.eq(0).text()).to.be('Apple');
-      expect($('.apple').eq(0).children()[0]).to.be($oranges[0]);
-      expect($oranges.eq(1).parent()[0]).to.be($fruits[0]);
-      expect($oranges.eq(1).text()).to.be('Orange');
+      expect($('.pear')).toHaveLength(1);
+      expect($oranges).toHaveLength(2);
+      expect($oranges.eq(0).parent()[0]).toBe($('.apple')[0]);
+      expect($oranges.eq(0).text()).toBe('Apple');
+      expect($('.apple').eq(0).children()[0]).toBe($oranges[0]);
+      expect($oranges.eq(1).parent()[0]).toBe($fruits[0]);
+      expect($oranges.eq(1).text()).toBe('Orange');
     });
 
     it('(fn) : should invoke the provided function with the correct arguments and context', function () {
@@ -225,12 +225,16 @@ describe('$(...)', function () {
       var thisValues = [];
 
       $children.wrapInner(function () {
-        args.push(toArray(arguments));
+        args.push(Array.from(arguments));
         thisValues.push(this);
       });
 
-      expect(args).to.eql([[0], [1], [2]]);
-      expect(thisValues).to.eql([$children[0], $children[1], $children[2]]);
+      expect(args).toStrictEqual([[0], [1], [2]]);
+      expect(thisValues).toStrictEqual([
+        $children[0],
+        $children[1],
+        $children[2],
+      ]);
     });
 
     it("(fn) : should use the returned HTML to wrap each element's contents", function () {
@@ -241,17 +245,17 @@ describe('$(...)', function () {
         return '<' + tagNames.shift() + '>';
       });
 
-      expect($fruits.find('div')).to.have.length(1);
-      expect($fruits.find('div')[0]).to.be($('.apple').children()[0]);
-      expect($fruits.find('.apple')).to.have.length(1);
+      expect($fruits.find('div')).toHaveLength(1);
+      expect($fruits.find('div')[0]).toBe($('.apple').children()[0]);
+      expect($fruits.find('.apple')).toHaveLength(1);
 
-      expect($fruits.find('span')).to.have.length(1);
-      expect($fruits.find('span')[0]).to.be($('.orange').children()[0]);
-      expect($fruits.find('.orange')).to.have.length(1);
+      expect($fruits.find('span')).toHaveLength(1);
+      expect($fruits.find('span')[0]).toBe($('.orange').children()[0]);
+      expect($fruits.find('.orange')).toHaveLength(1);
 
-      expect($fruits.find('p')).to.have.length(1);
-      expect($fruits.find('p')[0]).to.be($('.pear').children()[0]);
-      expect($fruits.find('.pear')).to.have.length(1);
+      expect($fruits.find('p')).toHaveLength(1);
+      expect($fruits.find('p')[0]).toBe($('.pear').children()[0]);
+      expect($fruits.find('.pear')).toHaveLength(1);
     });
 
     it("(fn) : should use the returned Cheerio object to wrap each element's contents", function () {
@@ -262,17 +266,17 @@ describe('$(...)', function () {
         return tags.shift();
       });
 
-      expect($fruits.find('div')).to.have.length(1);
-      expect($fruits.find('div')[0]).to.be($('.apple').children()[0]);
-      expect($fruits.find('.apple')).to.have.length(1);
+      expect($fruits.find('div')).toHaveLength(1);
+      expect($fruits.find('div')[0]).toBe($('.apple').children()[0]);
+      expect($fruits.find('.apple')).toHaveLength(1);
 
-      expect($fruits.find('span')).to.have.length(1);
-      expect($fruits.find('span')[0]).to.be($('.orange').children()[0]);
-      expect($fruits.find('.orange')).to.have.length(1);
+      expect($fruits.find('span')).toHaveLength(1);
+      expect($fruits.find('span')[0]).toBe($('.orange').children()[0]);
+      expect($fruits.find('.orange')).toHaveLength(1);
 
-      expect($fruits.find('p')).to.have.length(1);
-      expect($fruits.find('p')[0]).to.be($('.pear').children()[0]);
-      expect($fruits.find('.pear')).to.have.length(1);
+      expect($fruits.find('p')).toHaveLength(1);
+      expect($fruits.find('p')[0]).toBe($('.pear').children()[0]);
+      expect($fruits.find('.pear')).toHaveLength(1);
     });
 
     it('($(...)) : for each element it should add a wrapper elment and add the selected element as its child', function () {
@@ -280,19 +284,19 @@ describe('$(...)', function () {
       var $children = $fruits.children();
       $('li').wrapInner($fruitDecorator);
 
-      expect($('.fruit-decorator')).to.have.length(3);
+      expect($('.fruit-decorator')).toHaveLength(3);
       expect(
         $children.eq(0).children().eq(0).hasClass('fruit-decorator')
-      ).to.be.ok();
-      expect($children.eq(0).hasClass('apple')).to.be.ok();
+      ).toBeTruthy();
+      expect($children.eq(0).hasClass('apple')).toBeTruthy();
       expect(
         $children.eq(1).children().eq(0).hasClass('fruit-decorator')
-      ).to.be.ok();
-      expect($children.eq(1).hasClass('orange')).to.be.ok();
+      ).toBeTruthy();
+      expect($children.eq(1).hasClass('orange')).toBeTruthy();
       expect(
         $children.eq(2).children().eq(0).hasClass('fruit-decorator')
-      ).to.be.ok();
-      expect($children.eq(2).hasClass('pear')).to.be.ok();
+      ).toBeTruthy();
+      expect($children.eq(2).hasClass('pear')).toBeTruthy();
     });
 
     it('(html) : wraps with nested elements', function () {
@@ -303,19 +307,19 @@ describe('$(...)', function () {
 
       expect(
         $('.orange').children().eq(0).hasClass('orange-you-glad')
-      ).to.be.ok();
+      ).toBeTruthy();
       expect(
         $('.orange-you-glad').children().eq(0).hasClass('i-didnt-say-apple')
-      ).to.be.ok();
-      expect($fruits.children().eq(2).hasClass('pear')).to.be.ok();
-      expect($('.orange-you-glad').children()).to.have.length(1);
+      ).toBeTruthy();
+      expect($fruits.children().eq(2).hasClass('pear')).toBeTruthy();
+      expect($('.orange-you-glad').children()).toHaveLength(1);
     });
 
     it('(html) : should only worry about the first tag children', function () {
       var delicious = '<span> This guy is delicious: <b></b></span>';
       $('.apple').wrapInner(delicious);
-      expect($('.apple>span>b')).to.have.length(1);
-      expect($('.apple>span>b').text()).to.equal('Apple');
+      expect($('.apple>span>b')).toHaveLength(1);
+      expect($('.apple>span>b').text()).toBe('Apple');
     });
   });
 
@@ -333,17 +337,17 @@ describe('$(...)', function () {
       var $container = doc('.container');
       var $wrap = doc('b');
 
-      expect($container).to.have.length(2);
-      expect($container[0].children).to.have.length(1);
-      expect($container[1].children).to.have.length(0);
-      expect($container[0].children[0]).to.be(doc('#new')[0]);
+      expect($container).toHaveLength(2);
+      expect($container[0].children).toHaveLength(1);
+      expect($container[1].children).toHaveLength(0);
+      expect($container[0].children[0]).toBe(doc('#new')[0]);
 
-      expect($inner).to.have.length(4);
-      expect($wrap[0].children).to.have.length(4);
-      expect($inner[0].parent).to.be($wrap[0]);
-      expect($inner[1].parent).to.be($wrap[0]);
-      expect($inner[2].parent).to.be($wrap[0]);
-      expect($inner[3].parent).to.be($wrap[0]);
+      expect($inner).toHaveLength(4);
+      expect($wrap[0].children).toHaveLength(4);
+      expect($inner[0].parent).toBe($wrap[0]);
+      expect($inner[1].parent).toBe($wrap[0]);
+      expect($inner[2].parent).toBe($wrap[0]);
+      expect($inner[3].parent).toBe($wrap[0]);
     });
 
     it('(html) : should wrap elements with it', function () {
@@ -351,18 +355,18 @@ describe('$(...)', function () {
       var $container = doc('.container');
       var $wrap = doc('.wrap');
 
-      expect($inner).to.have.length(4);
-      expect($container).to.have.length(2);
-      expect($wrap).to.have.length(1);
-      expect($wrap[0].children).to.have.length(4);
-      expect($container[0].children).to.have.length(1);
-      expect($container[1].children).to.have.length(0);
-      expect($inner[0].parent).to.be($wrap[0]);
-      expect($inner[1].parent).to.be($wrap[0]);
-      expect($inner[2].parent).to.be($wrap[0]);
-      expect($inner[3].parent).to.be($wrap[0]);
-      expect($wrap[0].parent).to.be($container[0]);
-      expect($container[0].children[0]).to.be($wrap[0]);
+      expect($inner).toHaveLength(4);
+      expect($container).toHaveLength(2);
+      expect($wrap).toHaveLength(1);
+      expect($wrap[0].children).toHaveLength(4);
+      expect($container[0].children).toHaveLength(1);
+      expect($container[1].children).toHaveLength(0);
+      expect($inner[0].parent).toBe($wrap[0]);
+      expect($inner[1].parent).toBe($wrap[0]);
+      expect($inner[2].parent).toBe($wrap[0]);
+      expect($inner[3].parent).toBe($wrap[0]);
+      expect($wrap[0].parent).toBe($container[0]);
+      expect($container[0].children[0]).toBe($wrap[0]);
     });
 
     it('(selector) : should find element from dom, wrap elements with it', function () {
@@ -371,73 +375,73 @@ describe('$(...)', function () {
       var $wrap = doc('b');
       var $new = doc('#new');
 
-      expect($inner).to.have.length(4);
-      expect($container).to.have.length(2);
-      expect($container[0].children).to.have.length(1);
-      expect($container[1].children).to.have.length(0);
-      expect($wrap[0].children).to.have.length(4);
-      expect($inner[0].parent).to.be($wrap[0]);
-      expect($inner[1].parent).to.be($wrap[0]);
-      expect($inner[2].parent).to.be($wrap[0]);
-      expect($inner[3].parent).to.be($wrap[0]);
-      expect($new[0].parent).to.be($container[0]);
-      expect($container[0].children[0]).to.be($new[0]);
+      expect($inner).toHaveLength(4);
+      expect($container).toHaveLength(2);
+      expect($container[0].children).toHaveLength(1);
+      expect($container[1].children).toHaveLength(0);
+      expect($wrap[0].children).toHaveLength(4);
+      expect($inner[0].parent).toBe($wrap[0]);
+      expect($inner[1].parent).toBe($wrap[0]);
+      expect($inner[2].parent).toBe($wrap[0]);
+      expect($inner[3].parent).toBe($wrap[0]);
+      expect($new[0].parent).toBe($container[0]);
+      expect($container[0].children[0]).toBe($new[0]);
     });
   });
 
   describe('.append', function () {
     it('() : should do nothing', function () {
-      expect($('#fruits').append()[0].tagName).to.equal('ul');
+      expect($('#fruits').append()[0].tagName).toBe('ul');
     });
 
     it('(html) : should add element as last child', function () {
       $fruits.append('<li class="plum">Plum</li>');
-      expect($fruits.children().eq(3).hasClass('plum')).to.be.ok();
+      expect($fruits.children().eq(3).hasClass('plum')).toBeTruthy();
     });
 
     it('($(...)) : should add element as last child', function () {
       var $plum = $('<li class="plum">Plum</li>');
       $fruits.append($plum);
-      expect($fruits.children().eq(3).hasClass('plum')).to.be.ok();
+      expect($fruits.children().eq(3).hasClass('plum')).toBeTruthy();
     });
 
     it('(Node) : should add element as last child', function () {
       var plum = $('<li class="plum">Plum</li>')[0];
       $fruits.append(plum);
-      expect($fruits.children().eq(3).hasClass('plum')).to.be.ok();
+      expect($fruits.children().eq(3).hasClass('plum')).toBeTruthy();
     });
 
     it('(existing Node) : should remove node from previous location', function () {
       var apple = $fruits.children()[0];
 
-      expect($fruits.children()).to.have.length(3);
+      expect($fruits.children()).toHaveLength(3);
       $fruits.append(apple);
       var $children = $fruits.children();
 
-      expect($children).to.have.length(3);
-      expect($children[0]).to.not.equal(apple);
-      expect($children[2]).to.equal(apple);
+      expect($children).toHaveLength(3);
+      expect($children[0]).not.toBe(apple);
+      expect($children[2]).toBe(apple);
     });
 
     it('(existing Node) : should remove existing node from previous location', function () {
       var apple = $fruits.children()[0];
       var $dest = $('<div></div>');
 
-      expect($fruits.children()).to.have.length(3);
+      expect($fruits.children()).toHaveLength(3);
       $dest.append(apple);
       var $children = $fruits.children();
 
-      expect($children).to.have.length(2);
-      expect($children[0]).to.not.equal(apple);
+      expect($children).toHaveLength(2);
+      expect($children[0]).not.toBe(apple);
 
-      expect($dest.children()).to.have.length(1);
-      expect($dest.children()[0]).to.equal(apple);
+      expect($dest.children()).toHaveLength(1);
+      expect($dest.children()[0]).toBe(apple);
     });
 
     it('(existing Node) : should update original direct siblings', function () {
       $('.pear').append($('.orange'));
-      expect($('.apple').next()[0]).to.be($('.pear')[0]);
-      expect($('.pear').prev()[0]).to.be($('.apple')[0]);
+      expect($('.apple').next()[0]).toBe($('.pear')[0]);
+      expect($('.pear').prev()[0]).toBe($('.apple')[0]);
     });
 
     it('(existing Node) : should clone all but the last occurrence', function () {
@@ -446,10 +450,10 @@ describe('$(...)', function () {
       $('.orange, .pear').append($originalApple);
 
       var $apples = $('.apple');
-      expect($apples).to.have.length(2);
-      expect($apples.eq(0).parent()[0]).to.be($('.orange')[0]);
-      expect($apples.eq(1).parent()[0]).to.be($('.pear')[0]);
-      expect($apples[1]).to.be($originalApple[0]);
+      expect($apples).toHaveLength(2);
+      expect($apples.eq(0).parent()[0]).toBe($('.orange')[0]);
+      expect($apples.eq(1).parent()[0]).toBe($('.pear')[0]);
+      expect($apples[1]).toBe($originalApple[0]);
     });
 
     it('(elem) : should NOP if removed', function () {
@@ -457,15 +461,15 @@ describe('$(...)', function () {
 
       $apple.remove();
       $fruits.append($apple);
-      expect($fruits.children().eq(2).hasClass('apple')).to.be.ok();
+      expect($fruits.children().eq(2).hasClass('apple')).toBeTruthy();
     });
 
     it('($(...), html) : should add multiple elements as last children', function () {
       var $plum = $('<li class="plum">Plum</li>');
       var grape = '<li class="grape">Grape</li>';
       $fruits.append($plum, grape);
-      expect($fruits.children().eq(3).hasClass('plum')).to.be.ok();
-      expect($fruits.children().eq(4).hasClass('grape')).to.be.ok();
+      expect($fruits.children().eq(3).hasClass('plum')).toBeTruthy();
+      expect($fruits.children().eq(4).hasClass('grape')).toBeTruthy();
     });
 
     it('(Array) : should append all elements in the array', function () {
@@ -473,8 +477,8 @@ describe('$(...)', function () {
         '<li class="plum">Plum</li><li class="grape">Grape</li>'
       ).get();
       $fruits.append(more);
-      expect($fruits.children().eq(3).hasClass('plum')).to.be.ok();
-      expect($fruits.children().eq(4).hasClass('grape')).to.be.ok();
+      expect($fruits.children().eq(3).hasClass('plum')).toBeTruthy();
+      expect($fruits.children().eq(4).hasClass('grape')).toBeTruthy();
     });
 
     it('(fn) : should invoke the callback with the correct arguments and context', function () {
@@ -483,16 +487,16 @@ describe('$(...)', function () {
       var thisValues = [];
 
       $fruits.append(function () {
-        args.push(toArray(arguments));
+        args.push(Array.from(arguments));
         thisValues.push(this);
       });
 
-      expect(args).to.eql([
+      expect(args).toStrictEqual([
         [0, 'Apple'],
         [1, 'Orange'],
         [2, 'Pear'],
       ]);
-      expect(thisValues).to.eql([$fruits[0], $fruits[1], $fruits[2]]);
+      expect(thisValues).toStrictEqual([$fruits[0], $fruits[1], $fruits[2]]);
     });
 
     it('(fn) : should add returned string as last child', function () {
@@ -506,9 +510,9 @@ describe('$(...)', function () {
       var $orange = $fruits.eq(1);
       var $pear = $fruits.eq(2);
 
-      expect($apple.find('.first')[0]).to.equal($apple.contents()[1]);
-      expect($orange.find('.first')[0]).to.equal($orange.contents()[1]);
-      expect($pear.find('.first')[0]).to.equal($pear.contents()[1]);
+      expect($apple.find('.first')[0]).toBe($apple.contents()[1]);
+      expect($orange.find('.first')[0]).toBe($orange.contents()[1]);
+      expect($pear.find('.first')[0]).toBe($pear.contents()[1]);
     });
 
     it('(fn) : should add returned Cheerio object as last child', function () {
@@ -522,9 +526,9 @@ describe('$(...)', function () {
       var $orange = $fruits.eq(1);
       var $pear = $fruits.eq(2);
 
-      expect($apple.find('.second')[0]).to.equal($apple.contents()[1]);
-      expect($orange.find('.second')[0]).to.equal($orange.contents()[1]);
-      expect($pear.find('.second')[0]).to.equal($pear.contents()[1]);
+      expect($apple.find('.second')[0]).toBe($apple.contents()[1]);
+      expect($orange.find('.second')[0]).toBe($orange.contents()[1]);
+      expect($pear.find('.second')[0]).toBe($pear.contents()[1]);
     });
 
     it('(fn) : should add returned Node as last child', function () {
@@ -538,9 +542,9 @@ describe('$(...)', function () {
       var $orange = $fruits.eq(1);
       var $pear = $fruits.eq(2);
 
-      expect($apple.find('.third')[0]).to.equal($apple.contents()[1]);
-      expect($orange.find('.third')[0]).to.equal($orange.contents()[1]);
-      expect($pear.find('.third')[0]).to.equal($pear.contents()[1]);
+      expect($apple.find('.third')[0]).toBe($apple.contents()[1]);
+      expect($orange.find('.third')[0]).toBe($orange.contents()[1]);
+      expect($pear.find('.third')[0]).toBe($pear.contents()[1]);
     });
 
     it('should maintain correct object state (Issue: #10)', function () {
@@ -549,74 +553,74 @@ describe('$(...)', function () {
         .children()
         .children()
         .parent();
-      expect($obj).to.be.ok();
+      expect($obj).toBeTruthy();
     });
 
     it('($(...)) : should remove from root element', function () {
       var $plum = $('<li class="plum">Plum</li>');
       var parent = $plum[0].parent;
-      expect(parent).to.be.ok();
+      expect(parent).toBeTruthy();
 
       $fruits.append($plum);
-      expect($plum[0].parent.type).to.not.be('root');
-      expect(parent.childNodes).to.not.contain($plum[0]);
+      expect($plum[0].parent.type).not.toBe('root');
+      expect(parent.childNodes).not.toContain($plum[0]);
     });
   });
 
   describe('.prepend', function () {
     it('() : should do nothing', function () {
-      expect($('#fruits').prepend()[0].tagName).to.equal('ul');
+      expect($('#fruits').prepend()[0].tagName).toBe('ul');
     });
 
     it('(html) : should add element as first child', function () {
       $fruits.prepend('<li class="plum">Plum</li>');
-      expect($fruits.children().eq(0).hasClass('plum')).to.be.ok();
+      expect($fruits.children().eq(0).hasClass('plum')).toBeTruthy();
     });
 
     it('($(...)) : should add element as first child', function () {
       var $plum = $('<li class="plum">Plum</li>');
       $fruits.prepend($plum);
-      expect($fruits.children().eq(0).hasClass('plum')).to.be.ok();
+      expect($fruits.children().eq(0).hasClass('plum')).toBeTruthy();
     });
 
     it('($(...)) : should add style element as first child', function () {
       var $style = $('<style>.foo {}</style>');
       $fruits.prepend($style);
       var styleTag = $fruits.children().get(0);
-      expect(styleTag.tagName).to.be('style');
-      expect(styleTag.children[0].data).to.be('.foo {}');
+      expect(styleTag.tagName).toBe('style');
+      expect(styleTag.children[0].data).toBe('.foo {}');
     });
 
     it('($(...)) : should add script element as first child', function () {
       var $script = $('<script>var foo;</script>');
       $fruits.prepend($script);
       var scriptTag = $fruits.children().get(0);
-      expect(scriptTag.tagName).to.be('script');
-      expect(scriptTag.children[0].data).to.be('var foo;');
+      expect(scriptTag.tagName).toBe('script');
+      expect(scriptTag.children[0].data).toBe('var foo;');
     });
 
     it('(Node) : should add node as first child', function () {
       var plum = $('<li class="plum">Plum</li>')[0];
       $fruits.prepend(plum);
-      expect($fruits.children().eq(0).hasClass('plum')).to.be.ok();
+      expect($fruits.children().eq(0).hasClass('plum')).toBeTruthy();
     });
 
     it('(existing Node) : should remove existing nodes from previous locations', function () {
       var pear = $fruits.children()[2];
 
-      expect($fruits.children()).to.have.length(3);
+      expect($fruits.children()).toHaveLength(3);
       $fruits.prepend(pear);
       var $children = $fruits.children();
 
-      expect($children).to.have.length(3);
-      expect($children[2]).to.not.equal(pear);
-      expect($children[0]).to.equal(pear);
+      expect($children).toHaveLength(3);
+      expect($children[2]).not.toBe(pear);
+      expect($children[0]).toBe(pear);
     });
 
     it('(existing Node) : should update original direct siblings', function () {
       $('.pear').prepend($('.orange'));
-      expect($('.apple').next()[0]).to.be($('.pear')[0]);
-      expect($('.pear').prev()[0]).to.be($('.apple')[0]);
+      expect($('.apple').next()[0]).toBe($('.pear')[0]);
+      expect($('.pear').prev()[0]).toBe($('.apple')[0]);
     });
 
     it('(existing Node) : should clone all but the last occurrence', function () {
@@ -625,10 +629,10 @@ describe('$(...)', function () {
       $('.orange, .pear').prepend($originalApple);
 
       var $apples = $('.apple');
-      expect($apples).to.have.length(2);
-      expect($apples.eq(0).parent()[0]).to.be($('.orange')[0]);
-      expect($apples.eq(1).parent()[0]).to.be($('.pear')[0]);
-      expect($apples[1]).to.be($originalApple[0]);
+      expect($apples).toHaveLength(2);
+      expect($apples.eq(0).parent()[0]).toBe($('.orange')[0]);
+      expect($apples.eq(1).parent()[0]).toBe($('.pear')[0]);
+      expect($apples[1]).toBe($originalApple[0]);
     });
 
     it('(elem) : should handle if removed', function () {
@@ -636,7 +640,7 @@ describe('$(...)', function () {
 
       $apple.remove();
       $fruits.prepend($apple);
-      expect($fruits.children().eq(0).hasClass('apple')).to.be.ok();
+      expect($fruits.children().eq(0).hasClass('apple')).toBeTruthy();
     });
 
     it('(Array) : should add all elements in the array as inital children', function () {
@@ -644,16 +648,16 @@ describe('$(...)', function () {
         '<li class="plum">Plum</li><li class="grape">Grape</li>'
       ).get();
       $fruits.prepend(more);
-      expect($fruits.children().eq(0).hasClass('plum')).to.be.ok();
-      expect($fruits.children().eq(1).hasClass('grape')).to.be.ok();
+      expect($fruits.children().eq(0).hasClass('plum')).toBeTruthy();
+      expect($fruits.children().eq(1).hasClass('grape')).toBeTruthy();
     });
 
     it('(html, $(...), html) : should add multiple elements as first children', function () {
       var $plum = $('<li class="plum">Plum</li>');
       var grape = '<li class="grape">Grape</li>';
       $fruits.prepend($plum, grape);
-      expect($fruits.children().eq(0).hasClass('plum')).to.be.ok();
-      expect($fruits.children().eq(1).hasClass('grape')).to.be.ok();
+      expect($fruits.children().eq(0).hasClass('plum')).toBeTruthy();
+      expect($fruits.children().eq(1).hasClass('grape')).toBeTruthy();
     });
 
     it('(fn) : should invoke the callback with the correct arguments and context', function () {
@@ -662,16 +666,16 @@ describe('$(...)', function () {
       $fruits = $fruits.children();
 
       $fruits.prepend(function () {
-        args.push(toArray(arguments));
+        args.push(Array.from(arguments));
         thisValues.push(this);
       });
 
-      expect(args).to.eql([
+      expect(args).toStrictEqual([
         [0, 'Apple'],
         [1, 'Orange'],
         [2, 'Pear'],
       ]);
-      expect(thisValues).to.eql([$fruits[0], $fruits[1], $fruits[2]]);
+      expect(thisValues).toStrictEqual([$fruits[0], $fruits[1], $fruits[2]]);
     });
 
     it('(fn) : should add returned string as first child', function () {
@@ -685,9 +689,9 @@ describe('$(...)', function () {
       var $orange = $fruits.eq(1);
       var $pear = $fruits.eq(2);
 
-      expect($apple.find('.first')[0]).to.equal($apple.contents()[0]);
-      expect($orange.find('.first')[0]).to.equal($orange.contents()[0]);
-      expect($pear.find('.first')[0]).to.equal($pear.contents()[0]);
+      expect($apple.find('.first')[0]).toBe($apple.contents()[0]);
+      expect($orange.find('.first')[0]).toBe($orange.contents()[0]);
+      expect($pear.find('.first')[0]).toBe($pear.contents()[0]);
     });
 
     it('(fn) : should add returned Cheerio object as first child', function () {
@@ -701,9 +705,9 @@ describe('$(...)', function () {
       var $orange = $fruits.eq(1);
       var $pear = $fruits.eq(2);
 
-      expect($apple.find('.second')[0]).to.equal($apple.contents()[0]);
-      expect($orange.find('.second')[0]).to.equal($orange.contents()[0]);
-      expect($pear.find('.second')[0]).to.equal($pear.contents()[0]);
+      expect($apple.find('.second')[0]).toBe($apple.contents()[0]);
+      expect($orange.find('.second')[0]).toBe($orange.contents()[0]);
+      expect($pear.find('.second')[0]).toBe($pear.contents()[0]);
     });
 
     it('(fn) : should add returned Node as first child', function () {
@@ -717,89 +721,89 @@ describe('$(...)', function () {
       var $orange = $fruits.eq(1);
       var $pear = $fruits.eq(2);
 
-      expect($apple.find('.third')[0]).to.equal($apple.contents()[0]);
-      expect($orange.find('.third')[0]).to.equal($orange.contents()[0]);
-      expect($pear.find('.third')[0]).to.equal($pear.contents()[0]);
+      expect($apple.find('.third')[0]).toBe($apple.contents()[0]);
+      expect($orange.find('.third')[0]).toBe($orange.contents()[0]);
+      expect($pear.find('.third')[0]).toBe($pear.contents()[0]);
     });
 
     it('($(...)) : should remove from root element', function () {
       var $plum = $('<li class="plum">Plum</li>');
       var root = $plum[0].parent;
-      expect(root.type).to.be('root');
+      expect(root.type).toBe('root');
 
       $fruits.prepend($plum);
-      expect($plum[0].parent.type).to.not.be('root');
-      expect(root.childNodes).to.not.contain($plum[0]);
+      expect($plum[0].parent.type).not.toBe('root');
+      expect(root.childNodes).not.toContain($plum[0]);
     });
   });
 
   describe('.appendTo', function () {
     it('(html) : should add element as last child', function () {
       var $plum = $('<li class="plum">Plum</li>').appendTo(fruits);
-      expect($plum.parent().children().eq(3).hasClass('plum')).to.be.ok();
+      expect($plum.parent().children().eq(3).hasClass('plum')).toBeTruthy();
     });
 
     it('($(...)) : should add element as last child', function () {
       $('<li class="plum">Plum</li>').appendTo($fruits);
-      expect($fruits.children().eq(3).hasClass('plum')).to.be.ok();
+      expect($fruits.children().eq(3).hasClass('plum')).toBeTruthy();
     });
 
     it('(Node) : should add element as last child', function () {
       $('<li class="plum">Plum</li>').appendTo($fruits[0]);
-      expect($fruits.children().eq(3).hasClass('plum')).to.be.ok();
+      expect($fruits.children().eq(3).hasClass('plum')).toBeTruthy();
     });
 
     it('(selector) : should add element as last child', function () {
       $('<li class="plum">Plum</li>').appendTo('#fruits');
-      expect($fruits.children().eq(3).hasClass('plum')).to.be.ok();
+      expect($fruits.children().eq(3).hasClass('plum')).toBeTruthy();
     });
 
     it('(Array) : should add element as last child of all elements in the array', function () {
       var $multiple = $('<ul><li>Apple</li></ul><ul><li>Orange</li></ul>');
       $('<li class="plum">Plum</li>').appendTo($multiple.get());
-      expect($multiple.first().children().eq(1).hasClass('plum')).to.be.ok();
-      expect($multiple.last().children().eq(1).hasClass('plum')).to.be.ok();
+      expect($multiple.first().children().eq(1).hasClass('plum')).toBeTruthy();
+      expect($multiple.last().children().eq(1).hasClass('plum')).toBeTruthy();
     });
   });
 
   describe('.prependTo', function () {
     it('(html) : should add element as first child', function () {
       var $plum = $('<li class="plum">Plum</li>').prependTo(fruits);
-      expect($plum.parent().children().eq(0).hasClass('plum')).to.be.ok();
+      expect($plum.parent().children().eq(0).hasClass('plum')).toBeTruthy();
     });
 
     it('($(...)) : should add element as first child', function () {
       $('<li class="plum">Plum</li>').prependTo($fruits);
-      expect($fruits.children().eq(0).hasClass('plum')).to.be.ok();
+      expect($fruits.children().eq(0).hasClass('plum')).toBeTruthy();
     });
 
     it('(Node) : should add node as first child', function () {
       $('<li class="plum">Plum</li>').prependTo($fruits[0]);
-      expect($fruits.children().eq(0).hasClass('plum')).to.be.ok();
+      expect($fruits.children().eq(0).hasClass('plum')).toBeTruthy();
     });
 
     it('(selector) : should add element as first child', function () {
       $('<li class="plum">Plum</li>').prependTo('#fruits');
-      expect($fruits.children().eq(0).hasClass('plum')).to.be.ok();
+      expect($fruits.children().eq(0).hasClass('plum')).toBeTruthy();
     });
 
     it('(Array) : should add element as first child of all elements in the array', function () {
       var $multiple = $('<ul><li>Apple</li></ul><ul><li>Orange</li></ul>');
       $('<li class="plum">Plum</li>').prependTo($multiple.get());
-      expect($multiple.first().children().eq(0).hasClass('plum')).to.be.ok();
-      expect($multiple.last().children().eq(0).hasClass('plum')).to.be.ok();
+      expect($multiple.first().children().eq(0).hasClass('plum')).toBeTruthy();
+      expect($multiple.last().children().eq(0).hasClass('plum')).toBeTruthy();
     });
   });
 
   describe('.after', function () {
     it('() : should do nothing', function () {
-      expect($('#fruits').after()[0].tagName).to.equal('ul');
+      expect($('#fruits').after()[0].tagName).toBe('ul');
     });
 
     it('(html) : should add element as next sibling', function () {
       var grape = '<li class="grape">Grape</li>';
       $('.apple').after(grape);
-      expect($('.apple').next().hasClass('grape')).to.be.ok();
+      expect($('.apple').next().hasClass('grape')).toBeTruthy();
     });
 
     it('(Array) : should add all elements in the array as next sibling', function () {
@@ -807,20 +811,20 @@ describe('$(...)', function () {
         '<li class="plum">Plum</li><li class="grape">Grape</li>'
       ).get();
       $('.apple').after(more);
-      expect($fruits.children().eq(1).hasClass('plum')).to.be.ok();
-      expect($fruits.children().eq(2).hasClass('grape')).to.be.ok();
+      expect($fruits.children().eq(1).hasClass('plum')).toBeTruthy();
+      expect($fruits.children().eq(2).hasClass('grape')).toBeTruthy();
     });
 
     it('($(...)) : should add element as next sibling', function () {
       var $plum = $('<li class="plum">Plum</li>');
       $('.apple').after($plum);
-      expect($('.apple').next().hasClass('plum')).to.be.ok();
+      expect($('.apple').next().hasClass('plum')).toBeTruthy();
     });
 
     it('(Node) : should add element as next sibling', function () {
       var plum = $('<li class="plum">Plum</li>')[0];
       $('.apple').after(plum);
-      expect($('.apple').next().hasClass('plum')).to.be.ok();
+      expect($('.apple').next().hasClass('plum')).toBeTruthy();
     });
 
     it('(existing Node) : should remove existing nodes from previous locations', function () {
@@ -829,27 +833,27 @@ describe('$(...)', function () {
       $('.apple').after(pear);
 
       var $children = $fruits.children();
-      expect($children).to.have.length(3);
-      expect($children[1]).to.be(pear);
+      expect($children).toHaveLength(3);
+      expect($children[1]).toBe(pear);
     });
 
     it('(existing Node) : should update original direct siblings', function () {
       $('.pear').after($('.orange'));
-      expect($('.apple').next()[0]).to.be($('.pear')[0]);
-      expect($('.pear').prev()[0]).to.be($('.apple')[0]);
+      expect($('.apple').next()[0]).toBe($('.pear')[0]);
+      expect($('.pear').prev()[0]).toBe($('.apple')[0]);
     });
 
     it('(existing Node) : should clone all but the last occurrence', function () {
       var $originalApple = $('.apple');
       $('.orange, .pear').after($originalApple);
 
-      expect($('.apple')).to.have.length(2);
-      expect($('.apple').eq(0).prev()[0]).to.be($('.orange')[0]);
-      expect($('.apple').eq(0).next()[0]).to.be($('.pear')[0]);
-      expect($('.apple').eq(1).prev()[0]).to.be($('.pear')[0]);
-      expect($('.apple').eq(1).next()).to.have.length(0);
-      expect($('.apple')[0]).to.not.eql($originalApple[0]);
-      expect($('.apple')[1]).to.eql($originalApple[0]);
+      expect($('.apple')).toHaveLength(2);
+      expect($('.apple').eq(0).prev()[0]).toBe($('.orange')[0]);
+      expect($('.apple').eq(0).next()[0]).toBe($('.pear')[0]);
+      expect($('.apple').eq(1).prev()[0]).toBe($('.pear')[0]);
+      expect($('.apple').eq(1).next()).toHaveLength(0);
+      expect($('.apple')[0]).not.toStrictEqual($originalApple[0]);
+      expect($('.apple')[1]).toStrictEqual($originalApple[0]);
     });
 
     it('(elem) : should handle if removed', function () {
@@ -858,15 +862,15 @@ describe('$(...)', function () {
 
       $apple.remove();
       $apple.after($plum);
-      expect($plum.prev()).to.be.empty();
+      expect($plum.prev()).toHaveLength(0);
     });
 
     it('($(...), html) : should add multiple elements as next siblings', function () {
       var $plum = $('<li class="plum">Plum</li>');
       var grape = '<li class="grape">Grape</li>';
       $('.apple').after($plum, grape);
-      expect($('.apple').next().hasClass('plum')).to.be.ok();
-      expect($('.plum').next().hasClass('grape')).to.be.ok();
+      expect($('.apple').next().hasClass('plum')).toBeTruthy();
+      expect($('.plum').next().hasClass('grape')).toBeTruthy();
     });
 
     it('(fn) : should invoke the callback with the correct arguments and context', function () {
@@ -875,16 +879,16 @@ describe('$(...)', function () {
       $fruits = $fruits.children();
 
       $fruits.after(function () {
-        args.push(toArray(arguments));
+        args.push(Array.from(arguments));
         thisValues.push(this);
       });
 
-      expect(args).to.eql([
+      expect(args).toStrictEqual([
         [0, 'Apple'],
         [1, 'Orange'],
         [2, 'Pear'],
       ]);
-      expect(thisValues).to.eql([$fruits[0], $fruits[1], $fruits[2]]);
+      expect(thisValues).toStrictEqual([$fruits[0], $fruits[1], $fruits[2]]);
     });
 
     it('(fn) : should add returned string as next sibling', function () {
@@ -894,9 +898,9 @@ describe('$(...)', function () {
         return '<li class="first">';
       });
 
-      expect($('.first')[0]).to.equal($('#fruits').contents()[1]);
-      expect($('.first')[1]).to.equal($('#fruits').contents()[3]);
-      expect($('.first')[2]).to.equal($('#fruits').contents()[5]);
+      expect($('.first')[0]).toBe($('#fruits').contents()[1]);
+      expect($('.first')[1]).toBe($('#fruits').contents()[3]);
+      expect($('.first')[2]).toBe($('#fruits').contents()[5]);
     });
 
     it('(fn) : should add returned Cheerio object as next sibling', function () {
@@ -906,9 +910,9 @@ describe('$(...)', function () {
         return $('<li class="second">');
       });
 
-      expect($('.second')[0]).to.equal($('#fruits').contents()[1]);
-      expect($('.second')[1]).to.equal($('#fruits').contents()[3]);
-      expect($('.second')[2]).to.equal($('#fruits').contents()[5]);
+      expect($('.second')[0]).toBe($('#fruits').contents()[1]);
+      expect($('.second')[1]).toBe($('#fruits').contents()[3]);
+      expect($('.second')[2]).toBe($('#fruits').contents()[5]);
     });
 
     it('(fn) : should add returned element as next sibling', function () {
@@ -918,19 +922,19 @@ describe('$(...)', function () {
         return $('<li class="third">')[0];
       });
 
-      expect($('.third')[0]).to.equal($('#fruits').contents()[1]);
-      expect($('.third')[1]).to.equal($('#fruits').contents()[3]);
-      expect($('.third')[2]).to.equal($('#fruits').contents()[5]);
+      expect($('.third')[0]).toBe($('#fruits').contents()[1]);
+      expect($('.third')[1]).toBe($('#fruits').contents()[3]);
+      expect($('.third')[2]).toBe($('#fruits').contents()[5]);
     });
 
     it('($(...)) : should remove from root element', function () {
       var $plum = $('<li class="plum">Plum</li>');
       var root = $plum[0].parent;
-      expect(root.type).to.be('root');
+      expect(root.type).toBe('root');
 
       $fruits.after($plum);
-      expect($plum[0].parent.type).to.not.be('root');
-      expect(root.childNodes).to.not.contain($plum[0]);
+      expect($plum[0].parent.type).not.toBe('root');
+      expect(root.childNodes).not.toContain($plum[0]);
     });
   });
 
@@ -938,63 +942,63 @@ describe('$(...)', function () {
     it('(selector) : should create element and add as next sibling', function () {
       var grape = $('<li class="grape">Grape</li>');
       grape.insertAfter('.apple');
-      expect($('.apple').next().hasClass('grape')).to.be.ok();
+      expect($('.apple').next().hasClass('grape')).toBeTruthy();
     });
 
     it('(selector) : should create element and add as next sibling of multiple elements', function () {
       var grape = $('<li class="grape">Grape</li>');
       grape.insertAfter('.apple, .pear');
-      expect($('.apple').next().hasClass('grape')).to.be.ok();
-      expect($('.pear').next().hasClass('grape')).to.be.ok();
+      expect($('.apple').next().hasClass('grape')).toBeTruthy();
+      expect($('.pear').next().hasClass('grape')).toBeTruthy();
     });
 
     it('($(...)) : should create element and add as next sibling', function () {
       var grape = $('<li class="grape">Grape</li>');
       grape.insertAfter($('.apple'));
-      expect($('.apple').next().hasClass('grape')).to.be.ok();
+      expect($('.apple').next().hasClass('grape')).toBeTruthy();
     });
 
     it('($(...)) : should create element and add as next sibling of multiple elements', function () {
       var grape = $('<li class="grape">Grape</li>');
       grape.insertAfter($('.apple, .pear'));
-      expect($('.apple').next().hasClass('grape')).to.be.ok();
-      expect($('.pear').next().hasClass('grape')).to.be.ok();
+      expect($('.apple').next().hasClass('grape')).toBeTruthy();
+      expect($('.pear').next().hasClass('grape')).toBeTruthy();
     });
 
     it('($(...)) : should create all elements in the array and add as next siblings', function () {
       var more = $('<li class="plum">Plum</li><li class="grape">Grape</li>');
       more.insertAfter($('.apple'));
-      expect($fruits.children().eq(0).hasClass('apple')).to.be.ok();
-      expect($fruits.children().eq(1).hasClass('plum')).to.be.ok();
-      expect($fruits.children().eq(2).hasClass('grape')).to.be.ok();
+      expect($fruits.children().eq(0).hasClass('apple')).toBeTruthy();
+      expect($fruits.children().eq(1).hasClass('plum')).toBeTruthy();
+      expect($fruits.children().eq(2).hasClass('grape')).toBeTruthy();
     });
 
     it('(existing Node) : should remove existing nodes from previous locations', function () {
       $('.orange').insertAfter('.pear');
-      expect($fruits.children().eq(1).hasClass('orange')).to.not.be.ok();
-      expect($fruits.children().length).to.be(3);
-      expect($('.orange').length).to.be(1);
+      expect($fruits.children().eq(1).hasClass('orange')).toBeFalsy();
+      expect($fruits.children().length).toBe(3);
+      expect($('.orange').length).toBe(1);
     });
 
     it('(existing Node) : should update original direct siblings', function () {
       $('.orange').insertAfter('.pear');
-      expect($('.apple').next().hasClass('pear')).to.be.ok();
-      expect($('.pear').prev().hasClass('apple')).to.be.ok();
-      expect($('.pear').next().hasClass('orange')).to.be.ok();
-      expect($('.orange').next()).to.be.empty();
+      expect($('.apple').next().hasClass('pear')).toBeTruthy();
+      expect($('.pear').prev().hasClass('apple')).toBeTruthy();
+      expect($('.pear').next().hasClass('orange')).toBeTruthy();
+      expect($('.orange').next()).toHaveLength(0);
     });
 
     it('(existing Node) : should update original direct siblings of multiple elements', function () {
       $('.apple').insertAfter('.orange, .pear');
-      expect($('.orange').prev()).to.be.empty();
-      expect($('.orange').next().hasClass('apple')).to.be.ok();
-      expect($('.pear').next().hasClass('apple')).to.be.ok();
-      expect($('.pear').prev().hasClass('apple')).to.be.ok();
-      expect($fruits.children().length).to.be(4);
+      expect($('.orange').prev()).toHaveLength(0);
+      expect($('.orange').next().hasClass('apple')).toBeTruthy();
+      expect($('.pear').next().hasClass('apple')).toBeTruthy();
+      expect($('.pear').prev().hasClass('apple')).toBeTruthy();
+      expect($fruits.children().length).toBe(4);
       var apples = $('.apple');
-      expect(apples.length).to.be(2);
-      expect(apples.eq(0).prev().hasClass('orange')).to.be.ok();
-      expect(apples.eq(1).prev().hasClass('pear')).to.be.ok();
+      expect(apples.length).toBe(2);
+      expect(apples.eq(0).prev().hasClass('orange')).toBeTruthy();
+      expect(apples.eq(1).prev().hasClass('pear')).toBeTruthy();
     });
 
     it('(elem) : should handle if removed', function () {
@@ -1002,92 +1006,92 @@ describe('$(...)', function () {
       var $plum = $('<li class="plum">Plum</li>');
       $apple.remove();
       $plum.insertAfter($apple);
-      expect($plum.prev()).to.be.empty();
+      expect($plum.prev()).toHaveLength(0);
     });
 
     it('(single) should return the new element for chaining', function () {
       var $grape = $('<li class="grape">Grape</li>').insertAfter('.apple');
-      expect($grape.cheerio).to.be.ok();
-      expect($grape.each).to.be.ok();
-      expect($grape.length).to.be(1);
-      expect($grape.hasClass('grape')).to.be.ok();
+      expect($grape.cheerio).toBeTruthy();
+      expect($grape.each).toBeTruthy();
+      expect($grape.length).toBe(1);
+      expect($grape.hasClass('grape')).toBeTruthy();
     });
 
     it('(single) should return the new elements for chaining', function () {
       var $purple = $(
         '<li class="grape">Grape</li><li class="plum">Plum</li>'
       ).insertAfter('.apple');
-      expect($purple.cheerio).to.be.ok();
-      expect($purple.each).to.be.ok();
-      expect($purple.length).to.be(2);
-      expect($purple.eq(0).hasClass('grape')).to.be.ok();
-      expect($purple.eq(1).hasClass('plum')).to.be.ok();
+      expect($purple.cheerio).toBeTruthy();
+      expect($purple.each).toBeTruthy();
+      expect($purple.length).toBe(2);
+      expect($purple.eq(0).hasClass('grape')).toBeTruthy();
+      expect($purple.eq(1).hasClass('plum')).toBeTruthy();
     });
 
     it('(multiple) should return the new elements for chaining', function () {
       var $purple = $(
         '<li class="grape">Grape</li><li class="plum">Plum</li>'
       ).insertAfter('.apple, .pear');
-      expect($purple.cheerio).to.be.ok();
-      expect($purple.each).to.be.ok();
-      expect($purple.length).to.be(4);
-      expect($purple.eq(0).hasClass('grape')).to.be.ok();
-      expect($purple.eq(1).hasClass('plum')).to.be.ok();
-      expect($purple.eq(2).hasClass('grape')).to.be.ok();
-      expect($purple.eq(3).hasClass('plum')).to.be.ok();
+      expect($purple.cheerio).toBeTruthy();
+      expect($purple.each).toBeTruthy();
+      expect($purple.length).toBe(4);
+      expect($purple.eq(0).hasClass('grape')).toBeTruthy();
+      expect($purple.eq(1).hasClass('plum')).toBeTruthy();
+      expect($purple.eq(2).hasClass('grape')).toBeTruthy();
+      expect($purple.eq(3).hasClass('plum')).toBeTruthy();
     });
 
     it('(single) should return the existing element for chaining', function () {
       var $pear = $('.pear').insertAfter('.apple');
-      expect($pear.cheerio).to.be.ok();
-      expect($pear.each).to.be.ok();
-      expect($pear.length).to.be(1);
-      expect($pear.hasClass('pear')).to.be.ok();
+      expect($pear.cheerio).toBeTruthy();
+      expect($pear.each).toBeTruthy();
+      expect($pear.length).toBe(1);
+      expect($pear.hasClass('pear')).toBeTruthy();
     });
 
     it('(single) should return the existing elements for chaining', function () {
       var $things = $('.orange, .apple').insertAfter('.pear');
-      expect($things.cheerio).to.be.ok();
-      expect($things.each).to.be.ok();
-      expect($things.length).to.be(2);
-      expect($things.eq(0).hasClass('apple')).to.be.ok();
-      expect($things.eq(1).hasClass('orange')).to.be.ok();
+      expect($things.cheerio).toBeTruthy();
+      expect($things.each).toBeTruthy();
+      expect($things.length).toBe(2);
+      expect($things.eq(0).hasClass('apple')).toBeTruthy();
+      expect($things.eq(1).hasClass('orange')).toBeTruthy();
     });
 
     it('(multiple) should return the existing elements for chaining', function () {
       $('<li class="grape">Grape</li>').insertAfter('.apple');
       var $things = $('.orange, .apple').insertAfter('.pear, .grape');
-      expect($things.cheerio).to.be.ok();
-      expect($things.each).to.be.ok();
-      expect($things.length).to.be(4);
-      expect($things.eq(0).hasClass('apple')).to.be.ok();
-      expect($things.eq(1).hasClass('orange')).to.be.ok();
-      expect($things.eq(2).hasClass('apple')).to.be.ok();
-      expect($things.eq(3).hasClass('orange')).to.be.ok();
+      expect($things.cheerio).toBeTruthy();
+      expect($things.each).toBeTruthy();
+      expect($things.length).toBe(4);
+      expect($things.eq(0).hasClass('apple')).toBeTruthy();
+      expect($things.eq(1).hasClass('orange')).toBeTruthy();
+      expect($things.eq(2).hasClass('apple')).toBeTruthy();
+      expect($things.eq(3).hasClass('orange')).toBeTruthy();
     });
   });
 
   describe('.before', function () {
     it('() : should do nothing', function () {
-      expect($('#fruits').before()[0].tagName).to.equal('ul');
+      expect($('#fruits').before()[0].tagName).toBe('ul');
     });
 
     it('(html) : should add element as previous sibling', function () {
       var grape = '<li class="grape">Grape</li>';
       $('.apple').before(grape);
-      expect($('.apple').prev().hasClass('grape')).to.be.ok();
+      expect($('.apple').prev().hasClass('grape')).toBeTruthy();
     });
 
     it('($(...)) : should add element as previous sibling', function () {
       var $plum = $('<li class="plum">Plum</li>');
       $('.apple').before($plum);
-      expect($('.apple').prev().hasClass('plum')).to.be.ok();
+      expect($('.apple').prev().hasClass('plum')).toBeTruthy();
     });
 
     it('(Node) : should add element as previous sibling', function () {
       var plum = $('<li class="plum">Plum</li>')[0];
       $('.apple').before(plum);
-      expect($('.apple').prev().hasClass('plum')).to.be.ok();
+      expect($('.apple').prev().hasClass('plum')).toBeTruthy();
     });
 
     it('(existing Node) : should remove existing nodes from previous locations', function () {
@@ -1096,27 +1100,27 @@ describe('$(...)', function () {
       $('.apple').before(pear);
 
       var $children = $fruits.children();
-      expect($children).to.have.length(3);
-      expect($children[0]).to.be(pear);
+      expect($children).toHaveLength(3);
+      expect($children[0]).toBe(pear);
     });
 
     it('(existing Node) : should update original direct siblings', function () {
       $('.apple').before($('.orange'));
-      expect($('.apple').next()[0]).to.be($('.pear')[0]);
-      expect($('.pear').prev()[0]).to.be($('.apple')[0]);
+      expect($('.apple').next()[0]).toBe($('.pear')[0]);
+      expect($('.pear').prev()[0]).toBe($('.apple')[0]);
     });
 
     it('(existing Node) : should clone all but the last occurrence', function () {
       var $originalPear = $('.pear');
       $('.apple, .orange').before($originalPear);
 
-      expect($('.pear')).to.have.length(2);
-      expect($('.pear').eq(0).prev()).to.have.length(0);
-      expect($('.pear').eq(0).next()[0]).to.be($('.apple')[0]);
-      expect($('.pear').eq(1).prev()[0]).to.be($('.apple')[0]);
-      expect($('.pear').eq(1).next()[0]).to.be($('.orange')[0]);
-      expect($('.pear')[0]).to.not.eql($originalPear[0]);
-      expect($('.pear')[1]).to.eql($originalPear[0]);
+      expect($('.pear')).toHaveLength(2);
+      expect($('.pear').eq(0).prev()).toHaveLength(0);
+      expect($('.pear').eq(0).next()[0]).toBe($('.apple')[0]);
+      expect($('.pear').eq(1).prev()[0]).toBe($('.apple')[0]);
+      expect($('.pear').eq(1).next()[0]).toBe($('.orange')[0]);
+      expect($('.pear')[0]).not.toStrictEqual($originalPear[0]);
+      expect($('.pear')[1]).toStrictEqual($originalPear[0]);
     });
 
     it('(elem) : should handle if removed', function () {
@@ -1125,7 +1129,7 @@ describe('$(...)', function () {
 
       $apple.remove();
       $apple.before($plum);
-      expect($plum.next()).to.be.empty();
+      expect($plum.next()).toHaveLength(0);
     });
 
     it('(Array) : should add all elements in the array as previous sibling', function () {
@@ -1133,16 +1137,16 @@ describe('$(...)', function () {
         '<li class="plum">Plum</li><li class="grape">Grape</li>'
       ).get();
       $('.apple').before(more);
-      expect($fruits.children().eq(0).hasClass('plum')).to.be.ok();
-      expect($fruits.children().eq(1).hasClass('grape')).to.be.ok();
+      expect($fruits.children().eq(0).hasClass('plum')).toBeTruthy();
+      expect($fruits.children().eq(1).hasClass('grape')).toBeTruthy();
     });
 
     it('($(...), html) : should add multiple elements as previous siblings', function () {
       var $plum = $('<li class="plum">Plum</li>');
       var grape = '<li class="grape">Grape</li>';
       $('.apple').before($plum, grape);
-      expect($('.apple').prev().hasClass('grape')).to.be.ok();
-      expect($('.grape').prev().hasClass('plum')).to.be.ok();
+      expect($('.apple').prev().hasClass('grape')).toBeTruthy();
+      expect($('.grape').prev().hasClass('plum')).toBeTruthy();
     });
 
     it('(fn) : should invoke the callback with the correct arguments and context', function () {
@@ -1151,16 +1155,16 @@ describe('$(...)', function () {
       $fruits = $fruits.children();
 
       $fruits.before(function () {
-        args.push(toArray(arguments));
+        args.push(Array.from(arguments));
         thisValues.push(this);
       });
 
-      expect(args).to.eql([
+      expect(args).toStrictEqual([
         [0, 'Apple'],
         [1, 'Orange'],
         [2, 'Pear'],
       ]);
-      expect(thisValues).to.eql([$fruits[0], $fruits[1], $fruits[2]]);
+      expect(thisValues).toStrictEqual([$fruits[0], $fruits[1], $fruits[2]]);
     });
 
     it('(fn) : should add returned string as previous sibling', function () {
@@ -1170,9 +1174,9 @@ describe('$(...)', function () {
         return '<li class="first">';
       });
 
-      expect($('.first')[0]).to.equal($('#fruits').contents()[0]);
-      expect($('.first')[1]).to.equal($('#fruits').contents()[2]);
-      expect($('.first')[2]).to.equal($('#fruits').contents()[4]);
+      expect($('.first')[0]).toBe($('#fruits').contents()[0]);
+      expect($('.first')[1]).toBe($('#fruits').contents()[2]);
+      expect($('.first')[2]).toBe($('#fruits').contents()[4]);
     });
 
     it('(fn) : should add returned Cheerio object as previous sibling', function () {
@@ -1182,9 +1186,9 @@ describe('$(...)', function () {
         return $('<li class="second">');
       });
 
-      expect($('.second')[0]).to.equal($('#fruits').contents()[0]);
-      expect($('.second')[1]).to.equal($('#fruits').contents()[2]);
-      expect($('.second')[2]).to.equal($('#fruits').contents()[4]);
+      expect($('.second')[0]).toBe($('#fruits').contents()[0]);
+      expect($('.second')[1]).toBe($('#fruits').contents()[2]);
+      expect($('.second')[2]).toBe($('#fruits').contents()[4]);
     });
 
     it('(fn) : should add returned Node as previous sibling', function () {
@@ -1194,19 +1198,19 @@ describe('$(...)', function () {
         return $('<li class="third">')[0];
       });
 
-      expect($('.third')[0]).to.equal($('#fruits').contents()[0]);
-      expect($('.third')[1]).to.equal($('#fruits').contents()[2]);
-      expect($('.third')[2]).to.equal($('#fruits').contents()[4]);
+      expect($('.third')[0]).toBe($('#fruits').contents()[0]);
+      expect($('.third')[1]).toBe($('#fruits').contents()[2]);
+      expect($('.third')[2]).toBe($('#fruits').contents()[4]);
     });
 
     it('($(...)) : should remove from root element', function () {
       var $plum = $('<li class="plum">Plum</li>');
       var root = $plum[0].parent;
-      expect(root.type).to.be('root');
+      expect(root.type).toBe('root');
 
       $fruits.before($plum);
-      expect($plum[0].parent.type).to.not.be('root');
-      expect(root.childNodes).to.not.contain($plum[0]);
+      expect($plum[0].parent.type).not.toBe('root');
+      expect(root.childNodes).not.toContain($plum[0]);
     });
   });
 
@@ -1214,63 +1218,63 @@ describe('$(...)', function () {
     it('(selector) : should create element and add as prev sibling', function () {
       var grape = $('<li class="grape">Grape</li>');
       grape.insertBefore('.apple');
-      expect($('.apple').prev().hasClass('grape')).to.be.ok();
+      expect($('.apple').prev().hasClass('grape')).toBeTruthy();
     });
 
     it('(selector) : should create element and add as prev sibling of multiple elements', function () {
       var grape = $('<li class="grape">Grape</li>');
       grape.insertBefore('.apple, .pear');
-      expect($('.apple').prev().hasClass('grape')).to.be.ok();
-      expect($('.pear').prev().hasClass('grape')).to.be.ok();
+      expect($('.apple').prev().hasClass('grape')).toBeTruthy();
+      expect($('.pear').prev().hasClass('grape')).toBeTruthy();
     });
 
     it('($(...)) : should create element and add as prev sibling', function () {
       var grape = $('<li class="grape">Grape</li>');
       grape.insertBefore($('.apple'));
-      expect($('.apple').prev().hasClass('grape')).to.be.ok();
+      expect($('.apple').prev().hasClass('grape')).toBeTruthy();
     });
 
     it('($(...)) : should create element and add as next sibling of multiple elements', function () {
       var grape = $('<li class="grape">Grape</li>');
       grape.insertBefore($('.apple, .pear'));
-      expect($('.apple').prev().hasClass('grape')).to.be.ok();
-      expect($('.pear').prev().hasClass('grape')).to.be.ok();
+      expect($('.apple').prev().hasClass('grape')).toBeTruthy();
+      expect($('.pear').prev().hasClass('grape')).toBeTruthy();
     });
 
     it('($(...)) : should create all elements in the array and add as prev siblings', function () {
       var more = $('<li class="plum">Plum</li><li class="grape">Grape</li>');
       more.insertBefore($('.apple'));
-      expect($fruits.children().eq(0).hasClass('plum')).to.be.ok();
-      expect($fruits.children().eq(1).hasClass('grape')).to.be.ok();
-      expect($fruits.children().eq(2).hasClass('apple')).to.be.ok();
+      expect($fruits.children().eq(0).hasClass('plum')).toBeTruthy();
+      expect($fruits.children().eq(1).hasClass('grape')).toBeTruthy();
+      expect($fruits.children().eq(2).hasClass('apple')).toBeTruthy();
     });
 
     it('(existing Node) : should remove existing nodes from previous locations', function () {
       $('.pear').insertBefore('.apple');
-      expect($fruits.children().eq(2).hasClass('pear')).to.not.be.ok();
-      expect($fruits.children().length).to.be(3);
-      expect($('.pear').length).to.be(1);
+      expect($fruits.children().eq(2).hasClass('pear')).toBeFalsy();
+      expect($fruits.children().length).toBe(3);
+      expect($('.pear').length).toBe(1);
     });
 
     it('(existing Node) : should update original direct siblings', function () {
       $('.pear').insertBefore('.apple');
-      expect($('.apple').prev().hasClass('pear')).to.be.ok();
-      expect($('.apple').next().hasClass('orange')).to.be.ok();
-      expect($('.pear').next().hasClass('apple')).to.be.ok();
-      expect($('.pear').prev()).to.be.empty();
+      expect($('.apple').prev().hasClass('pear')).toBeTruthy();
+      expect($('.apple').next().hasClass('orange')).toBeTruthy();
+      expect($('.pear').next().hasClass('apple')).toBeTruthy();
+      expect($('.pear').prev()).toHaveLength(0);
     });
 
     it('(existing Node) : should update original direct siblings of multiple elements', function () {
       $('.pear').insertBefore('.apple, .orange');
-      expect($('.apple').prev().hasClass('pear')).to.be.ok();
-      expect($('.apple').next().hasClass('pear')).to.be.ok();
-      expect($('.orange').prev().hasClass('pear')).to.be.ok();
-      expect($('.orange').next()).to.be.empty();
-      expect($fruits.children().length).to.be(4);
+      expect($('.apple').prev().hasClass('pear')).toBeTruthy();
+      expect($('.apple').next().hasClass('pear')).toBeTruthy();
+      expect($('.orange').prev().hasClass('pear')).toBeTruthy();
+      expect($('.orange').next()).toHaveLength(0);
+      expect($fruits.children().length).toBe(4);
       var pears = $('.pear');
-      expect(pears.length).to.be(2);
-      expect(pears.eq(0).next().hasClass('apple')).to.be.ok();
-      expect(pears.eq(1).next().hasClass('orange')).to.be.ok();
+      expect(pears.length).toBe(2);
+      expect(pears.eq(0).next().hasClass('apple')).toBeTruthy();
+      expect(pears.eq(1).next().hasClass('orange')).toBeTruthy();
     });
 
     it('(elem) : should handle if removed', function () {
@@ -1279,97 +1283,97 @@ describe('$(...)', function () {
 
       $apple.remove();
       $plum.insertBefore($apple);
-      expect($plum.next()).to.be.empty();
+      expect($plum.next()).toHaveLength(0);
     });
 
     it('(single) should return the new element for chaining', function () {
       var $grape = $('<li class="grape">Grape</li>').insertBefore('.apple');
-      expect($grape.cheerio).to.be.ok();
-      expect($grape.each).to.be.ok();
-      expect($grape.length).to.be(1);
-      expect($grape.hasClass('grape')).to.be.ok();
+      expect($grape.cheerio).toBeTruthy();
+      expect($grape.each).toBeTruthy();
+      expect($grape.length).toBe(1);
+      expect($grape.hasClass('grape')).toBeTruthy();
     });
 
     it('(single) should return the new elements for chaining', function () {
       var $purple = $(
         '<li class="grape">Grape</li><li class="plum">Plum</li>'
       ).insertBefore('.apple');
-      expect($purple.cheerio).to.be.ok();
-      expect($purple.each).to.be.ok();
-      expect($purple.length).to.be(2);
-      expect($purple.eq(0).hasClass('grape')).to.be.ok();
-      expect($purple.eq(1).hasClass('plum')).to.be.ok();
+      expect($purple.cheerio).toBeTruthy();
+      expect($purple.each).toBeTruthy();
+      expect($purple.length).toBe(2);
+      expect($purple.eq(0).hasClass('grape')).toBeTruthy();
+      expect($purple.eq(1).hasClass('plum')).toBeTruthy();
     });
 
     it('(multiple) should return the new elements for chaining', function () {
       var $purple = $(
         '<li class="grape">Grape</li><li class="plum">Plum</li>'
       ).insertBefore('.apple, .pear');
-      expect($purple.cheerio).to.be.ok();
-      expect($purple.each).to.be.ok();
-      expect($purple.length).to.be(4);
-      expect($purple.eq(0).hasClass('grape')).to.be.ok();
-      expect($purple.eq(1).hasClass('plum')).to.be.ok();
-      expect($purple.eq(2).hasClass('grape')).to.be.ok();
-      expect($purple.eq(3).hasClass('plum')).to.be.ok();
+      expect($purple.cheerio).toBeTruthy();
+      expect($purple.each).toBeTruthy();
+      expect($purple.length).toBe(4);
+      expect($purple.eq(0).hasClass('grape')).toBeTruthy();
+      expect($purple.eq(1).hasClass('plum')).toBeTruthy();
+      expect($purple.eq(2).hasClass('grape')).toBeTruthy();
+      expect($purple.eq(3).hasClass('plum')).toBeTruthy();
     });
 
     it('(single) should return the existing element for chaining', function () {
       var $orange = $('.orange').insertBefore('.apple');
-      expect($orange.cheerio).to.be.ok();
-      expect($orange.each).to.be.ok();
-      expect($orange.length).to.be(1);
-      expect($orange.hasClass('orange')).to.be.ok();
+      expect($orange.cheerio).toBeTruthy();
+      expect($orange.each).toBeTruthy();
+      expect($orange.length).toBe(1);
+      expect($orange.hasClass('orange')).toBeTruthy();
     });
 
     it('(single) should return the existing elements for chaining', function () {
       var $things = $('.orange, .pear').insertBefore('.apple');
-      expect($things.cheerio).to.be.ok();
-      expect($things.each).to.be.ok();
-      expect($things.length).to.be(2);
-      expect($things.eq(0).hasClass('orange')).to.be.ok();
-      expect($things.eq(1).hasClass('pear')).to.be.ok();
+      expect($things.cheerio).toBeTruthy();
+      expect($things.each).toBeTruthy();
+      expect($things.length).toBe(2);
+      expect($things.eq(0).hasClass('orange')).toBeTruthy();
+      expect($things.eq(1).hasClass('pear')).toBeTruthy();
     });
 
     it('(multiple) should return the existing elements for chaining', function () {
       $('<li class="grape">Grape</li>').insertBefore('.apple');
       var $things = $('.orange, .apple').insertBefore('.pear, .grape');
-      expect($things.cheerio).to.be.ok();
-      expect($things.each).to.be.ok();
-      expect($things.length).to.be(4);
-      expect($things.eq(0).hasClass('apple')).to.be.ok();
-      expect($things.eq(1).hasClass('orange')).to.be.ok();
-      expect($things.eq(2).hasClass('apple')).to.be.ok();
-      expect($things.eq(3).hasClass('orange')).to.be.ok();
+      expect($things.cheerio).toBeTruthy();
+      expect($things.each).toBeTruthy();
+      expect($things.length).toBe(4);
+      expect($things.eq(0).hasClass('apple')).toBeTruthy();
+      expect($things.eq(1).hasClass('orange')).toBeTruthy();
+      expect($things.eq(2).hasClass('apple')).toBeTruthy();
+      expect($things.eq(3).hasClass('orange')).toBeTruthy();
     });
   });
 
   describe('.remove', function () {
     it('() : should remove selected elements', function () {
       $('.apple').remove();
-      expect($fruits.find('.apple')).to.have.length(0);
+      expect($fruits.find('.apple')).toHaveLength(0);
     });
 
     it('() : should be reentrant', function () {
       var $apple = $('.apple');
       $apple.remove();
       $apple.remove();
-      expect($fruits.find('.apple')).to.have.length(0);
+      expect($fruits.find('.apple')).toHaveLength(0);
     });
 
     it('(selector) : should remove matching selected elements', function () {
       $('li').remove('.apple');
-      expect($fruits.find('.apple')).to.have.length(0);
+      expect($fruits.find('.apple')).toHaveLength(0);
     });
 
     it('($(...)) : should remove from root element', function () {
       var $plum = $('<li class="plum">Plum</li>');
       var root = $plum[0].parent;
-      expect(root.type).to.be('root');
+      expect(root.type).toBe('root');
 
       $plum.remove();
-      expect($plum[0].parent).to.be(null);
-      expect(root.childNodes).to.not.contain($plum[0]);
+      expect($plum[0].parent).toBe(null);
+      expect(root.childNodes).not.toContain($plum[0]);
     });
   });
 
@@ -1377,10 +1381,10 @@ describe('$(...)', function () {
     it('(elem) : should replace one <li> tag with another', function () {
       var $plum = $('<li class="plum">Plum</li>');
       $('.orange').replaceWith($plum);
-      expect($('.apple').next().hasClass('plum')).to.be.ok();
-      expect($('.apple').next().html()).to.equal('Plum');
-      expect($('.pear').prev().hasClass('plum')).to.be.ok();
-      expect($('.pear').prev().html()).to.equal('Plum');
+      expect($('.apple').next().hasClass('plum')).toBeTruthy();
+      expect($('.apple').next().html()).toBe('Plum');
+      expect($('.pear').prev().hasClass('plum')).toBeTruthy();
+      expect($('.pear').prev().html()).toBe('Plum');
     });
 
     it('(Array) : should replace one <li> tag with the elements in the array', function () {
@@ -1389,27 +1393,27 @@ describe('$(...)', function () {
       ).get();
       $('.orange').replaceWith(more);
 
-      expect($fruits.children().eq(1).hasClass('plum')).to.be.ok();
-      expect($fruits.children().eq(2).hasClass('grape')).to.be.ok();
-      expect($('.apple').next().hasClass('plum')).to.be.ok();
-      expect($('.pear').prev().hasClass('grape')).to.be.ok();
-      expect($fruits.children()).to.have.length(4);
+      expect($fruits.children().eq(1).hasClass('plum')).toBeTruthy();
+      expect($fruits.children().eq(2).hasClass('grape')).toBeTruthy();
+      expect($('.apple').next().hasClass('plum')).toBeTruthy();
+      expect($('.pear').prev().hasClass('grape')).toBeTruthy();
+      expect($fruits.children()).toHaveLength(4);
     });
 
     it('(Node) : should replace the selected element with given node', function () {
       var $src = $('<h2>hi <span>there</span></h2>');
       var $new = $('<ul></ul>');
       var $replaced = $src.find('span').replaceWith($new[0]);
-      expect($new[0].parentNode).to.equal($src[0]);
-      expect($replaced[0].parentNode).to.equal(null);
-      expect($.html($src)).to.equal('<h2>hi <ul></ul></h2>');
+      expect($new[0].parentNode).toBe($src[0]);
+      expect($replaced[0].parentNode).toBe(null);
+      expect($.html($src)).toBe('<h2>hi <ul></ul></h2>');
     });
 
     it('(existing element) : should remove element from its previous location', function () {
       $('.pear').replaceWith($('.apple'));
-      expect($fruits.children()).to.have.length(2);
-      expect($fruits.children()[0]).to.equal($('.orange')[0]);
-      expect($fruits.children()[1]).to.equal($('.apple')[0]);
+      expect($fruits.children()).toHaveLength(2);
+      expect($fruits.children()[0]).toBe($('.orange')[0]);
+      expect($fruits.children()[1]).toBe($('.apple')[0]);
     });
 
     it('(elem) : should NOP if removed', function () {
@@ -1418,16 +1422,16 @@ describe('$(...)', function () {
 
       $pear.remove();
       $pear.replaceWith($plum);
-      expect($('.orange').next().hasClass('plum')).to.not.be.ok();
+      expect($('.orange').next().hasClass('plum')).toBeFalsy();
     });
 
     it('(elem) : should replace the single selected element with given element', function () {
       var $src = $('<h2>hi <span>there</span></h2>');
       var $new = $('<div>here</div>');
       var $replaced = $src.find('span').replaceWith($new);
-      expect($new[0].parentNode).to.equal($src[0]);
-      expect($replaced[0].parentNode).to.equal(null);
-      expect($.html($src)).to.equal('<h2>hi <div>here</div></h2>');
+      expect($new[0].parentNode).toBe($src[0]);
+      expect($replaced[0].parentNode).toBe(null);
+      expect($.html($src)).toBe('<h2>hi <div>here</div></h2>');
     });
 
     it('(self) : should be replaced after replacing it with itself', function () {
@@ -1437,22 +1441,22 @@ describe('$(...)', function () {
         return el;
       });
       $a('a').replaceWith(replacement);
-      expect($a.html()).to.be.equal(replacement);
+      expect($a.html()).toBe(replacement);
     });
 
     it('(str) : should accept strings', function () {
       var $src = $('<h2>hi <span>there</span></h2>');
       var newStr = '<div>here</div>';
       var $replaced = $src.find('span').replaceWith(newStr);
-      expect($replaced[0].parentNode).to.equal(null);
-      expect($.html($src)).to.equal('<h2>hi <div>here</div></h2>');
+      expect($replaced[0].parentNode).toBe(null);
+      expect($.html($src)).toBe('<h2>hi <div>here</div></h2>');
     });
 
     it('(str) : should replace all selected elements', function () {
       var $src = $('<b>a<br>b<br>c<br>d</b>');
       var $replaced = $src.find('br').replaceWith(' ');
-      expect($replaced[0].parentNode).to.equal(null);
-      expect($.html($src)).to.equal('<b>a b c d</b>');
+      expect($replaced[0].parentNode).toBe(null);
+      expect($.html($src)).toBe('<b>a b c d</b>');
     });
 
     it('(fn) : should invoke the callback with the correct argument and context', function () {
@@ -1461,17 +1465,17 @@ describe('$(...)', function () {
       var thisValues = [];
 
       $fruits.children().replaceWith(function () {
-        args.push(toArray(arguments));
+        args.push(Array.from(arguments));
         thisValues.push(this);
         return '<li class="first">';
       });
 
-      expect(args).to.eql([
+      expect(args).toStrictEqual([
         [0, origChildren[0]],
         [1, origChildren[1]],
         [2, origChildren[2]],
       ]);
-      expect(thisValues).to.eql([
+      expect(thisValues).toStrictEqual([
         origChildren[0],
         origChildren[1],
         origChildren[2],
@@ -1483,7 +1487,7 @@ describe('$(...)', function () {
         return '<li class="first">';
       });
 
-      expect($fruits.find('.first')).to.have.length(3);
+      expect($fruits.find('.first')).toHaveLength(3);
     });
 
     it('(fn) : should replace the selected element with the returned Cheerio object', function () {
@@ -1491,7 +1495,7 @@ describe('$(...)', function () {
         return $('<li class="second">');
       });
 
-      expect($fruits.find('.second')).to.have.length(3);
+      expect($fruits.find('.second')).toHaveLength(3);
     });
 
     it('(fn) : should replace the selected element with the returned node', function () {
@@ -1499,40 +1503,40 @@ describe('$(...)', function () {
         return $('<li class="third">')[0];
       });
 
-      expect($fruits.find('.third')).to.have.length(3);
+      expect($fruits.find('.third')).toHaveLength(3);
     });
 
     it('($(...)) : should remove from root element', function () {
       var $plum = $('<li class="plum">Plum</li>');
       var root = $plum[0].parent;
-      expect(root.type).to.be('root');
+      expect(root.type).toBe('root');
 
       $fruits.children().replaceWith($plum);
-      expect($plum[0].parent.type).to.not.be('root');
-      expect(root.childNodes).to.not.contain($plum[0]);
+      expect($plum[0].parent.type).not.toBe('root');
+      expect(root.childNodes).not.toContain($plum[0]);
     });
   });
 
   describe('.empty', function () {
     it('() : should remove all children from selected elements', function () {
-      expect($fruits.children()).to.have.length(3);
+      expect($fruits.children()).toHaveLength(3);
 
       $fruits.empty();
-      expect($fruits.children()).to.have.length(0);
+      expect($fruits.children()).toHaveLength(0);
     });
 
     it('() : should allow element reinsertion', function () {
       var $children = $fruits.children();
 
       $fruits.empty();
-      expect($fruits.children()).to.have.length(0);
-      expect($children).to.have.length(3);
+      expect($fruits.children()).toHaveLength(0);
+      expect($children).toHaveLength(3);
 
       $fruits.append($('<div></div><div></div>'));
       var $remove = $fruits.children().eq(0);
 
       $remove.replaceWith($children);
-      expect($fruits.children()).to.have.length(4);
+      expect($fruits.children()).toHaveLength(4);
     });
 
     it("() : should destroy children's references to the parent", function () {
@@ -1540,21 +1544,21 @@ describe('$(...)', function () {
 
       $fruits.empty();
 
-      expect($children.eq(0).parent()).to.have.length(0);
-      expect($children.eq(0).next()).to.have.length(0);
-      expect($children.eq(0).prev()).to.have.length(0);
-      expect($children.eq(1).parent()).to.have.length(0);
-      expect($children.eq(1).next()).to.have.length(0);
-      expect($children.eq(1).prev()).to.have.length(0);
-      expect($children.eq(2).parent()).to.have.length(0);
-      expect($children.eq(2).next()).to.have.length(0);
-      expect($children.eq(2).prev()).to.have.length(0);
+      expect($children.eq(0).parent()).toHaveLength(0);
+      expect($children.eq(0).next()).toHaveLength(0);
+      expect($children.eq(0).prev()).toHaveLength(0);
+      expect($children.eq(1).parent()).toHaveLength(0);
+      expect($children.eq(1).next()).toHaveLength(0);
+      expect($children.eq(1).prev()).toHaveLength(0);
+      expect($children.eq(2).parent()).toHaveLength(0);
+      expect($children.eq(2).next()).toHaveLength(0);
+      expect($children.eq(2).prev()).toHaveLength(0);
     });
   });
 
   describe('.html', function () {
     it('() : should get the innerHTML for an element', function () {
-      expect($fruits.html()).to.equal(
+      expect($fruits.html()).toBe(
         [
           '<li class="apple">Apple</li>',
           '<li class="orange">Orange</li>',
@@ -1565,18 +1569,18 @@ describe('$(...)', function () {
 
     it('() : should get innerHTML even if its just text', function () {
       var item = '<li class="pear">Pear</li>';
-      expect($('.pear', item).html()).to.equal('Pear');
+      expect($('.pear', item).html()).toBe('Pear');
     });
 
     it('() : should return empty string if nothing inside', function () {
       var item = '<li></li>';
-      expect($('li', item).html()).to.equal('');
+      expect($('li', item).html()).toBe('');
     });
 
     it('(html) : should set the html for its children', function () {
       $fruits.html('<li class="durian">Durian</li>');
       var html = $fruits.html();
-      expect(html).to.equal('<li class="durian">Durian</li>');
+      expect(html).toBe('<li class="durian">Durian</li>');
     });
 
     it('(html) : should add new elements for each element in selection', function () {
@@ -1584,75 +1588,75 @@ describe('$(...)', function () {
       $fruits.html('<li class="durian">Durian</li>');
       var tested = 0;
       $fruits.each(function () {
-        expect($(this).children().parent().get(0)).to.equal(this);
+        expect($(this).children().parent().get(0)).toBe(this);
         tested++;
       });
-      expect(tested).to.equal(3);
+      expect(tested).toBe(3);
     });
 
     it('(elem) : should set the html for its children with element', function () {
       $fruits.html($('<li class="durian">Durian</li>'));
       var html = $fruits.html();
-      expect(html).to.equal('<li class="durian">Durian</li>');
+      expect(html).toBe('<li class="durian">Durian</li>');
     });
 
     it('() : should allow element reinsertion', function () {
       var $children = $fruits.children();
 
       $fruits.html('<div></div><div></div>');
-      expect($fruits.children()).to.have.length(2);
+      expect($fruits.children()).toHaveLength(2);
 
       var $remove = $fruits.children().eq(0);
 
       $remove.replaceWith($children);
-      expect($fruits.children()).to.have.length(4);
+      expect($fruits.children()).toHaveLength(4);
     });
   });
 
   describe('.toString', function () {
     it('() : should get the outerHTML for an element', function () {
-      expect($fruits.toString()).to.equal(fruits);
+      expect($fruits.toString()).toBe(fruits);
     });
 
     it('() : should return an html string for a set of elements', function () {
-      expect($fruits.find('li').toString()).to.equal(
+      expect($fruits.find('li').toString()).toBe(
         '<li class="apple">Apple</li><li class="orange">Orange</li><li class="pear">Pear</li>'
       );
     });
 
     it('() : should be called implicitly', function () {
       var string = [$('<foo>'), $('<bar>'), $('<baz>')].join('');
-      expect(string).to.equal('<foo></foo><bar></bar><baz></baz>');
+      expect(string).toBe('<foo></foo><bar></bar><baz></baz>');
     });
 
     it('() : should pass options', function () {
       var dom = cheerio.load('&', { xml: { decodeEntities: false } });
-      expect(dom.root().toString()).to.equal('&');
+      expect(dom.root().toString()).toBe('&');
     });
   });
 
   describe('.text', function () {
     it('() : gets the text for a single element', function () {
-      expect($('.apple').text()).to.equal('Apple');
+      expect($('.apple').text()).toBe('Apple');
     });
 
     it('() : combines all text from children text nodes', function () {
-      expect($('#fruits').text()).to.equal('AppleOrangePear');
+      expect($('#fruits').text()).toBe('AppleOrangePear');
     });
 
     it('(text) : sets the text for the child node', function () {
       $('.apple').text('Granny Smith Apple');
-      expect($('.apple')[0].childNodes[0].data).to.equal('Granny Smith Apple');
+      expect($('.apple')[0].childNodes[0].data).toBe('Granny Smith Apple');
     });
 
     it('(text) : inserts separate nodes for all children', function () {
       $('li').text('Fruits');
       var tested = 0;
       $('li').each(function () {
-        expect(this.childNodes[0].parentNode).to.equal(this);
+        expect(this.childNodes[0].parentNode).toBe(this);
         tested++;
       });
-      expect(tested).to.equal(3);
+      expect(tested).toBe(3);
     });
 
     it('(text) : should create a Node with the DOM level 1 API', function () {
@@ -1661,18 +1665,18 @@ describe('$(...)', function () {
       $apple.text('anything');
       var textNode = $apple[0].childNodes[0];
 
-      expect(textNode.parentNode).to.be($apple[0]);
-      expect(textNode.nodeType).to.be(3);
-      expect(textNode.data).to.be('anything');
+      expect(textNode.parentNode).toBe($apple[0]);
+      expect(textNode.nodeType).toBe(3);
+      expect(textNode.data).toBe('anything');
     });
 
     it('should allow functions as arguments', function () {
       $('.apple').text(function (idx, content) {
-        expect(idx).to.equal(0);
-        expect(content).to.equal('Apple');
+        expect(idx).toBe(0);
+        expect(content).toBe('Apple');
         return 'whatever mate';
       });
-      expect($('.apple')[0].childNodes[0].data).to.equal('whatever mate');
+      expect($('.apple')[0].childNodes[0].data).toBe('whatever mate');
     });
 
     it('should allow functions as arguments for multiple elements', function () {
@@ -1680,52 +1684,50 @@ describe('$(...)', function () {
         return 'text' + idx;
       });
       $('li').each(function (idx) {
-        expect(this.childNodes[0].data).to.equal('text' + idx);
+        expect(this.childNodes[0].data).toBe('text' + idx);
       });
     });
 
     it('should decode special chars', function () {
       var text = $('<p>M&amp;M</p>').text();
-      expect(text).to.equal('M&M');
+      expect(text).toBe('M&M');
     });
 
     it('should work with special chars added as strings', function () {
       var text = $('<p>M&M</p>').text();
-      expect(text).to.equal('M&M');
+      expect(text).toBe('M&M');
     });
 
     it('( undefined ) : should act as an accessor', function () {
       var $div = $('<div>test</div>');
-      expect($div.text(undefined)).to.be.a('string');
-      expect($div.text()).to.be('test');
+      expect(typeof $div.text(undefined)).toBe('string');
+      expect($div.text()).toBe('test');
     });
 
     it('( "" ) : should convert to string', function () {
       var $div = $('<div>test</div>');
-      expect($div.text('').text()).to.equal('');
+      expect($div.text('').text()).toBe('');
     });
 
     it('( null ) : should convert to string', function () {
-      expect($('<div>').text(null).text()).to.equal('null');
+      expect($('<div>').text(null).text()).toBe('null');
     });
 
     it('( 0 ) : should convert to string', function () {
-      expect($('<div>').text(0).text()).to.equal('0');
+      expect($('<div>').text(0).text()).toBe('0');
     });
 
     it('(str) should encode then decode unsafe characters', function () {
       var $apple = $('.apple');
 
       $apple.text('blah <script>alert("XSS!")</script> blah');
-      expect($apple[0].childNodes[0].data).to.equal(
+      expect($apple[0].childNodes[0].data).toBe(
         'blah <script>alert("XSS!")</script> blah'
       );
-      expect($apple.text()).to.equal(
-        'blah <script>alert("XSS!")</script> blah'
-      );
+      expect($apple.text()).toBe('blah <script>alert("XSS!")</script> blah');
 
       $apple.text('blah <script>alert("XSS!")</script> blah');
-      expect($apple.html()).to.not.contain('<script>alert("XSS!")</script>');
+      expect($apple.html()).not.toContain('<script>alert("XSS!")</script>');
     });
   });
 });

--- a/test/api/traversing.js
+++ b/test/api/traversing.js
@@ -1,9 +1,8 @@
-var expect = require('expect.js');
 var cheerio = require('../..');
-var food = require('../fixtures').food;
-var fruits = require('../fixtures').fruits;
-var drinks = require('../fixtures').drinks;
-var text = require('../fixtures').text;
+var food = require('../__fixtures__/fixtures').food;
+var fruits = require('../__fixtures__/fixtures').fruits;
+var drinks = require('../__fixtures__/fixtures').drinks;
+var text = require('../__fixtures__/fixtures').text;
 
 describe('$(...)', function () {
   var $;
@@ -14,77 +13,84 @@ describe('$(...)', function () {
 
   describe('.load', function () {
     it('should throw a TypeError if given invalid input', function () {
-      expect(function () {
-        cheerio.load();
-      }).to.throwException(function (err) {
-        expect(err).to.be.an(Error);
-        expect(err.message).to.be('cheerio.load() expects a string');
-      });
+      try {
+        (function () {
+          cheerio.load();
+        })();
+
+        throw Error('Function did not throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(Error);
+        expect(err.message).toBe('cheerio.load() expects a string');
+      }
     });
   });
 
   describe('.find', function () {
     it('() : should find nothing', function () {
-      expect($('ul').find()).to.have.length(0);
+      expect($('ul').find()).toHaveLength(0);
     });
 
     it('(single) : should find one descendant', function () {
-      expect($('#fruits').find('.apple')[0].attribs['class']).to.equal('apple');
+      expect($('#fruits').find('.apple')[0].attribs['class']).toBe('apple');
     });
 
     it('(many) : should find all matching descendant', function () {
-      expect($('#fruits').find('li')).to.have.length(3);
+      expect($('#fruits').find('li')).toHaveLength(3);
     });
 
     it('(many) : should merge all selected elems with matching descendants', function () {
-      expect($('#fruits, #food', food).find('.apple')).to.have.length(1);
+      expect($('#fruits, #food', food).find('.apple')).toHaveLength(1);
     });
 
     it('(invalid single) : should return empty if cant find', function () {
-      expect($('ul').find('blah')).to.have.length(0);
+      expect($('ul').find('blah')).toHaveLength(0);
     });
 
     it('(invalid single) : should query descendants only', function () {
-      expect($('#fruits').find('ul')).to.have.length(0);
+      expect($('#fruits').find('ul')).toHaveLength(0);
     });
 
     it('should return empty if search already empty result', function () {
-      expect($('#not-fruits').find('li')).to.have.length(0);
+      expect($('#not-fruits').find('li')).toHaveLength(0);
     });
 
     it('should lowercase selectors', function () {
-      expect($('#fruits').find('LI')).to.have.length(3);
+      expect($('#fruits').find('LI')).toHaveLength(3);
     });
 
     it('should query immediate descendant only', function () {
       var q = cheerio.load('<foo><bar><bar></bar><bar></bar></bar></foo>');
-      expect(q('foo').find('> bar')).to.have.length(1);
+      expect(q('foo').find('> bar')).toHaveLength(1);
     });
 
     it('should find siblings', function () {
       var q = cheerio.load('<p class=a><p class=b></p>');
-      expect(q('.a').find('+.b')).to.have.length(1);
-      expect(q('.a').find('~.b')).to.have.length(1);
-      // Should not find itself
-      expect(q('.a').find('+.a')).to.have.length(0);
-      expect(q('.a').find('~.a')).to.have.length(0);
+      expect(q('.a').find('+.b')).toHaveLength(1);
+      expect(q('.a').find('~.b')).toHaveLength(1);
+      expect(q('.a').find('+.a')).toHaveLength(0);
+      expect(q('.a').find('~.a')).toHaveLength(0);
     });
 
     it('should query case-sensitively when in xml mode', function () {
       var q = cheerio.load('<caseSenSitive allTheWay>', { xml: true });
-      expect(q('caseSenSitive')).to.have.length(1);
-      expect(q('[allTheWay]')).to.have.length(1);
-      expect(q('casesensitive')).to.have.length(0);
-      expect(q('[alltheway]')).to.have.length(0);
+      expect(q('caseSenSitive')).toHaveLength(1);
+      expect(q('[allTheWay]')).toHaveLength(1);
+      expect(q('casesensitive')).toHaveLength(0);
+      expect(q('[alltheway]')).toHaveLength(0);
     });
 
     it('should throw an Error if given an invalid selector', function () {
-      expect(function () {
-        $('#fruits').find(':bah');
-      }).to.throwException(function (err) {
-        expect(err).to.be.a(Error);
-        expect(err.message).to.contain('unmatched pseudo-class');
-      });
+      try {
+        (function () {
+          $('#fruits').find(':bah');
+        })();
+
+        throw Error('Function did not throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(Error);
+        expect(err.message).toContain('unmatched pseudo-class');
+      }
     });
 
     describe('(cheerio object) :', function () {
@@ -92,18 +98,18 @@ describe('$(...)', function () {
         var q = cheerio.load(food);
         var $selection = q('#fruits').find(q('li'));
 
-        expect($selection).to.have.length(3);
-        expect($selection[0]).to.be(q('.apple')[0]);
-        expect($selection[1]).to.be(q('.orange')[0]);
-        expect($selection[2]).to.be(q('.pear')[0]);
+        expect($selection).toHaveLength(3);
+        expect($selection[0]).toBe(q('.apple')[0]);
+        expect($selection[1]).toBe(q('.orange')[0]);
+        expect($selection[2]).toBe(q('.pear')[0]);
       });
       it('returns only those nodes contained within any element in the current selection', function () {
         var q = cheerio.load(food);
         var $selection = q('.apple, #vegetables').find(q('li'));
 
-        expect($selection).to.have.length(2);
-        expect($selection[0]).to.be(q('.carrot')[0]);
-        expect($selection[1]).to.be(q('.sweetcorn')[0]);
+        expect($selection).toHaveLength(2);
+        expect($selection[0]).toBe(q('.carrot')[0]);
+        expect($selection[1]).toBe(q('.sweetcorn')[0]);
       });
     });
 
@@ -112,45 +118,45 @@ describe('$(...)', function () {
         var q = cheerio.load(food);
         var $selection = q('#fruits').find(q('.apple')[0]);
 
-        expect($selection).to.have.length(1);
-        expect($selection[0]).to.be(q('.apple')[0]);
+        expect($selection).toHaveLength(1);
+        expect($selection[0]).toBe(q('.apple')[0]);
       });
       it('returns node when contained within any element the current selection', function () {
         var q = cheerio.load(food);
         var $selection = q('#fruits, #vegetables').find(q('.carrot')[0]);
 
-        expect($selection).to.have.length(1);
-        expect($selection[0]).to.be(q('.carrot')[0]);
+        expect($selection).toHaveLength(1);
+        expect($selection[0]).toBe(q('.carrot')[0]);
       });
       it('does not return node that is not contained within the current selection', function () {
         var q = cheerio.load(food);
         var $selection = q('#fruits').find(q('.carrot')[0]);
 
-        expect($selection).to.have.length(0);
+        expect($selection).toHaveLength(0);
       });
     });
   });
 
   describe('.children', function () {
     it('() : should get all children', function () {
-      expect($('ul').children()).to.have.length(3);
+      expect($('ul').children()).toHaveLength(3);
     });
 
     it('() : should return children of all matched elements', function () {
-      expect($('ul ul', food).children()).to.have.length(5);
+      expect($('ul ul', food).children()).toHaveLength(5);
     });
 
     it('(selector) : should return children matching selector', function () {
       var cls = $('ul').children('.orange')[0].attribs['class'];
-      expect(cls).to.equal('orange');
+      expect(cls).toBe('orange');
     });
 
     it('(invalid selector) : should return empty', function () {
-      expect($('ul').children('.lulz')).to.have.length(0);
+      expect($('ul').children('.lulz')).toHaveLength(0);
     });
 
     it('should only match immediate children, not ancestors', function () {
-      expect($(food).children('li')).to.have.length(0);
+      expect($(food).children('li')).toHaveLength(0);
     });
   });
 
@@ -160,43 +166,43 @@ describe('$(...)', function () {
     });
 
     it('() : should get all contents', function () {
-      expect($('p').contents()).to.have.length(5);
+      expect($('p').contents()).toHaveLength(5);
     });
 
     it('() : should include text nodes', function () {
-      expect($('p').contents().first()[0].type).to.equal('text');
+      expect($('p').contents().first()[0].type).toBe('text');
     });
 
     it('() : should include comment nodes', function () {
-      expect($('p').contents().last()[0].type).to.equal('comment');
+      expect($('p').contents().last()[0].type).toBe('comment');
     });
   });
 
   describe('.next', function () {
     it('() : should return next element', function () {
       var cls = $('.orange').next()[0].attribs['class'];
-      expect(cls).to.equal('pear');
+      expect(cls).toBe('pear');
     });
 
     it('(no next) : should return empty for last child', function () {
-      expect($('.pear').next()).to.have.length(0);
+      expect($('.pear').next()).toHaveLength(0);
     });
 
     it('(next on empty object) : should return empty', function () {
-      expect($('.banana').next()).to.have.length(0);
+      expect($('.banana').next()).toHaveLength(0);
     });
 
     it('() : should operate over all elements in the selection', function () {
-      expect($('.apple, .orange', food).next()).to.have.length(2);
+      expect($('.apple, .orange', food).next()).toHaveLength(2);
     });
 
     describe('(selector) :', function () {
       it('should reject elements that violate the filter', function () {
-        expect($('.apple').next('.non-existent')).to.have.length(0);
+        expect($('.apple').next('.non-existent')).toHaveLength(0);
       });
 
       it('should accept elements that satisify the filter', function () {
-        expect($('.apple').next('.orange')).to.have.length(1);
+        expect($('.apple').next('.orange')).toHaveLength(1);
       });
     });
   });
@@ -204,35 +210,35 @@ describe('$(...)', function () {
   describe('.nextAll', function () {
     it('() : should return all following siblings', function () {
       var elems = $('.apple').nextAll();
-      expect(elems).to.have.length(2);
-      expect(elems[0].attribs['class']).to.equal('orange');
-      expect(elems[1].attribs['class']).to.equal('pear');
+      expect(elems).toHaveLength(2);
+      expect(elems[0].attribs['class']).toBe('orange');
+      expect(elems[1].attribs['class']).toBe('pear');
     });
 
     it('(no next) : should return empty for last child', function () {
-      expect($('.pear').nextAll()).to.have.length(0);
+      expect($('.pear').nextAll()).toHaveLength(0);
     });
 
     it('(nextAll on empty object) : should return empty', function () {
-      expect($('.banana').nextAll()).to.have.length(0);
+      expect($('.banana').nextAll()).toHaveLength(0);
     });
 
     it('() : should operate over all elements in the selection', function () {
-      expect($('.apple, .carrot', food).nextAll()).to.have.length(3);
+      expect($('.apple, .carrot', food).nextAll()).toHaveLength(3);
     });
 
     it('() : should not contain duplicate elements', function () {
       var elems = $('.apple, .orange', food);
-      expect(elems.nextAll()).to.have.length(2);
+      expect(elems.nextAll()).toHaveLength(2);
     });
 
     describe('(selector) :', function () {
       it('should filter according to the provided selector', function () {
-        expect($('.apple').nextAll('.pear')).to.have.length(1);
+        expect($('.apple').nextAll('.pear')).toHaveLength(1);
       });
 
       it("should not consider siblings' contents when filtering", function () {
-        expect($('#fruits', food).nextAll('li')).to.have.length(0);
+        expect($('#fruits', food).nextAll('li')).toHaveLength(0);
       });
     });
   });
@@ -240,97 +246,97 @@ describe('$(...)', function () {
   describe('.nextUntil', function () {
     it('() : should return all following siblings if no selector specified', function () {
       var elems = $('.apple', food).nextUntil();
-      expect(elems).to.have.length(2);
-      expect(elems[0].attribs['class']).to.equal('orange');
-      expect(elems[1].attribs['class']).to.equal('pear');
+      expect(elems).toHaveLength(2);
+      expect(elems[0].attribs['class']).toBe('orange');
+      expect(elems[1].attribs['class']).toBe('pear');
     });
 
     it('() : should filter out non-element nodes', function () {
       var elems = $('<div><div></div><!-- comment -->text<div></div></div>');
       var div = elems.children().eq(0);
-      expect(div.nextUntil()).to.have.length(1);
+      expect(div.nextUntil()).toHaveLength(1);
     });
 
     it('() : should operate over all elements in the selection', function () {
       var elems = $('.apple, .carrot', food);
-      expect(elems.nextUntil()).to.have.length(3);
+      expect(elems.nextUntil()).toHaveLength(3);
     });
 
     it('() : should not contain duplicate elements', function () {
       var elems = $('.apple, .orange', food);
-      expect(elems.nextUntil()).to.have.length(2);
+      expect(elems.nextUntil()).toHaveLength(2);
     });
 
     it('(selector) : should return all following siblings until selector', function () {
       var elems = $('.apple', food).nextUntil('.pear');
-      expect(elems).to.have.length(1);
-      expect(elems[0].attribs['class']).to.equal('orange');
+      expect(elems).toHaveLength(1);
+      expect(elems[0].attribs['class']).toBe('orange');
     });
 
     it('(selector not sibling) : should return all following siblings', function () {
       var elems = $('.apple').nextUntil('#vegetables');
-      expect(elems).to.have.length(2);
+      expect(elems).toHaveLength(2);
     });
 
     it('(selector, filterString) : should return all following siblings until selector, filtered by filter', function () {
       var elems = $('.beer', drinks).nextUntil('.water', '.milk');
-      expect(elems).to.have.length(1);
-      expect(elems[0].attribs['class']).to.equal('milk');
+      expect(elems).toHaveLength(1);
+      expect(elems[0].attribs['class']).toBe('milk');
     });
 
     it('(null, filterString) : should return all following siblings until selector, filtered by filter', function () {
       var elems = $('<ul><li></li><li><p></p></li></ul>');
       var empty = elems.find('li').eq(0).nextUntil(null, 'p');
-      expect(empty).to.have.length(0);
+      expect(empty).toHaveLength(0);
     });
 
     it('() : should return an empty object for last child', function () {
-      expect($('.pear').nextUntil()).to.have.length(0);
+      expect($('.pear').nextUntil()).toHaveLength(0);
     });
 
     it('() : should return an empty object when called on an empty object', function () {
-      expect($('.banana').nextUntil()).to.have.length(0);
+      expect($('.banana').nextUntil()).toHaveLength(0);
     });
 
     it('(node) : should return all following siblings until the node', function () {
       var $fruits = $('#fruits').children();
       var elems = $fruits.eq(0).nextUntil($fruits[2]);
-      expect(elems).to.have.length(1);
+      expect(elems).toHaveLength(1);
     });
 
     it('(cheerio object) : should return all following siblings until any member of the cheerio object', function () {
       var $drinks = $(drinks).children();
       var $until = $([$drinks[4], $drinks[3]]);
       var elems = $drinks.eq(0).nextUntil($until);
-      expect(elems).to.have.length(2);
+      expect(elems).toHaveLength(2);
     });
   });
 
   describe('.prev', function () {
     it('() : should return previous element', function () {
       var cls = $('.orange').prev()[0].attribs['class'];
-      expect(cls).to.equal('apple');
+      expect(cls).toBe('apple');
     });
 
     it('(no prev) : should return empty for first child', function () {
-      expect($('.apple').prev()).to.have.length(0);
+      expect($('.apple').prev()).toHaveLength(0);
     });
 
     it('(prev on empty object) : should return empty', function () {
-      expect($('.banana').prev()).to.have.length(0);
+      expect($('.banana').prev()).toHaveLength(0);
     });
 
     it('() : should operate over all elements in the selection', function () {
-      expect($('.orange, .pear', food).prev()).to.have.length(2);
+      expect($('.orange, .pear', food).prev()).toHaveLength(2);
     });
 
     describe('(selector) :', function () {
       it('should reject elements that violate the filter', function () {
-        expect($('.orange').prev('.non-existent')).to.have.length(0);
+        expect($('.orange').prev('.non-existent')).toHaveLength(0);
       });
 
       it('should accept elements that satisify the filter', function () {
-        expect($('.orange').prev('.apple')).to.have.length(1);
+        expect($('.orange').prev('.apple')).toHaveLength(1);
       });
     });
   });
@@ -338,37 +344,37 @@ describe('$(...)', function () {
   describe('.prevAll', function () {
     it('() : should return all preceding siblings', function () {
       var elems = $('.pear').prevAll();
-      expect(elems).to.have.length(2);
-      expect(elems[0].attribs['class']).to.equal('orange');
-      expect(elems[1].attribs['class']).to.equal('apple');
+      expect(elems).toHaveLength(2);
+      expect(elems[0].attribs['class']).toBe('orange');
+      expect(elems[1].attribs['class']).toBe('apple');
     });
 
     it('(no prev) : should return empty for first child', function () {
-      expect($('.apple').prevAll()).to.have.length(0);
+      expect($('.apple').prevAll()).toHaveLength(0);
     });
 
     it('(prevAll on empty object) : should return empty', function () {
-      expect($('.banana').prevAll()).to.have.length(0);
+      expect($('.banana').prevAll()).toHaveLength(0);
     });
 
     it('() : should operate over all elements in the selection', function () {
-      expect($('.orange, .sweetcorn', food).prevAll()).to.have.length(2);
+      expect($('.orange, .sweetcorn', food).prevAll()).toHaveLength(2);
     });
 
     it('() : should not contain duplicate elements', function () {
       var elems = $('.orange, .pear', food);
-      expect(elems.prevAll()).to.have.length(2);
+      expect(elems.prevAll()).toHaveLength(2);
     });
 
     describe('(selector) :', function () {
       it('should filter returned elements', function () {
         var elems = $('.pear').prevAll('.apple');
-        expect(elems).to.have.length(1);
+        expect(elems).toHaveLength(1);
       });
 
       it("should not consider siblings's descendents", function () {
         var elems = $('#vegetables', food).prevAll('li');
-        expect(elems).to.have.length(0);
+        expect(elems).toHaveLength(0);
       });
     });
   });
@@ -376,9 +382,9 @@ describe('$(...)', function () {
   describe('.prevUntil', function () {
     it('() : should return all preceding siblings if no selector specified', function () {
       var elems = $('.pear').prevUntil();
-      expect(elems).to.have.length(2);
-      expect(elems[0].attribs['class']).to.equal('orange');
-      expect(elems[1].attribs['class']).to.equal('apple');
+      expect(elems).toHaveLength(2);
+      expect(elems[0].attribs['class']).toBe('orange');
+      expect(elems[1].attribs['class']).toBe('apple');
     });
 
     it('() : should filter out non-element nodes', function () {
@@ -386,88 +392,92 @@ describe('$(...)', function () {
         '<div class="1"><div class="2"></div><!-- comment -->text<div class="3"></div></div>'
       );
       var div = elems.children().last();
-      expect(div.prevUntil()).to.have.length(1);
+      expect(div.prevUntil()).toHaveLength(1);
     });
 
     it('() : should operate over all elements in the selection', function () {
       var elems = $('.pear, .sweetcorn', food);
-      expect(elems.prevUntil()).to.have.length(3);
+      expect(elems.prevUntil()).toHaveLength(3);
     });
 
     it('() : should not contain duplicate elements', function () {
       var elems = $('.orange, .pear', food);
-      expect(elems.prevUntil()).to.have.length(2);
+      expect(elems.prevUntil()).toHaveLength(2);
     });
 
     it('(selector) : should return all preceding siblings until selector', function () {
       var elems = $('.pear').prevUntil('.apple');
-      expect(elems).to.have.length(1);
-      expect(elems[0].attribs['class']).to.equal('orange');
+      expect(elems).toHaveLength(1);
+      expect(elems[0].attribs['class']).toBe('orange');
     });
 
     it('(selector not sibling) : should return all preceding siblings', function () {
       var elems = $('.sweetcorn', food).prevUntil('#fruits');
-      expect(elems).to.have.length(1);
-      expect(elems[0].attribs['class']).to.equal('carrot');
+      expect(elems).toHaveLength(1);
+      expect(elems[0].attribs['class']).toBe('carrot');
     });
 
     it('(selector, filterString) : should return all preceding siblings until selector, filtered by filter', function () {
       var elems = $('.cider', drinks).prevUntil('.juice', '.water');
-      expect(elems).to.have.length(1);
-      expect(elems[0].attribs['class']).to.equal('water');
+      expect(elems).toHaveLength(1);
+      expect(elems[0].attribs['class']).toBe('water');
     });
 
     it('(selector, filterString) : should return all preceding siblings until selector', function () {
       var elems = $('<ul><li><p></p></li><li></li></ul>');
       var empty = elems.find('li').eq(1).prevUntil(null, 'p');
-      expect(empty).to.have.length(0);
+      expect(empty).toHaveLength(0);
     });
 
     it('() : should return an empty object for first child', function () {
-      expect($('.apple').prevUntil()).to.have.length(0);
+      expect($('.apple').prevUntil()).toHaveLength(0);
     });
 
     it('() : should return an empty object when called on an empty object', function () {
-      expect($('.banana').prevUntil()).to.have.length(0);
+      expect($('.banana').prevUntil()).toHaveLength(0);
     });
 
     it('(node) : should return all previous siblings until the node', function () {
       var $fruits = $('#fruits').children();
       var elems = $fruits.eq(2).prevUntil($fruits[0]);
-      expect(elems).to.have.length(1);
+      expect(elems).toHaveLength(1);
     });
 
     it('(cheerio object) : should return all previous siblings until any member of the cheerio object', function () {
       var $drinks = $(drinks).children();
       var $until = $([$drinks[0], $drinks[1]]);
       var elems = $drinks.eq(4).prevUntil($until);
-      expect(elems).to.have.length(2);
+      expect(elems).toHaveLength(2);
     });
   });
 
   describe('.siblings', function () {
     it('() : should get all the siblings', function () {
-      expect($('.orange').siblings()).to.have.length(2);
-      expect($('#fruits').siblings()).to.have.length(0);
-      expect($('.apple, .carrot', food).siblings()).to.have.length(3);
+      expect($('.orange').siblings()).toHaveLength(2);
+      expect($('#fruits').siblings()).toHaveLength(0);
+      expect($('.apple, .carrot', food).siblings()).toHaveLength(3);
     });
 
     it('(selector) : should get all siblings that match the selector', function () {
-      expect($('.orange').siblings('.apple')).to.have.length(1);
-      expect($('.orange').siblings('.peach')).to.have.length(0);
+      expect($('.orange').siblings('.apple')).toHaveLength(1);
+      expect($('.orange').siblings('.peach')).toHaveLength(0);
     });
 
     it('(selector) : should throw an Error if given an invalid selector', function () {
-      expect(function () {
-        $('.orange').siblings(':bah');
-      }).to.throwException(function (err) {
-        expect(err).to.be.a(Error);
-        expect(err.message).to.contain('unmatched pseudo-class');
-      });
+      try {
+        (function () {
+          $('.orange').siblings(':bah');
+        })();
+
+        throw Error('Function did not throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(Error);
+        expect(err.message).toContain('unmatched pseudo-class');
+      }
     });
 
     it('(selector) : does not consider the contents of siblings when filtering (GH-374)', function () {
-      expect($('#fruits', food).siblings('li')).to.have.length(0);
+      expect($('#fruits', food).siblings('li')).toHaveLength(0);
     });
   });
 
@@ -478,47 +488,47 @@ describe('$(...)', function () {
 
     it('() : should get all of the parents in logical order', function () {
       var result = $('.orange').parents();
-      expect(result).to.have.length(4);
-      expect(result[0].attribs.id).to.be('fruits');
-      expect(result[1].attribs.id).to.be('food');
-      expect(result[2].tagName).to.be('body');
-      expect(result[3].tagName).to.be('html');
+      expect(result).toHaveLength(4);
+      expect(result[0].attribs.id).toBe('fruits');
+      expect(result[1].attribs.id).toBe('food');
+      expect(result[2].tagName).toBe('body');
+      expect(result[3].tagName).toBe('html');
       result = $('#fruits').parents();
-      expect(result).to.have.length(3);
-      expect(result[0].attribs.id).to.be('food');
-      expect(result[1].tagName).to.be('body');
-      expect(result[2].tagName).to.be('html');
+      expect(result).toHaveLength(3);
+      expect(result[0].attribs.id).toBe('food');
+      expect(result[1].tagName).toBe('body');
+      expect(result[2].tagName).toBe('html');
     });
 
     it('(selector) : should get all of the parents that match the selector in logical order', function () {
       var result = $('.orange').parents('#fruits');
-      expect(result).to.have.length(1);
-      expect(result[0].attribs.id).to.be('fruits');
+      expect(result).toHaveLength(1);
+      expect(result[0].attribs.id).toBe('fruits');
       result = $('.orange').parents('ul');
-      expect(result).to.have.length(2);
-      expect(result[0].attribs.id).to.be('fruits');
-      expect(result[1].attribs.id).to.be('food');
+      expect(result).toHaveLength(2);
+      expect(result[0].attribs.id).toBe('fruits');
+      expect(result[1].attribs.id).toBe('food');
     });
 
     it('() : should not break if the selector does not have any results', function () {
       var result = $('.saladbar').parents();
-      expect(result).to.have.length(0);
+      expect(result).toHaveLength(0);
     });
 
     it('() : should return an empty set for top-level elements', function () {
       var result = $('html').parents();
-      expect(result).to.have.length(0);
+      expect(result).toHaveLength(0);
     });
 
     it('() : should return the parents of every element in the *reveresed* collection, omitting duplicates', function () {
       var $parents = $('li').parents();
 
-      expect($parents).to.have.length(5);
-      expect($parents[0]).to.be($('#vegetables')[0]);
-      expect($parents[1]).to.be($('#food')[0]);
-      expect($parents[2]).to.be($('body')[0]);
-      expect($parents[3]).to.be($('html')[0]);
-      expect($parents[4]).to.be($('#fruits')[0]);
+      expect($parents).toHaveLength(5);
+      expect($parents[0]).toBe($('#vegetables')[0]);
+      expect($parents[1]).toBe($('#food')[0]);
+      expect($parents[2]).toBe($('body')[0]);
+      expect($parents[3]).toBe($('html')[0]);
+      expect($parents[4]).toBe($('#fruits')[0]);
     });
   });
 
@@ -529,38 +539,38 @@ describe('$(...)', function () {
 
     it('() : should get all of the parents in logical order', function () {
       var result = $('.orange').parentsUntil();
-      expect(result).to.have.length(4);
-      expect(result[0].attribs.id).to.be('fruits');
-      expect(result[1].attribs.id).to.be('food');
-      expect(result[2].tagName).to.be('body');
-      expect(result[3].tagName).to.be('html');
+      expect(result).toHaveLength(4);
+      expect(result[0].attribs.id).toBe('fruits');
+      expect(result[1].attribs.id).toBe('food');
+      expect(result[2].tagName).toBe('body');
+      expect(result[3].tagName).toBe('html');
     });
 
     it('() : should get all of the parents in reversed order, omitting duplicates', function () {
       var result = $('.apple, .sweetcorn').parentsUntil();
-      expect(result).to.have.length(5);
-      expect(result[0].attribs.id).to.be('vegetables');
-      expect(result[1].attribs.id).to.be('food');
-      expect(result[2].tagName).to.be('body');
-      expect(result[3].tagName).to.be('html');
-      expect(result[4].attribs.id).to.be('fruits');
+      expect(result).toHaveLength(5);
+      expect(result[0].attribs.id).toBe('vegetables');
+      expect(result[1].attribs.id).toBe('food');
+      expect(result[2].tagName).toBe('body');
+      expect(result[3].tagName).toBe('html');
+      expect(result[4].attribs.id).toBe('fruits');
     });
 
     it('(selector) : should get all of the parents until selector', function () {
       var result = $('.orange').parentsUntil('#food');
-      expect(result).to.have.length(1);
-      expect(result[0].attribs.id).to.be('fruits');
+      expect(result).toHaveLength(1);
+      expect(result[0].attribs.id).toBe('fruits');
       result = $('.orange').parentsUntil('#fruits');
-      expect(result).to.have.length(0);
+      expect(result).toHaveLength(0);
     });
 
     it('(selector not parent) : should return all parents', function () {
       var result = $('.orange').parentsUntil('.apple');
-      expect(result).to.have.length(4);
-      expect(result[0].attribs.id).to.be('fruits');
-      expect(result[1].attribs.id).to.be('food');
-      expect(result[2].tagName).to.be('body');
-      expect(result[3].tagName).to.be('html');
+      expect(result).toHaveLength(4);
+      expect(result[0].attribs.id).toBe('fruits');
+      expect(result[1].attribs.id).toBe('food');
+      expect(result[2].tagName).toBe('body');
+      expect(result[3].tagName).toBe('html');
     });
 
     it('(selector, filter) : should get all of the parents that match the filter', function () {
@@ -568,85 +578,85 @@ describe('$(...)', function () {
         '.saladbar',
         '#vegetables'
       );
-      expect(result).to.have.length(1);
-      expect(result[0].attribs.id).to.be('vegetables');
+      expect(result).toHaveLength(1);
+      expect(result[0].attribs.id).toBe('vegetables');
     });
 
     it('() : should return empty object when called on an empty object', function () {
       var result = $('.saladbar').parentsUntil();
-      expect(result).to.have.length(0);
+      expect(result).toHaveLength(0);
     });
 
     it('() : should return an empty set for top-level elements', function () {
       var result = $('html').parentsUntil();
-      expect(result).to.have.length(0);
+      expect(result).toHaveLength(0);
     });
 
     it('(cheerio object) : should return all parents until any member of the cheerio object', function () {
       var $fruits = $('#fruits');
       var $until = $('#food');
       var result = $fruits.children().eq(1).parentsUntil($until);
-      expect(result).to.have.length(1);
-      expect(result[0].attribs.id).to.be('fruits');
+      expect(result).toHaveLength(1);
+      expect(result[0].attribs.id).toBe('fruits');
     });
   });
 
   describe('.parent', function () {
     it('() : should return the parent of each matched element', function () {
       var result = $('.orange').parent();
-      expect(result).to.have.length(1);
-      expect(result[0].attribs.id).to.be('fruits');
+      expect(result).toHaveLength(1);
+      expect(result[0].attribs.id).toBe('fruits');
       result = $('li', food).parent();
-      expect(result).to.have.length(2);
-      expect(result[0].attribs.id).to.be('fruits');
-      expect(result[1].attribs.id).to.be('vegetables');
+      expect(result).toHaveLength(2);
+      expect(result[0].attribs.id).toBe('fruits');
+      expect(result[1].attribs.id).toBe('vegetables');
     });
 
     it('() : should return an empty object for top-level elements', function () {
       var result = $('html').parent();
-      expect(result).to.have.length(0);
+      expect(result).toHaveLength(0);
     });
 
     it('() : should not contain duplicate elements', function () {
       var result = $('li').parent();
-      expect(result).to.have.length(1);
+      expect(result).toHaveLength(1);
     });
 
     it('(selector) : should filter the matched parent elements by the selector', function () {
       var result = $('.orange').parent();
-      expect(result).to.have.length(1);
-      expect(result[0].attribs.id).to.be('fruits');
+      expect(result).toHaveLength(1);
+      expect(result[0].attribs.id).toBe('fruits');
       result = $('li', food).parent('#fruits');
-      expect(result).to.have.length(1);
-      expect(result[0].attribs.id).to.be('fruits');
+      expect(result).toHaveLength(1);
+      expect(result[0].attribs.id).toBe('fruits');
     });
   });
 
   describe('.closest', function () {
     it('() : should return an empty array', function () {
       var result = $('.orange').closest();
-      expect(result).to.have.length(0);
-      expect(result).to.be.a(cheerio);
+      expect(result).toHaveLength(0);
+      expect(result).toBeInstanceOf(cheerio);
     });
 
     it('(selector) : should find the closest element that matches the selector, searching through its ancestors and itself', function () {
-      expect($('.orange').closest('.apple')).to.have.length(0);
+      expect($('.orange').closest('.apple')).toHaveLength(0);
       var result = $('.orange', food).closest('#food');
-      expect(result[0].attribs.id).to.be('food');
+      expect(result[0].attribs.id).toBe('food');
       result = $('.orange', food).closest('ul');
-      expect(result[0].attribs.id).to.be('fruits');
+      expect(result[0].attribs.id).toBe('fruits');
       result = $('.orange', food).closest('li');
-      expect(result[0].attribs['class']).to.be('orange');
+      expect(result[0].attribs['class']).toBe('orange');
     });
 
     it('(selector) : should find the closest element of each item, removing duplicates', function () {
       var result = $('li', food).closest('ul');
-      expect(result).to.have.length(2);
+      expect(result).toHaveLength(2);
     });
 
     it('() : should not break if the selector does not have any results', function () {
       var result = $('.saladbar', food).closest('ul');
-      expect(result).to.have.length(0);
+      expect(result).toHaveLength(0);
     });
   });
 
@@ -656,11 +666,11 @@ describe('$(...)', function () {
       var classes = ['apple', 'orange', 'pear'];
       $('li').each(function (idx, elem) {
         items[idx] = elem;
-        expect(this.attribs['class']).to.equal(classes[idx]);
+        expect(this.attribs['class']).toBe(classes[idx]);
       });
-      expect(items[0].attribs['class']).to.equal('apple');
-      expect(items[1].attribs['class']).to.equal('orange');
-      expect(items[2].attribs['class']).to.equal('pear');
+      expect(items[0].attribs['class']).toBe('apple');
+      expect(items[1].attribs['class']).toBe('orange');
+      expect(items[2].attribs['class']).toBe('pear');
     });
 
     it('( (i, elem) -> ) : should break iteration when the iterator function returns false', function () {
@@ -670,7 +680,7 @@ describe('$(...)', function () {
         return idx < 1;
       });
 
-      expect(iterationCount).to.equal(2);
+      expect(iterationCount).toBe(2);
     });
   });
 
@@ -680,10 +690,10 @@ describe('$(...)', function () {
         // The equivalent of: for (const element of $('li')) ...
         var $li = $('li');
         var iterator = $li[Symbol.iterator]();
-        expect(iterator.next().value.attribs['class']).to.equal('apple');
-        expect(iterator.next().value.attribs['class']).to.equal('orange');
-        expect(iterator.next().value.attribs['class']).to.equal('pear');
-        expect(iterator.next().done).to.equal(true);
+        expect(iterator.next().value.attribs['class']).toBe('apple');
+        expect(iterator.next().value.attribs['class']).toBe('orange');
+        expect(iterator.next().value.attribs['class']).toBe('pear');
+        expect(iterator.next().done).toBe(true);
       });
     });
   }
@@ -699,12 +709,12 @@ describe('$(...)', function () {
         thisVals.push(this);
       });
 
-      expect(args).to.eql([
+      expect(args).toStrictEqual([
         [0, $fruits[0]],
         [1, $fruits[1]],
         [2, $fruits[2]],
       ]);
-      expect(thisVals).to.eql([$fruits[0], $fruits[1], $fruits[2]]);
+      expect(thisVals).toStrictEqual([$fruits[0], $fruits[1], $fruits[2]]);
     });
 
     it('(fn) : should return an Cheerio object wrapping the returned items', function () {
@@ -713,10 +723,10 @@ describe('$(...)', function () {
         return $fruits[2 - i];
       });
 
-      expect($mapped).to.have.length(3);
-      expect($mapped[0]).to.be($fruits[2]);
-      expect($mapped[1]).to.be($fruits[1]);
-      expect($mapped[2]).to.be($fruits[0]);
+      expect($mapped).toHaveLength(3);
+      expect($mapped[0]).toBe($fruits[2]);
+      expect($mapped[1]).toBe($fruits[1]);
+      expect($mapped[2]).toBe($fruits[0]);
     });
 
     it('(fn) : should ignore `null` and `undefined` returned by iterator', function () {
@@ -727,8 +737,8 @@ describe('$(...)', function () {
         return retVals[i];
       });
 
-      expect($mapped).to.have.length(1);
-      expect($mapped[0]).to.be($fruits[1]);
+      expect($mapped).toHaveLength(1);
+      expect($mapped[0]).toBe($fruits[1]);
     });
 
     it('(fn) : should preform a shallow merge on arrays returned by iterator', function () {
@@ -738,7 +748,7 @@ describe('$(...)', function () {
         return [1, [3, 4]];
       });
 
-      expect($mapped.get()).to.eql([1, [3, 4], 1, [3, 4], 1, [3, 4]]);
+      expect($mapped.get()).toStrictEqual([1, [3, 4], 1, [3, 4], 1, [3, 4]]);
     });
 
     it('(fn) : should tolerate `null` and `undefined` when flattening arrays returned by iterator', function () {
@@ -748,7 +758,7 @@ describe('$(...)', function () {
         return [null, undefined];
       });
 
-      expect($mapped.get()).to.eql([
+      expect($mapped.get()).toStrictEqual([
         null,
         undefined,
         null,
@@ -762,37 +772,37 @@ describe('$(...)', function () {
   describe('.filter', function () {
     it('(selector) : should reduce the set of matched elements to those that match the selector', function () {
       var pear = $('li').filter('.pear').text();
-      expect(pear).to.be('Pear');
+      expect(pear).toBe('Pear');
     });
 
     it('(selector) : should not consider nested elements', function () {
       var lis = $('#fruits').filter('li');
-      expect(lis).to.have.length(0);
+      expect(lis).toHaveLength(0);
     });
 
     it('(selection) : should reduce the set of matched elements to those that are contained in the provided selection', function () {
       var $fruits = $('li');
       var $pear = $fruits.filter('.pear, .apple');
-      expect($fruits.filter($pear)).to.have.length(2);
+      expect($fruits.filter($pear)).toHaveLength(2);
     });
 
     it('(element) : should reduce the set of matched elements to those that specified directly', function () {
       var $fruits = $('li');
       var pear = $fruits.filter('.pear')[0];
-      expect($fruits.filter(pear)).to.have.length(1);
+      expect($fruits.filter(pear)).toHaveLength(1);
     });
 
     it("(fn) : should reduce the set of matched elements to those that pass the function's test", function () {
       var orange = $('li')
         .filter(function (i, el) {
-          expect(this).to.be(el);
-          expect(el.tagName).to.be('li');
-          expect(i).to.be.a('number');
+          expect(this).toBe(el);
+          expect(el.tagName).toBe('li');
+          expect(typeof i).toBe('number');
           return $(this).attr('class') === 'orange';
         })
         .text();
 
-      expect(orange).to.be('Orange');
+      expect(orange).toBe('Orange');
     });
   });
 
@@ -802,14 +812,14 @@ describe('$(...)', function () {
 
       var $notPear = $fruits.not('.pear');
 
-      expect($notPear).to.have.length(2);
-      expect($notPear[0]).to.be($fruits[0]);
-      expect($notPear[1]).to.be($fruits[1]);
+      expect($notPear).toHaveLength(2);
+      expect($notPear[0]).toBe($fruits[0]);
+      expect($notPear[1]).toBe($fruits[1]);
     });
 
     it('(selector) : should not consider nested elements', function () {
       var lis = $('#fruits').not('li');
-      expect(lis).to.have.length(1);
+      expect(lis).toHaveLength(1);
     });
 
     it('(selection) : should reduce the set of matched elements to those that are mot contained in the provided selection', function () {
@@ -818,9 +828,9 @@ describe('$(...)', function () {
 
       var $notOrange = $fruits.not($orange);
 
-      expect($notOrange).to.have.length(2);
-      expect($notOrange[0]).to.be($fruits[0]);
-      expect($notOrange[1]).to.be($fruits[2]);
+      expect($notOrange).toHaveLength(2);
+      expect($notOrange[0]).toBe($fruits[0]);
+      expect($notOrange[1]).toBe($fruits[2]);
     });
 
     it('(element) : should reduce the set of matched elements to those that specified directly', function () {
@@ -829,24 +839,24 @@ describe('$(...)', function () {
 
       var $notApple = $fruits.not(apple);
 
-      expect($notApple).to.have.length(2);
-      expect($notApple[0]).to.be($fruits[1]);
-      expect($notApple[1]).to.be($fruits[2]);
+      expect($notApple).toHaveLength(2);
+      expect($notApple[0]).toBe($fruits[1]);
+      expect($notApple[1]).toBe($fruits[2]);
     });
 
     it("(fn) : should reduce the set of matched elements to those that do not pass the function's test", function () {
       var $fruits = $('li');
 
       var $notOrange = $fruits.not(function (i, el) {
-        expect(this).to.be(el);
-        expect(el.name).to.be('li');
-        expect(i).to.be.a('number');
+        expect(this).toBe(el);
+        expect(el.name).toBe('li');
+        expect(typeof i).toBe('number');
         return $(this).attr('class') === 'orange';
       });
 
-      expect($notOrange).to.have.length(2);
-      expect($notOrange[0]).to.be($fruits[0]);
-      expect($notOrange[1]).to.be($fruits[2]);
+      expect($notOrange).toHaveLength(2);
+      expect($notOrange[0]).toBe($fruits[0]);
+      expect($notOrange[1]).toBe($fruits[2]);
     });
   });
 
@@ -857,19 +867,19 @@ describe('$(...)', function () {
 
     it('(selector) : should reduce the set of matched elements to those with descendants that match the selector', function () {
       var $fruits = $('#fruits,#vegetables').has('.pear');
-      expect($fruits).to.have.length(1);
-      expect($fruits[0]).to.be($('#fruits')[0]);
+      expect($fruits).toHaveLength(1);
+      expect($fruits[0]).toBe($('#fruits')[0]);
     });
 
     it('(selector) : should only consider nested elements', function () {
       var $empty = $('#fruits').has('#fruits');
-      expect($empty).to.have.length(0);
+      expect($empty).toHaveLength(0);
     });
 
     it('(element) : should reduce the set of matched elements to those that are ancestors of the provided element', function () {
       var $fruits = $('#fruits,#vegetables').has($('.pear')[0]);
-      expect($fruits).to.have.length(1);
-      expect($fruits[0]).to.be($('#fruits')[0]);
+      expect($fruits).toHaveLength(1);
+      expect($fruits[0]).toBe($('#fruits')[0]);
     });
 
     it('(element) : should only consider nested elements', function () {
@@ -877,7 +887,7 @@ describe('$(...)', function () {
       var fruitsEl = $fruits[0];
       var $empty = $fruits.has(fruitsEl);
 
-      expect($empty).to.have.length(0);
+      expect($empty).toHaveLength(0);
     });
   });
 
@@ -885,15 +895,15 @@ describe('$(...)', function () {
     it('() : should return the first item', function () {
       var $src = $('<span>foo</span><span>bar</span><span>baz</span>');
       var $elem = $src.first();
-      expect($elem.length).to.equal(1);
-      expect($elem[0].childNodes[0].data).to.equal('foo');
+      expect($elem.length).toBe(1);
+      expect($elem[0].childNodes[0].data).toBe('foo');
     });
 
     it('() : should return an empty object for an empty object', function () {
       var $src = $();
       var $first = $src.first();
-      expect($first.length).to.equal(0);
-      expect($first[0]).to.be(undefined);
+      expect($first.length).toBe(0);
+      expect($first[0]).toBe(undefined);
     });
   });
 
@@ -901,15 +911,15 @@ describe('$(...)', function () {
     it('() : should return the last element', function () {
       var $src = $('<span>foo</span><span>bar</span><span>baz</span>');
       var $elem = $src.last();
-      expect($elem.length).to.equal(1);
-      expect($elem[0].childNodes[0].data).to.equal('baz');
+      expect($elem.length).toBe(1);
+      expect($elem[0].childNodes[0].data).toBe('baz');
     });
 
     it('() : should return an empty object for an empty object', function () {
       var $src = $();
       var $last = $src.last();
-      expect($last.length).to.equal(0);
-      expect($last[0]).to.be(undefined);
+      expect($last.length).toBe(0);
+      expect($last[0]).toBe(undefined);
     });
   });
 
@@ -918,11 +928,11 @@ describe('$(...)', function () {
       var $src = $('<span>bar</span>');
       var $first = $src.first();
       var $last = $src.last();
-      expect($first.length).to.equal(1);
-      expect($first[0].childNodes[0].data).to.equal('bar');
-      expect($last.length).to.equal(1);
-      expect($last[0].childNodes[0].data).to.equal('bar');
-      expect($first[0]).to.equal($last[0]);
+      expect($first.length).toBe(1);
+      expect($first[0].childNodes[0].data).toBe('bar');
+      expect($last.length).toBe(1);
+      expect($last[0].childNodes[0].data).toBe('bar');
+      expect($first[0]).toBe($last[0]);
     });
   });
 
@@ -933,87 +943,87 @@ describe('$(...)', function () {
     }
 
     it('(i) : should return the element at the specified index', function () {
-      expect(getText($('li').eq(0))).to.equal('Apple');
-      expect(getText($('li').eq(1))).to.equal('Orange');
-      expect(getText($('li').eq(2))).to.equal('Pear');
-      expect(getText($('li').eq(3))).to.equal('');
-      expect(getText($('li').eq(-1))).to.equal('Pear');
+      expect(getText($('li').eq(0))).toBe('Apple');
+      expect(getText($('li').eq(1))).toBe('Orange');
+      expect(getText($('li').eq(2))).toBe('Pear');
+      expect(getText($('li').eq(3))).toBe('');
+      expect(getText($('li').eq(-1))).toBe('Pear');
     });
   });
 
   describe('.get', function () {
     it('(i) : should return the element at the specified index', function () {
       var children = $('#fruits').children();
-      expect(children.get(0)).to.be(children[0]);
-      expect(children.get(1)).to.be(children[1]);
-      expect(children.get(2)).to.be(children[2]);
+      expect(children.get(0)).toBe(children[0]);
+      expect(children.get(1)).toBe(children[1]);
+      expect(children.get(2)).toBe(children[2]);
     });
 
     it('(-1) : should return the element indexed from the end of the collection', function () {
       var children = $('#fruits').children();
-      expect(children.get(-1)).to.be(children[2]);
-      expect(children.get(-2)).to.be(children[1]);
-      expect(children.get(-3)).to.be(children[0]);
+      expect(children.get(-1)).toBe(children[2]);
+      expect(children.get(-2)).toBe(children[1]);
+      expect(children.get(-3)).toBe(children[0]);
     });
 
     it('() : should return an array containing all of the collection', function () {
       var children = $('#fruits').children();
       var all = children.get();
-      expect(Array.isArray(all)).to.be.ok();
-      expect(all).to.eql([children[0], children[1], children[2]]);
+      expect(Array.isArray(all)).toBeTruthy();
+      expect(all).toStrictEqual([children[0], children[1], children[2]]);
     });
   });
 
   describe('.index', function () {
     describe('() : ', function () {
       it('returns the index of a child amongst its siblings', function () {
-        expect($('.orange').index()).to.be(1);
+        expect($('.orange').index()).toBe(1);
       });
       it('returns -1 when the selection has no parent', function () {
-        expect($('<div/>').index()).to.be(-1);
+        expect($('<div/>').index()).toBe(-1);
       });
     });
 
     describe('(selector) : ', function () {
       it('returns the index of the first element in the set matched by `selector`', function () {
-        expect($('.apple').index('#fruits, li')).to.be(1);
+        expect($('.apple').index('#fruits, li')).toBe(1);
       });
       it('returns -1 when the item is not present in the set matched by `selector`', function () {
-        expect($('.apple').index('#fuits')).to.be(-1);
+        expect($('.apple').index('#fuits')).toBe(-1);
       });
       it('returns -1 when the first element in the set has no parent', function () {
-        expect($('<div/>').index('*')).to.be(-1);
+        expect($('<div/>').index('*')).toBe(-1);
       });
     });
 
     describe('(node) : ', function () {
       it('returns the index of the given node within the current selection', function () {
         var $lis = $('li');
-        expect($lis.index($lis.get(1))).to.be(1);
+        expect($lis.index($lis.get(1))).toBe(1);
       });
       it('returns the index of the given node within the current selection when the current selection has no parent', function () {
         var $apple = $('.apple').remove();
 
-        expect($apple.index($apple.get(0))).to.be(0);
+        expect($apple.index($apple.get(0))).toBe(0);
       });
       it('returns -1 when the given node is not present in the current selection', function () {
-        expect($('li').index($('#fruits').get(0))).to.be(-1);
+        expect($('li').index($('#fruits').get(0))).toBe(-1);
       });
       it('returns -1 when the current selection is empty', function () {
-        expect($('.not-fruit').index($('#fruits').get(0))).to.be(-1);
+        expect($('.not-fruit').index($('#fruits').get(0))).toBe(-1);
       });
     });
 
     describe('(selection) : ', function () {
       it('returns the index of the first node in the provided selection within the current selection', function () {
         var $lis = $('li');
-        expect($lis.index($('.orange, .pear'))).to.be(1);
+        expect($lis.index($('.orange, .pear'))).toBe(1);
       });
       it('returns -1 when the given node is not present in the current selection', function () {
-        expect($('li').index($('#fruits'))).to.be(-1);
+        expect($('li').index($('#fruits'))).toBe(-1);
       });
       it('returns -1 when the current selection is empty', function () {
-        expect($('.not-fruit').index($('#fruits'))).to.be(-1);
+        expect($('.not-fruit').index($('#fruits'))).toBe(-1);
       });
     });
   });
@@ -1026,21 +1036,21 @@ describe('$(...)', function () {
 
     it('(start) : should return all elements after the given index', function () {
       var sliced = $('li').slice(1);
-      expect(sliced).to.have.length(2);
-      expect(getText(sliced.eq(0))).to.equal('Orange');
-      expect(getText(sliced.eq(1))).to.equal('Pear');
+      expect(sliced).toHaveLength(2);
+      expect(getText(sliced.eq(0))).toBe('Orange');
+      expect(getText(sliced.eq(1))).toBe('Pear');
     });
 
     it('(start, end) : should return all elements matching the given range', function () {
       var sliced = $('li').slice(1, 2);
-      expect(sliced).to.have.length(1);
-      expect(getText(sliced.eq(0))).to.equal('Orange');
+      expect(sliced).toHaveLength(1);
+      expect(getText(sliced.eq(0))).toBe('Orange');
     });
 
     it('(-start) : should return element matching the offset from the end', function () {
       var sliced = $('li').slice(-1);
-      expect(sliced).to.have.length(1);
-      expect(getText(sliced.eq(0))).to.equal('Pear');
+      expect(sliced).toHaveLength(1);
+      expect(getText(sliced.eq(0))).toBe('Pear');
     });
   });
 
@@ -1052,14 +1062,14 @@ describe('$(...)', function () {
     });
 
     it('returns an empty object at the end of the chain', function () {
-      expect($fruits.end().end().end()).to.be.ok();
-      expect($fruits.end().end().end()).to.have.length(0);
+      expect($fruits.end().end().end()).toBeTruthy();
+      expect($fruits.end().end().end()).toHaveLength(0);
     });
     it('find', function () {
-      expect($fruits.find('.apple').end()).to.be($fruits);
+      expect($fruits.find('.apple').end()).toBe($fruits);
     });
     it('filter', function () {
-      expect($fruits.filter('.apple').end()).to.be($fruits);
+      expect($fruits.filter('.apple').end()).toBe($fruits);
     });
     it('map', function () {
       expect(
@@ -1068,52 +1078,52 @@ describe('$(...)', function () {
             return this;
           })
           .end()
-      ).to.be($fruits);
+      ).toBe($fruits);
     });
     it('contents', function () {
-      expect($fruits.contents().end()).to.be($fruits);
+      expect($fruits.contents().end()).toBe($fruits);
     });
     it('eq', function () {
-      expect($fruits.eq(1).end()).to.be($fruits);
+      expect($fruits.eq(1).end()).toBe($fruits);
     });
     it('first', function () {
-      expect($fruits.first().end()).to.be($fruits);
+      expect($fruits.first().end()).toBe($fruits);
     });
     it('last', function () {
-      expect($fruits.last().end()).to.be($fruits);
+      expect($fruits.last().end()).toBe($fruits);
     });
     it('slice', function () {
-      expect($fruits.slice(1).end()).to.be($fruits);
+      expect($fruits.slice(1).end()).toBe($fruits);
     });
     it('children', function () {
-      expect($fruits.children().end()).to.be($fruits);
+      expect($fruits.children().end()).toBe($fruits);
     });
     it('parent', function () {
-      expect($fruits.parent().end()).to.be($fruits);
+      expect($fruits.parent().end()).toBe($fruits);
     });
     it('parents', function () {
-      expect($fruits.parents().end()).to.be($fruits);
+      expect($fruits.parents().end()).toBe($fruits);
     });
     it('closest', function () {
-      expect($fruits.closest('ul').end()).to.be($fruits);
+      expect($fruits.closest('ul').end()).toBe($fruits);
     });
     it('siblings', function () {
-      expect($fruits.siblings().end()).to.be($fruits);
+      expect($fruits.siblings().end()).toBe($fruits);
     });
     it('next', function () {
-      expect($fruits.next().end()).to.be($fruits);
+      expect($fruits.next().end()).toBe($fruits);
     });
     it('nextAll', function () {
-      expect($fruits.nextAll().end()).to.be($fruits);
+      expect($fruits.nextAll().end()).toBe($fruits);
     });
     it('prev', function () {
-      expect($fruits.prev().end()).to.be($fruits);
+      expect($fruits.prev().end()).toBe($fruits);
     });
     it('prevAll', function () {
-      expect($fruits.prevAll().end()).to.be($fruits);
+      expect($fruits.prevAll().end()).toBe($fruits);
     });
     it('clone', function () {
-      expect($fruits.clone().end()).to.be($fruits);
+      expect($fruits.clone().end()).toBe($fruits);
     });
   });
 
@@ -1141,80 +1151,80 @@ describe('$(...)', function () {
           it('occurs before current selection', function () {
             var $selection = $orange.add('.apple');
 
-            expect($selection).to.have.length(2);
-            expect($selection[0]).to.be($apple[0]);
-            expect($selection[1]).to.be($orange[0]);
+            expect($selection).toHaveLength(2);
+            expect($selection[0]).toBe($apple[0]);
+            expect($selection[1]).toBe($orange[0]);
           });
           it('is identical to the current selection', function () {
             var $selection = $orange.add('.orange');
 
-            expect($selection).to.have.length(1);
-            expect($selection[0]).to.be($orange[0]);
+            expect($selection).toHaveLength(1);
+            expect($selection[0]).toBe($orange[0]);
           });
           it('occurs after current selection', function () {
             var $selection = $orange.add('.pear');
 
-            expect($selection).to.have.length(2);
-            expect($selection[0]).to.be($orange[0]);
-            expect($selection[1]).to.be($pear[0]);
+            expect($selection).toHaveLength(2);
+            expect($selection[0]).toBe($orange[0]);
+            expect($selection[1]).toBe($pear[0]);
           });
           it('contains the current selection', function () {
             var $selection = $orange.add('#fruits');
 
-            expect($selection).to.have.length(2);
-            expect($selection[0]).to.be($fruits[0]);
-            expect($selection[1]).to.be($orange[0]);
+            expect($selection).toHaveLength(2);
+            expect($selection[0]).toBe($fruits[0]);
+            expect($selection[1]).toBe($orange[0]);
           });
           it('is a child of the current selection', function () {
             var $selection = $fruits.add('.orange');
 
-            expect($selection).to.have.length(2);
-            expect($selection[0]).to.be($fruits[0]);
-            expect($selection[1]).to.be($orange[0]);
+            expect($selection).toHaveLength(2);
+            expect($selection[0]).toBe($fruits[0]);
+            expect($selection[1]).toBe($orange[0]);
           });
         });
         describe('matched elements', function () {
           it('occur before the current selection', function () {
             var $selection = $pear.add('.apple, .orange');
 
-            expect($selection).to.have.length(3);
-            expect($selection[0]).to.be($apple[0]);
-            expect($selection[1]).to.be($orange[0]);
-            expect($selection[2]).to.be($pear[0]);
+            expect($selection).toHaveLength(3);
+            expect($selection[0]).toBe($apple[0]);
+            expect($selection[1]).toBe($orange[0]);
+            expect($selection[2]).toBe($pear[0]);
           });
           it('include the current selection', function () {
             var $selection = $pear.add('#fruits li');
 
-            expect($selection).to.have.length(3);
-            expect($selection[0]).to.be($apple[0]);
-            expect($selection[1]).to.be($orange[0]);
-            expect($selection[2]).to.be($pear[0]);
+            expect($selection).toHaveLength(3);
+            expect($selection[0]).toBe($apple[0]);
+            expect($selection[1]).toBe($orange[0]);
+            expect($selection[2]).toBe($pear[0]);
           });
           it('occur after the current selection', function () {
             var $selection = $apple.add('.orange, .pear');
 
-            expect($selection).to.have.length(3);
-            expect($selection[0]).to.be($apple[0]);
-            expect($selection[1]).to.be($orange[0]);
-            expect($selection[2]).to.be($pear[0]);
+            expect($selection).toHaveLength(3);
+            expect($selection[0]).toBe($apple[0]);
+            expect($selection[1]).toBe($orange[0]);
+            expect($selection[2]).toBe($pear[0]);
           });
           it('occur within the current selection', function () {
             var $selection = $fruits.add('#fruits li');
 
-            expect($selection).to.have.length(4);
-            expect($selection[0]).to.be($fruits[0]);
-            expect($selection[1]).to.be($apple[0]);
-            expect($selection[2]).to.be($orange[0]);
-            expect($selection[3]).to.be($pear[0]);
+            expect($selection).toHaveLength(4);
+            expect($selection[0]).toBe($fruits[0]);
+            expect($selection[1]).toBe($apple[0]);
+            expect($selection[2]).toBe($orange[0]);
+            expect($selection[3]).toBe($pear[0]);
           });
         });
       });
       it(', context)', function () {
         var $selection = $fruits.add('li', '#vegetables');
-        expect($selection).to.have.length(3);
-        expect($selection[0]).to.be($fruits[0]);
-        expect($selection[1]).to.be($carrot[0]);
-        expect($selection[2]).to.be($sweetcorn[0]);
+        expect($selection).toHaveLength(3);
+        expect($selection[0]).toBe($fruits[0]);
+        expect($selection[1]).toBe($carrot[0]);
+        expect($selection[2]).toBe($sweetcorn[0]);
       });
     });
 
@@ -1223,72 +1233,72 @@ describe('$(...)', function () {
         it('before the current selection', function () {
           var $selection = $orange.add($apple[0]);
 
-          expect($selection).to.have.length(2);
-          expect($selection[0]).to.be($apple[0]);
-          expect($selection[1]).to.be($orange[0]);
+          expect($selection).toHaveLength(2);
+          expect($selection[0]).toBe($apple[0]);
+          expect($selection[1]).toBe($orange[0]);
         });
         it('after the current selection', function () {
           var $selection = $orange.add($pear[0]);
 
-          expect($selection).to.have.length(2);
-          expect($selection[0]).to.be($orange[0]);
-          expect($selection[1]).to.be($pear[0]);
+          expect($selection).toHaveLength(2);
+          expect($selection[0]).toBe($orange[0]);
+          expect($selection[1]).toBe($pear[0]);
         });
         it('within the current selection', function () {
           var $selection = $fruits.add($orange[0]);
 
-          expect($selection).to.have.length(2);
-          expect($selection[0]).to.be($fruits[0]);
-          expect($selection[1]).to.be($orange[0]);
+          expect($selection).toHaveLength(2);
+          expect($selection[0]).toBe($fruits[0]);
+          expect($selection[1]).toBe($orange[0]);
         });
         it('as an ancestor of the current selection', function () {
           var $selection = $orange.add($fruits[0]);
 
-          expect($selection).to.have.length(2);
-          expect($selection[0]).to.be($fruits[0]);
-          expect($selection[1]).to.be($orange[0]);
+          expect($selection).toHaveLength(2);
+          expect($selection[0]).toBe($fruits[0]);
+          expect($selection[1]).toBe($orange[0]);
         });
       });
       it('does not insert an element already contained within the current selection', function () {
         var $selection = $apple.add($apple[0]);
 
-        expect($selection).to.have.length(1);
-        expect($selection[0]).to.be($apple[0]);
+        expect($selection).toHaveLength(1);
+        expect($selection[0]).toBe($apple[0]);
       });
     });
     describe('([elements]) : elements', function () {
       it('occur before the current selection', function () {
         var $selection = $pear.add($('.apple, .orange').get());
 
-        expect($selection).to.have.length(3);
-        expect($selection[0]).to.be($apple[0]);
-        expect($selection[1]).to.be($orange[0]);
-        expect($selection[2]).to.be($pear[0]);
+        expect($selection).toHaveLength(3);
+        expect($selection[0]).toBe($apple[0]);
+        expect($selection[1]).toBe($orange[0]);
+        expect($selection[2]).toBe($pear[0]);
       });
       it('include the current selection', function () {
         var $selection = $pear.add($('#fruits li').get());
 
-        expect($selection).to.have.length(3);
-        expect($selection[0]).to.be($apple[0]);
-        expect($selection[1]).to.be($orange[0]);
-        expect($selection[2]).to.be($pear[0]);
+        expect($selection).toHaveLength(3);
+        expect($selection[0]).toBe($apple[0]);
+        expect($selection[1]).toBe($orange[0]);
+        expect($selection[2]).toBe($pear[0]);
       });
       it('occur after the current selection', function () {
         var $selection = $apple.add($('.orange, .pear').get());
 
-        expect($selection).to.have.length(3);
-        expect($selection[0]).to.be($apple[0]);
-        expect($selection[1]).to.be($orange[0]);
-        expect($selection[2]).to.be($pear[0]);
+        expect($selection).toHaveLength(3);
+        expect($selection[0]).toBe($apple[0]);
+        expect($selection[1]).toBe($orange[0]);
+        expect($selection[2]).toBe($pear[0]);
       });
       it('occur within the current selection', function () {
         var $selection = $fruits.add($('#fruits li').get());
 
-        expect($selection).to.have.length(4);
-        expect($selection[0]).to.be($fruits[0]);
-        expect($selection[1]).to.be($apple[0]);
-        expect($selection[2]).to.be($orange[0]);
-        expect($selection[3]).to.be($pear[0]);
+        expect($selection).toHaveLength(4);
+        expect($selection[0]).toBe($fruits[0]);
+        expect($selection[1]).toBe($apple[0]);
+        expect($selection[2]).toBe($orange[0]);
+        expect($selection[3]).toBe($pear[0]);
       });
     });
 
@@ -1303,9 +1313,9 @@ describe('$(...)', function () {
     it('(html) : correctly parses and adds the new elements', function () {
       var $selection = $apple.add('<li class="banana">banana</li>');
 
-      expect($selection).to.have.length(2);
-      expect($selection.is('.apple')).to.be(true);
-      expect($selection.is('.banana')).to.be(true);
+      expect($selection).toHaveLength(2);
+      expect($selection.is('.apple')).toBe(true);
+      expect($selection.is('.banana')).toBe(true);
     });
 
     describe('(selection) :', function () {
@@ -1313,71 +1323,71 @@ describe('$(...)', function () {
         it('occurs before current selection', function () {
           var $selection = $orange.add($('.apple'));
 
-          expect($selection).to.have.length(2);
-          expect($selection[0]).to.be($apple[0]);
-          expect($selection[1]).to.be($orange[0]);
+          expect($selection).toHaveLength(2);
+          expect($selection[0]).toBe($apple[0]);
+          expect($selection[1]).toBe($orange[0]);
         });
         it('is identical to the current selection', function () {
           var $selection = $orange.add($('.orange'));
 
-          expect($selection).to.have.length(1);
-          expect($selection[0]).to.be($orange[0]);
+          expect($selection).toHaveLength(1);
+          expect($selection[0]).toBe($orange[0]);
         });
         it('occurs after current selection', function () {
           var $selection = $orange.add($('.pear'));
 
-          expect($selection).to.have.length(2);
-          expect($selection[0]).to.be($orange[0]);
-          expect($selection[1]).to.be($pear[0]);
+          expect($selection).toHaveLength(2);
+          expect($selection[0]).toBe($orange[0]);
+          expect($selection[1]).toBe($pear[0]);
         });
         it('contains the current selection', function () {
           var $selection = $orange.add($('#fruits'));
 
-          expect($selection).to.have.length(2);
-          expect($selection[0]).to.be($fruits[0]);
-          expect($selection[1]).to.be($orange[0]);
+          expect($selection).toHaveLength(2);
+          expect($selection[0]).toBe($fruits[0]);
+          expect($selection[1]).toBe($orange[0]);
         });
         it('is a child of the current selection', function () {
           var $selection = $fruits.add($('.orange'));
 
-          expect($selection).to.have.length(2);
-          expect($selection[0]).to.be($fruits[0]);
-          expect($selection[1]).to.be($orange[0]);
+          expect($selection).toHaveLength(2);
+          expect($selection[0]).toBe($fruits[0]);
+          expect($selection[1]).toBe($orange[0]);
         });
       });
       describe('elements in the selection', function () {
         it('occur before the current selection', function () {
           var $selection = $pear.add($('.apple, .orange'));
 
-          expect($selection).to.have.length(3);
-          expect($selection[0]).to.be($apple[0]);
-          expect($selection[1]).to.be($orange[0]);
-          expect($selection[2]).to.be($pear[0]);
+          expect($selection).toHaveLength(3);
+          expect($selection[0]).toBe($apple[0]);
+          expect($selection[1]).toBe($orange[0]);
+          expect($selection[2]).toBe($pear[0]);
         });
         it('include the current selection', function () {
           var $selection = $pear.add($('#fruits li'));
 
-          expect($selection).to.have.length(3);
-          expect($selection[0]).to.be($apple[0]);
-          expect($selection[1]).to.be($orange[0]);
-          expect($selection[2]).to.be($pear[0]);
+          expect($selection).toHaveLength(3);
+          expect($selection[0]).toBe($apple[0]);
+          expect($selection[1]).toBe($orange[0]);
+          expect($selection[2]).toBe($pear[0]);
         });
         it('occur after the current selection', function () {
           var $selection = $apple.add($('.orange, .pear'));
 
-          expect($selection).to.have.length(3);
-          expect($selection[0]).to.be($apple[0]);
-          expect($selection[1]).to.be($orange[0]);
-          expect($selection[2]).to.be($pear[0]);
+          expect($selection).toHaveLength(3);
+          expect($selection[0]).toBe($apple[0]);
+          expect($selection[1]).toBe($orange[0]);
+          expect($selection[2]).toBe($pear[0]);
         });
         it('occur within the current selection', function () {
           var $selection = $fruits.add($('#fruits li'));
 
-          expect($selection).to.have.length(4);
-          expect($selection[0]).to.be($fruits[0]);
-          expect($selection[1]).to.be($apple[0]);
-          expect($selection[2]).to.be($orange[0]);
-          expect($selection[3]).to.be($pear[0]);
+          expect($selection).toHaveLength(4);
+          expect($selection[0]).toBe($fruits[0]);
+          expect($selection[1]).toBe($apple[0]);
+          expect($selection[2]).toBe($orange[0]);
+          expect($selection[3]).toBe($pear[0]);
         });
       });
     });
@@ -1388,45 +1398,45 @@ describe('$(...)', function () {
       it('includes siblings and self', function () {
         var $selection = $('.orange').siblings().addBack();
 
-        expect($selection).to.have.length(3);
-        expect($selection[0]).to.be($('.apple')[0]);
-        expect($selection[1]).to.be($('.orange')[0]);
-        expect($selection[2]).to.be($('.pear')[0]);
+        expect($selection).toHaveLength(3);
+        expect($selection[0]).toBe($('.apple')[0]);
+        expect($selection[1]).toBe($('.orange')[0]);
+        expect($selection[2]).toBe($('.pear')[0]);
       });
       it('includes children and self', function () {
         var $selection = $('#fruits').children().addBack();
 
-        expect($selection).to.have.length(4);
-        expect($selection[0]).to.be($('#fruits')[0]);
-        expect($selection[1]).to.be($('.apple')[0]);
-        expect($selection[2]).to.be($('.orange')[0]);
-        expect($selection[3]).to.be($('.pear')[0]);
+        expect($selection).toHaveLength(4);
+        expect($selection[0]).toBe($('#fruits')[0]);
+        expect($selection[1]).toBe($('.apple')[0]);
+        expect($selection[2]).toBe($('.orange')[0]);
+        expect($selection[3]).toBe($('.pear')[0]);
       });
       it('includes parent and self', function () {
         var $selection = $('.apple').parent().addBack();
 
-        expect($selection).to.have.length(2);
-        expect($selection[0]).to.be($('#fruits')[0]);
-        expect($selection[1]).to.be($('.apple')[0]);
+        expect($selection).toHaveLength(2);
+        expect($selection[0]).toBe($('#fruits')[0]);
+        expect($selection[1]).toBe($('.apple')[0]);
       });
       it('includes parents and self', function () {
         var q = cheerio.load(food);
         var $selection = q('.apple').parents().addBack();
 
-        expect($selection).to.have.length(5);
-        expect($selection[0]).to.be(q('html')[0]);
-        expect($selection[1]).to.be(q('body')[0]);
-        expect($selection[2]).to.be(q('#food')[0]);
-        expect($selection[3]).to.be(q('#fruits')[0]);
-        expect($selection[4]).to.be(q('.apple')[0]);
+        expect($selection).toHaveLength(5);
+        expect($selection[0]).toBe(q('html')[0]);
+        expect($selection[1]).toBe(q('body')[0]);
+        expect($selection[2]).toBe(q('#food')[0]);
+        expect($selection[3]).toBe(q('#fruits')[0]);
+        expect($selection[4]).toBe(q('.apple')[0]);
       });
     });
     it('(filter) : filters the previous selection', function () {
       var $selection = $('li').eq(1).addBack('.apple');
 
-      expect($selection).to.have.length(2);
-      expect($selection[0]).to.be($('.apple')[0]);
-      expect($selection[1]).to.be($('.orange')[0]);
+      expect($selection).toHaveLength(2);
+      expect($selection[0]).toBe($('.apple')[0]);
+      expect($selection[1]).toBe($('.orange')[0]);
     });
   });
 });

--- a/test/api/utils.js
+++ b/test/api/utils.js
@@ -1,5 +1,4 @@
-var expect = require('expect.js');
-var fixtures = require('../fixtures');
+var fixtures = require('../__fixtures__/fixtures');
 var cheerio = require('../..');
 
 describe('cheerio', function () {
@@ -7,24 +6,24 @@ describe('cheerio', function () {
     it('() : should return innerHTML; $.html(obj) should return outerHTML', function () {
       var $div = cheerio('div', '<div><span>foo</span><span>bar</span></div>');
       var span = $div.children()[1];
-      expect(cheerio(span).html()).to.equal('bar');
-      expect(cheerio.html(span)).to.equal('<span>bar</span>');
+      expect(cheerio(span).html()).toBe('bar');
+      expect(cheerio.html(span)).toBe('<span>bar</span>');
     });
 
     it('(<obj>) : should accept an object, an array, or a cheerio object', function () {
       var $span = cheerio('<span>foo</span>');
-      expect(cheerio.html($span[0])).to.equal('<span>foo</span>');
-      expect(cheerio.html($span)).to.equal('<span>foo</span>');
+      expect(cheerio.html($span[0])).toBe('<span>foo</span>');
+      expect(cheerio.html($span)).toBe('<span>foo</span>');
     });
 
     it('(<value>) : should be able to set to an empty string', function () {
       var $elem = cheerio('<span>foo</span>').html('');
-      expect(cheerio.html($elem)).to.equal('<span></span>');
+      expect(cheerio.html($elem)).toBe('<span></span>');
     });
 
     it('(<root>) : does not render the root element', function () {
       var $ = cheerio.load('');
-      expect(cheerio.html($.root())).to.equal(
+      expect(cheerio.html($.root())).toBe(
         '<html><head></head><body></body></html>'
       );
     });
@@ -34,26 +33,26 @@ describe('cheerio', function () {
       var $collection = $('div').add($.root()).add('span');
       var expected =
         '<html><head></head><body><div>a div</div><span>a span</span></body></html><div>a div</div><span>a span</span>';
-      expect(cheerio.html($collection)).to.equal(expected);
+      expect(cheerio.html($collection)).toBe(expected);
     });
   });
 
   describe('.text', function () {
     it('(cheerio object) : should return the text contents of the specified elements', function () {
       var $ = cheerio.load('<a>This is <em>content</em>.</a>');
-      expect(cheerio.text($('a'))).to.equal('This is content.');
+      expect(cheerio.text($('a'))).toBe('This is content.');
     });
 
     it('(cheerio object) : should omit comment nodes', function () {
       var $ = cheerio.load('<a>This is <!-- a comment --> not a comment.</a>');
-      expect(cheerio.text($('a'))).to.equal('This is  not a comment.');
+      expect(cheerio.text($('a'))).toBe('This is  not a comment.');
     });
 
     it('(cheerio object) : should include text contents of children recursively', function () {
       var $ = cheerio.load(
         '<a>This is <div>a child with <span>another child and <!-- a comment --> not a comment</span> followed by <em>one last child</em> and some final</div> text.</a>'
       );
-      expect(cheerio.text($('a'))).to.equal(
+      expect(cheerio.text($('a'))).toBe(
         'This is a child with another child and  not a comment followed by one last child and some final text.'
       );
     });
@@ -62,28 +61,28 @@ describe('cheerio', function () {
       var $ = cheerio.load(
         '<a>This is <div>a child with <span>another child and <!-- a comment --> not a comment</span> followed by <em>one last child</em> and some final</div> text.</a>'
       );
-      expect(cheerio.text($.root())).to.equal(
+      expect(cheerio.text($.root())).toBe(
         'This is a child with another child and  not a comment followed by one last child and some final text.'
       );
     });
 
     it('(cheerio object) : should omit script tags', function () {
       var $ = cheerio.load('<script>console.log("test")</script>');
-      expect(cheerio.text($.root())).to.equal('');
+      expect(cheerio.text($.root())).toBe('');
     });
 
     it('(cheerio object) : should omit style tags', function () {
       var $ = cheerio.load(
         '<style type="text/css">.cf-hidden { display: none; } .cf-invisible { visibility: hidden; }</style>'
       );
-      expect($.text()).to.equal('');
+      expect($.text()).toBe('');
     });
 
     it('(cheerio object) : should include text contents of children omiting style and script tags', function () {
       var $ = cheerio.load(
         '<body>Welcome <div>Hello, testing text function,<script>console.log("hello")</script></div><style type="text/css">.cf-hidden { display: none; }</style>End of messege</body>'
       );
-      expect(cheerio.text($.root())).to.equal(
+      expect(cheerio.text($.root())).toBe(
         'Welcome Hello, testing text function,End of messege'
       );
     });
@@ -92,23 +91,23 @@ describe('cheerio', function () {
   describe('.load', function () {
     it('(html) : should retain original root after creating a new node', function () {
       var $ = cheerio.load('<body><ul id="fruits"></ul></body>');
-      expect($('body')).to.have.length(1);
+      expect($('body')).toHaveLength(1);
       $('<script>');
-      expect($('body')).to.have.length(1);
+      expect($('body')).toHaveLength(1);
     });
 
     it('(html) : should handle lowercase tag options', function () {
       var $ = cheerio.load('<BODY><ul id="fruits"></ul></BODY>', {
         xml: { lowerCaseTags: true },
       });
-      expect($.html()).to.be('<body><ul id="fruits"/></body>');
+      expect($.html()).toBe('<body><ul id="fruits"/></body>');
     });
 
     it('(html) : should handle the `normalizeWhitepace` option', function () {
       var $ = cheerio.load('<body><b>foo</b>  <b>bar</b></body>', {
         xml: { normalizeWhitespace: true },
       });
-      expect($.html()).to.be('<body><b>foo</b> <b>bar</b></body>');
+      expect($.html()).toBe('<body><b>foo</b> <b>bar</b></body>');
     });
 
     // TODO:
@@ -121,7 +120,7 @@ describe('cheerio', function () {
     it('(buffer) : should accept a buffer', function () {
       var html = '<html><head></head><body>foo</body></html>';
       var $html = cheerio.load(Buffer.from(html));
-      expect($html.html()).to.be(html);
+      expect($html.html()).toBe(html);
     });
   });
 
@@ -131,11 +130,11 @@ describe('cheerio', function () {
         '<div><span>foo</span><span>bar</span><span>baz</span></div>'
       ).children();
       var $elem = $src.clone();
-      expect($elem.length).to.equal(3);
-      expect($elem.parent()).to.have.length(0);
-      expect($elem.text()).to.equal($src.text());
+      expect($elem.length).toBe(3);
+      expect($elem.parent()).toHaveLength(0);
+      expect($elem.text()).toBe($src.text());
       $src.text('rofl');
-      expect($elem.text()).to.not.equal($src.text());
+      expect($elem.text()).not.toBe($src.text());
     });
 
     it('() : should return a copy of document', function () {
@@ -144,18 +143,18 @@ describe('cheerio', function () {
         .root()
         .children();
       var $elem = $src.clone();
-      expect($elem.length).to.equal(1);
-      expect($elem.parent()).to.have.length(0);
-      expect($elem.text()).to.equal($src.text());
+      expect($elem.length).toBe(1);
+      expect($elem.parent()).toHaveLength(0);
+      expect($elem.text()).toBe($src.text());
       $src.text('rofl');
-      expect($elem.text()).to.not.equal($src.text());
+      expect($elem.text()).not.toBe($src.text());
     });
 
     it('() : should preserve parsing options', function () {
       var $ = cheerio.load('<div>π</div>', { decodeEntities: false });
       var $div = $('div');
 
-      expect($div.text()).to.equal($div.clone().text());
+      expect($div.text()).toBe($div.clone().text());
     });
   });
 
@@ -163,70 +162,70 @@ describe('cheerio', function () {
     var $ = cheerio.load('');
 
     it('() : returns null', function () {
-      expect($.parseHTML()).to.equal(null);
+      expect($.parseHTML()).toBe(null);
     });
 
     it('(null) : returns null', function () {
-      expect($.parseHTML(null)).to.equal(null);
+      expect($.parseHTML(null)).toBe(null);
     });
 
     it('("") : returns null', function () {
-      expect($.parseHTML('')).to.equal(null);
+      expect($.parseHTML('')).toBe(null);
     });
 
     it('(largeHtmlString) : parses large HTML strings', function () {
       var html = new Array(10).join('<div></div>');
       var nodes = $.parseHTML(html);
 
-      expect(nodes.length).to.be.greaterThan(4);
-      expect(nodes).to.be.an('array');
+      expect(nodes.length).toBeGreaterThan(4);
+      expect(nodes).toBeInstanceOf(Array);
     });
 
     it('("<script>") : ignores scripts by default', function () {
       var html = '<script>undefined()</script>';
-      expect($.parseHTML(html)).to.have.length(0);
+      expect($.parseHTML(html)).toHaveLength(0);
     });
 
     it('("<script>", true) : preserves scripts when requested', function () {
       var html = '<script>undefined()</script>';
-      expect($.parseHTML(html, true)[0].tagName).to.match(/script/i);
+      expect($.parseHTML(html, true)[0].tagName).toMatch(/script/i);
     });
 
     it('("scriptAndNonScript) : preserves non-script nodes', function () {
       var html = '<script>undefined()</script><div></div>';
-      expect($.parseHTML(html)[0].tagName).to.match(/div/i);
+      expect($.parseHTML(html)[0].tagName).toMatch(/div/i);
     });
 
     it('(scriptAndNonScript, true) : Preserves script position', function () {
       var html = '<script>undefined()</script><div></div>';
-      expect($.parseHTML(html, true)[0].tagName).to.match(/script/i);
+      expect($.parseHTML(html, true)[0].tagName).toMatch(/script/i);
     });
 
     it('(text) : returns a text node', function () {
-      expect($.parseHTML('text')[0].type).to.be('text');
+      expect($.parseHTML('text')[0].type).toBe('text');
     });
 
     it('(\\ttext) : preserves leading whitespace', function () {
-      expect($.parseHTML('\t<div></div>')[0].data).to.equal('\t');
+      expect($.parseHTML('\t<div></div>')[0].data).toBe('\t');
     });
 
     it('( text) : Leading spaces are treated as text nodes', function () {
-      expect($.parseHTML(' <div/> ')[0].type).to.be('text');
+      expect($.parseHTML(' <div/> ')[0].type).toBe('text');
     });
 
     it('(html) : should preserve content', function () {
       var html = '<div>test div</div>';
-      expect(cheerio($.parseHTML(html)[0]).html()).to.equal('test div');
+      expect(cheerio($.parseHTML(html)[0]).html()).toBe('test div');
     });
 
     it('(malformedHtml) : should not break', function () {
-      expect($.parseHTML('<span><span>')).to.have.length(1);
+      expect($.parseHTML('<span><span>')).toHaveLength(1);
     });
 
     it('(garbageInput) : should not cause an error', function () {
       expect(
         $.parseHTML('<#if><tr><p>This is a test.</p></tr><#/if>') || true
-      ).to.be.ok();
+      ).toBeTruthy();
     });
 
     it('(text) : should return an array that is not effected by DOM manipulation methods', function () {
@@ -235,7 +234,7 @@ describe('cheerio', function () {
 
       $div('div').append(elems);
 
-      expect(elems).to.have.length(2);
+      expect(elems).toHaveLength(2);
     });
   });
 
@@ -250,23 +249,23 @@ describe('cheerio', function () {
     });
 
     it('should be a function', function () {
-      expect(typeof $.merge).to.equal('function');
+      expect(typeof $.merge).toBe('function');
     });
 
     it('(arraylike, arraylike) : should return an array', function () {
       var ret = $.merge(arr1, arr2);
-      expect(typeof ret).to.equal('object');
-      expect(ret instanceof Array).to.be.ok();
+      expect(typeof ret).toBe('object');
+      expect(ret instanceof Array).toBeTruthy();
     });
 
     it('(arraylike, arraylike) : should modify the first array', function () {
       $.merge(arr1, arr2);
-      expect(arr1).to.have.length(6);
+      expect(arr1).toHaveLength(6);
     });
 
     it('(arraylike, arraylike) : should not modify the second array', function () {
       $.merge(arr1, arr2);
-      expect(arr2).to.have.length(3);
+      expect(arr2).toHaveLength(3);
     });
 
     it('(arraylike, arraylike) : should handle objects that arent arrays, but are arraylike', function () {
@@ -281,37 +280,37 @@ describe('cheerio', function () {
       arr2[1] = 'e';
       arr2[2] = 'f';
       $.merge(arr1, arr2);
-      expect(arr1).to.have.length(6);
-      expect(arr1[3]).to.equal('d');
-      expect(arr1[4]).to.equal('e');
-      expect(arr1[5]).to.equal('f');
-      expect(arr2).to.have.length(3);
+      expect(arr1).toHaveLength(6);
+      expect(arr1[3]).toBe('d');
+      expect(arr1[4]).toBe('e');
+      expect(arr1[5]).toBe('f');
+      expect(arr2).toHaveLength(3);
     });
 
     it('(?, ?) : should gracefully reject invalid inputs', function () {
       var ret = $.merge([4], 3);
-      expect(ret).to.not.be.ok();
+      expect(ret).toBeFalsy();
       ret = $.merge({}, {});
-      expect(ret).to.not.be.ok();
+      expect(ret).toBeFalsy();
       ret = $.merge([], {});
-      expect(ret).to.not.be.ok();
+      expect(ret).toBeFalsy();
       ret = $.merge({}, []);
-      expect(ret).to.not.be.ok();
+      expect(ret).toBeFalsy();
       var fakeArray1 = { length: 3 };
       fakeArray1[0] = 'a';
       fakeArray1[1] = 'b';
       fakeArray1[3] = 'd';
       ret = $.merge(fakeArray1, []);
-      expect(ret).to.not.be.ok();
+      expect(ret).toBeFalsy();
       ret = $.merge([], fakeArray1);
-      expect(ret).to.not.be.ok();
+      expect(ret).toBeFalsy();
       fakeArray1 = {};
       fakeArray1.length = '7';
       ret = $.merge(fakeArray1, []);
-      expect(ret).to.not.be.ok();
+      expect(ret).toBeFalsy();
       fakeArray1.length = -1;
       ret = $.merge(fakeArray1, []);
-      expect(ret).to.not.be.ok();
+      expect(ret).toBeFalsy();
     });
 
     it('(?, ?) : should no-op on invalid inputs', function () {
@@ -320,15 +319,15 @@ describe('cheerio', function () {
       fakeArray1[1] = 'b';
       fakeArray1[3] = 'd';
       $.merge(fakeArray1, []);
-      expect(fakeArray1).to.have.length(3);
-      expect(fakeArray1[0]).to.equal('a');
-      expect(fakeArray1[1]).to.equal('b');
-      expect(fakeArray1[3]).to.equal('d');
+      expect(fakeArray1).toHaveLength(3);
+      expect(fakeArray1[0]).toBe('a');
+      expect(fakeArray1[1]).toBe('b');
+      expect(fakeArray1[3]).toBe('d');
       $.merge([], fakeArray1);
-      expect(fakeArray1).to.have.length(3);
-      expect(fakeArray1[0]).to.equal('a');
-      expect(fakeArray1[1]).to.equal('b');
-      expect(fakeArray1[3]).to.equal('d');
+      expect(fakeArray1).toHaveLength(3);
+      expect(fakeArray1[0]).toBe('a');
+      expect(fakeArray1[1]).toBe('b');
+      expect(fakeArray1[3]).toBe('d');
     });
   });
 
@@ -344,8 +343,8 @@ describe('cheerio', function () {
       var $fruits = $('#fruits');
       var $apple = $('.apple');
 
-      expect($.contains($food[0], $fruits[0])).to.equal(true);
-      expect($.contains($food[0], $apple[0])).to.equal(true);
+      expect($.contains($food[0], $fruits[0])).toBe(true);
+      expect($.contains($food[0], $apple[0])).toBe(true);
     });
 
     it('(container, other) : should not detect elements that are not contained', function () {
@@ -353,11 +352,11 @@ describe('cheerio', function () {
       var $vegetables = $('#vegetables');
       var $apple = $('.apple');
 
-      expect($.contains($vegetables[0], $apple[0])).to.equal(false);
-      expect($.contains($fruits[0], $vegetables[0])).to.equal(false);
-      expect($.contains($vegetables[0], $fruits[0])).to.equal(false);
-      expect($.contains($fruits[0], $fruits[0])).to.equal(false);
-      expect($.contains($vegetables[0], $vegetables[0])).to.equal(false);
+      expect($.contains($vegetables[0], $apple[0])).toBe(false);
+      expect($.contains($fruits[0], $vegetables[0])).toBe(false);
+      expect($.contains($vegetables[0], $fruits[0])).toBe(false);
+      expect($.contains($fruits[0], $fruits[0])).toBe(false);
+      expect($.contains($vegetables[0], $vegetables[0])).toBe(false);
     });
   });
 
@@ -365,7 +364,7 @@ describe('cheerio', function () {
     it('() : should return a cheerio-wrapped root object', function () {
       var $ = cheerio.load('<html><head></head><body>foo</body></html>');
       $.root().append('<div id="test"></div>');
-      expect($.html()).to.equal(
+      expect($.html()).toBe(
         '<html><head></head><body>foo</body></html><div id="test"></div>'
       );
     });

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -1,7 +1,6 @@
-var expect = require('expect.js');
 var htmlparser2 = require('htmlparser2');
 var cheerio = require('../');
-var fixtures = require('./fixtures');
+var fixtures = require('./__fixtures__/fixtures');
 var fruits = fixtures.fruits;
 var food = fixtures.food;
 
@@ -11,57 +10,57 @@ var multiclass = '<p><a class="btn primary" href="#">Save</a></p>';
 
 describe('cheerio', function () {
   it('should get the version', function () {
-    expect(/\d+\.\d+\.\d+/.test(cheerio.version)).to.be.ok();
+    expect(cheerio.version).toMatch(/\d+\.\d+\.\d+/);
   });
 
   it('cheerio(null) should return be empty', function () {
-    expect(cheerio(null)).to.be.empty();
+    expect(cheerio(null)).toHaveLength(0);
   });
 
   it('cheerio(undefined) should be empty', function () {
-    expect(cheerio(undefined)).to.be.empty();
+    expect(cheerio(undefined)).toHaveLength(0);
   });
 
   it('cheerio(null) should be empty', function () {
-    expect(cheerio('')).to.be.empty();
+    expect(cheerio('')).toHaveLength(0);
   });
 
   it('cheerio(selector) with no context or root should be empty', function () {
-    expect(cheerio('.h2')).to.be.empty();
-    expect(cheerio('#fruits')).to.be.empty();
+    expect(cheerio('.h2')).toHaveLength(0);
+    expect(cheerio('#fruits')).toHaveLength(0);
   });
 
   it('cheerio(node) : should override previously-loaded nodes', function () {
     var $ = cheerio.load('<div><span></span></div>');
     var spanNode = $('span')[0];
     var $span = $(spanNode);
-    expect($span[0]).to.equal(spanNode);
+    expect($span[0]).toBe(spanNode);
   });
 
   it('should be able to create html without a root or context', function () {
     var $h2 = cheerio('<h2>');
-    expect($h2).to.not.be.empty();
-    expect($h2).to.have.length(1);
-    expect($h2[0].tagName).to.equal('h2');
+    expect($h2).not.toHaveLength(0);
+    expect($h2).toHaveLength(1);
+    expect($h2[0].tagName).toBe('h2');
   });
 
   it('should be able to create complicated html', function () {
     var $script = cheerio(script);
-    expect($script).to.not.be.empty();
-    expect($script).to.have.length(1);
-    expect($script[0].attribs.src).to.equal('script.js');
-    expect($script[0].attribs.type).to.equal('text/javascript');
-    expect($script[0].childNodes).to.be.empty();
+    expect($script).not.toHaveLength(0);
+    expect($script).toHaveLength(1);
+    expect($script[0].attribs.src).toBe('script.js');
+    expect($script[0].attribs.type).toBe('text/javascript');
+    expect($script[0].childNodes).toHaveLength(0);
   });
 
   function testAppleSelect($apple) {
-    expect($apple).to.have.length(1);
+    expect($apple).toHaveLength(1);
     $apple = $apple[0];
-    expect($apple.parentNode.tagName).to.equal('ul');
-    expect($apple.prev).to.be(null);
-    expect($apple.next.attribs['class']).to.equal('orange');
-    expect($apple.childNodes).to.have.length(1);
-    expect($apple.childNodes[0].data).to.equal('Apple');
+    expect($apple.parentNode.tagName).toBe('ul');
+    expect($apple.prev).toBe(null);
+    expect($apple.next.attribs['class']).toBe('orange');
+    expect($apple.childNodes).toHaveLength(1);
+    expect($apple.childNodes[0].data).toBe('Apple');
   }
 
   it('should be able to select .apple with only a context', function () {
@@ -81,24 +80,24 @@ describe('cheerio', function () {
 
   it('should be able to select an id', function () {
     var $fruits = cheerio('#fruits', null, fruits);
-    expect($fruits).to.have.length(1);
-    expect($fruits[0].attribs.id).to.equal('fruits');
+    expect($fruits).toHaveLength(1);
+    expect($fruits[0].attribs.id).toBe('fruits');
   });
 
   it('should be able to select a tag', function () {
     var $ul = cheerio('ul', fruits);
-    expect($ul).to.have.length(1);
-    expect($ul[0].tagName).to.equal('ul');
+    expect($ul).toHaveLength(1);
+    expect($ul[0].tagName).toBe('ul');
   });
 
   it('should accept a node reference as a context', function () {
     var $elems = cheerio('<div><span></span></div>');
-    expect(cheerio('span', $elems[0])).to.have.length(1);
+    expect(cheerio('span', $elems[0])).toHaveLength(1);
   });
 
   it('should accept an array of node references as a context', function () {
     var $elems = cheerio('<div><span></span></div>');
-    expect(cheerio('span', $elems.toArray())).to.have.length(1);
+    expect(cheerio('span', $elems.toArray())).toHaveLength(1);
   });
 
   it('should select only elements inside given context (Issue #193)', function () {
@@ -106,15 +105,15 @@ describe('cheerio', function () {
     var $fruits = $('#fruits');
     var fruitElements = $('li', $fruits);
 
-    expect(fruitElements).to.have.length(3);
+    expect(fruitElements).toHaveLength(3);
   });
 
   it('should be able to select multiple tags', function () {
     var $fruits = cheerio('li', null, fruits);
-    expect($fruits).to.have.length(3);
+    expect($fruits).toHaveLength(3);
     var classes = ['apple', 'orange', 'pear'];
     $fruits.each(function (idx, $fruit) {
-      expect($fruit.attribs['class']).to.equal(classes[idx]);
+      expect($fruit.attribs['class']).toBe(classes[idx]);
     });
   });
 
@@ -135,18 +134,18 @@ describe('cheerio', function () {
 
   it('should be able to select multiple classes: cheerio(".btn.primary")', function () {
     var $a = cheerio('.btn.primary', multiclass);
-    expect($a).to.have.length(1);
-    expect($a[0].childNodes[0].data).to.equal('Save');
+    expect($a).toHaveLength(1);
+    expect($a[0].childNodes[0].data).toBe('Save');
   });
 
   it('should not create a top-level node', function () {
     var $elem = cheerio('* div', '<div>');
-    expect($elem).to.have.length(0);
+    expect($elem).toHaveLength(0);
   });
 
   it('should be able to select multiple elements: cheerio(".apple, #fruits")', function () {
     var $elems = cheerio('.apple, #fruits', fruits);
-    expect($elems).to.have.length(2);
+    expect($elems).toHaveLength(2);
 
     var $apple = $elems.toArray().filter(function (elem) {
       return elem.attribs['class'] === 'apple';
@@ -155,66 +154,66 @@ describe('cheerio', function () {
       return elem.attribs.id === 'fruits';
     });
     testAppleSelect($apple);
-    expect($fruits[0].attribs.id).to.equal('fruits');
+    expect($fruits[0].attribs.id).toBe('fruits');
   });
 
   it('should select first element cheerio(:first)', function () {
     var $elem = cheerio('li:first', fruits);
-    expect($elem.attr('class')).to.equal('apple');
+    expect($elem.attr('class')).toBe('apple');
 
     var $filtered = cheerio('li', fruits).filter(':even');
-    expect($filtered).to.have.length(2);
+    expect($filtered).toHaveLength(2);
   });
 
   it('should be able to select immediate children: cheerio("#fruits > .pear")', function () {
     var $food = cheerio(food);
     cheerio('.pear', $food).append('<li class="pear">Another Pear!</li>');
-    expect(cheerio('#fruits .pear', $food)).to.have.length(2);
+    expect(cheerio('#fruits .pear', $food)).toHaveLength(2);
     var $elem = cheerio('#fruits > .pear', $food);
-    expect($elem).to.have.length(1);
-    expect($elem.attr('class')).to.equal('pear');
+    expect($elem).toHaveLength(1);
+    expect($elem.attr('class')).toBe('pear');
   });
 
   it('should be able to select immediate children: cheerio(".apple + .pear")', function () {
     var $elem = cheerio('.apple + li', fruits);
-    expect($elem).to.have.length(1);
+    expect($elem).toHaveLength(1);
     $elem = cheerio('.apple + .pear', fruits);
-    expect($elem).to.have.length(0);
+    expect($elem).toHaveLength(0);
     $elem = cheerio('.apple + .orange', fruits);
-    expect($elem).to.have.length(1);
-    expect($elem.attr('class')).to.equal('orange');
+    expect($elem).toHaveLength(1);
+    expect($elem.attr('class')).toBe('orange');
   });
 
   it('should be able to select immediate children: cheerio(".apple ~ .pear")', function () {
     var $elem = cheerio('.apple ~ li', fruits);
-    expect($elem).to.have.length(2);
+    expect($elem).toHaveLength(2);
     $elem = cheerio('.apple ~ .pear', fruits);
-    expect($elem.attr('class')).to.equal('pear');
+    expect($elem.attr('class')).toBe('pear');
   });
 
   it('should handle wildcards on attributes: cheerio("li[class*=r]")', function () {
     var $elem = cheerio('li[class*=r]', fruits);
-    expect($elem).to.have.length(2);
-    expect($elem.eq(0).attr('class')).to.equal('orange');
-    expect($elem.eq(1).attr('class')).to.equal('pear');
+    expect($elem).toHaveLength(2);
+    expect($elem.eq(0).attr('class')).toBe('orange');
+    expect($elem.eq(1).attr('class')).toBe('pear');
   });
 
   it('should handle beginning of attr selectors: cheerio("li[class^=o]")', function () {
     var $elem = cheerio('li[class^=o]', fruits);
-    expect($elem).to.have.length(1);
-    expect($elem.eq(0).attr('class')).to.equal('orange');
+    expect($elem).toHaveLength(1);
+    expect($elem.eq(0).attr('class')).toBe('orange');
   });
 
   it('should handle beginning of attr selectors: cheerio("li[class$=e]")', function () {
     var $elem = cheerio('li[class$=e]', fruits);
-    expect($elem).to.have.length(2);
-    expect($elem.eq(0).attr('class')).to.equal('apple');
-    expect($elem.eq(1).attr('class')).to.equal('orange');
+    expect($elem).toHaveLength(2);
+    expect($elem.eq(0).attr('class')).toBe('apple');
+    expect($elem.eq(1).attr('class')).toBe('orange');
   });
 
   it('should gracefully degrade on complex, unmatched queries', function () {
     var $elem = cheerio('Eastern States Cup #8-fin&nbsp;<br>Downhill&nbsp;');
-    expect($elem).to.have.length(0); // []
+    expect($elem).toHaveLength(0);
   });
 
   it('(extended Array) should not interfere with prototype methods (issue #119)', function () {
@@ -222,28 +221,28 @@ describe('cheerio', function () {
     extended.find = extended.children = extended.each = function () {};
     var $empty = cheerio(extended);
 
-    expect($empty.find).to.be(cheerio.prototype.find);
-    expect($empty.children).to.be(cheerio.prototype.children);
-    expect($empty.each).to.be(cheerio.prototype.each);
+    expect($empty.find).toBe(cheerio.prototype.find);
+    expect($empty.children).toBe(cheerio.prototype.children);
+    expect($empty.each).toBe(cheerio.prototype.each);
   });
 
   it('should set html(number) as a string', function () {
     var $elem = cheerio('<div>');
     $elem.html(123);
-    expect(typeof $elem.text()).to.equal('string');
+    expect(typeof $elem.text()).toBe('string');
   });
 
   it('should set text(number) as a string', function () {
     var $elem = cheerio('<div>');
     $elem.text(123);
-    expect(typeof $elem.text()).to.equal('string');
+    expect(typeof $elem.text()).toBe('string');
   });
 
   describe('.load', function () {
     it('should generate selections as proper instances', function () {
       var $ = cheerio.load(fruits);
 
-      expect($('.apple')).to.be.a($);
+      expect($('.apple')).toBeInstanceOf($);
     });
 
     it('should be able to filter down using the context', function () {
@@ -251,22 +250,22 @@ describe('cheerio', function () {
       var apple = $('.apple', 'ul');
       var lis = $('li', 'ul');
 
-      expect(apple).to.have.length(1);
-      expect(lis).to.have.length(3);
+      expect(apple).toHaveLength(1);
+      expect(lis).toHaveLength(3);
     });
 
     it('should allow loading a pre-parsed DOM', function () {
       var dom = htmlparser2.parseDOM(food);
       var $ = cheerio.load(dom);
 
-      expect($('ul')).to.have.length(3);
+      expect($('ul')).toHaveLength(3);
     });
 
     it('should allow loading a single element', function () {
       var el = htmlparser2.parseDOM(food)[0];
       var $ = cheerio.load(el);
 
-      expect($('ul')).to.have.length(3);
+      expect($('ul')).toHaveLength(3);
     });
 
     it('should render xml in html() when options.xml = true', function () {
@@ -274,8 +273,8 @@ describe('cheerio', function () {
       var expected = '<MixedCaseTag UPPERCASEATTRIBUTE=""/>';
       var $ = cheerio.load(str, { xml: true });
 
-      expect($('MixedCaseTag').get(0).tagName).to.equal('MixedCaseTag');
-      expect($.html()).to.be(expected);
+      expect($('MixedCaseTag').get(0).tagName).toBe('MixedCaseTag');
+      expect($.html()).toBe(expected);
     });
 
     it('should render xml in html() when options.xml = true passed to html()', function () {
@@ -287,9 +286,9 @@ describe('cheerio', function () {
         '<html><head></head><body><mixedcasetag uppercaseattribute=""></mixedcasetag></body></html>';
       var $ = cheerio.load(str);
 
-      expect($('MixedCaseTag').get(0).tagName).to.equal('mixedcasetag');
-      expect($.html()).to.be(expectedNoXml);
-      expect($.html({ xml: true })).to.be(expectedXml);
+      expect($('MixedCaseTag').get(0).tagName).toBe('mixedcasetag');
+      expect($.html()).toBe(expectedNoXml);
+      expect($.html({ xml: true })).toBe(expectedXml);
     });
 
     it('should respect options on the element level', function () {
@@ -302,22 +301,20 @@ describe('cheerio', function () {
       });
       var domEncoded = cheerio.load(str);
 
-      expect(domNotEncoded('footer').html()).to.be(expectedHtml);
-      // TODO: Make it more html friendly, maybe with custom encode tables
-      expect(domEncoded('footer').html()).to.be(expectedXml);
+      expect(domNotEncoded('footer').html()).toBe(expectedHtml);
+      expect(domEncoded('footer').html()).toBe(expectedXml);
     });
 
     it('should use htmlparser2 if xml option is used', function () {
       var str = '<div></div>';
       var dom = cheerio.load(str, null, false);
-      // Should use htmlparser2 and not add <html>, <body> etc. tags
-      expect(dom.html()).to.be(str);
+      expect(dom.html()).toBe(str);
     });
 
     it('should return a fully-qualified Function', function () {
       var $ = cheerio.load('<div>');
 
-      expect($).to.be.a(Function);
+      expect($).toBeInstanceOf(Function);
     });
 
     describe('prototype extensions', function () {
@@ -332,13 +329,11 @@ describe('cheerio', function () {
 
         var $div = $('div');
 
-        expect($div.myPlugin).to.be.a('function');
-        expect($div.myPlugin().context).to.be($div);
-        expect(Array.prototype.slice.call($div.myPlugin(1, 2, 3).args)).to.eql([
-          1,
-          2,
-          3,
-        ]);
+        expect(typeof $div.myPlugin).toBe('function');
+        expect($div.myPlugin().context).toBe($div);
+        expect(
+          Array.prototype.slice.call($div.myPlugin(1, 2, 3).args)
+        ).toStrictEqual([1, 2, 3]);
       });
 
       it('should honor extensions defined on `fn` property', function () {
@@ -352,13 +347,11 @@ describe('cheerio', function () {
 
         var $div = $('div');
 
-        expect($div.myPlugin).to.be.a('function');
-        expect($div.myPlugin().context).to.be($div);
-        expect(Array.prototype.slice.call($div.myPlugin(1, 2, 3).args)).to.eql([
-          1,
-          2,
-          3,
-        ]);
+        expect(typeof $div.myPlugin).toBe('function');
+        expect($div.myPlugin().context).toBe($div);
+        expect(
+          Array.prototype.slice.call($div.myPlugin(1, 2, 3).args)
+        ).toStrictEqual([1, 2, 3]);
       });
 
       it('should isolate extensions between loaded functions', function () {
@@ -367,7 +360,7 @@ describe('cheerio', function () {
 
         $a.prototype.foo = function () {};
 
-        expect($b('div').foo).to.be(undefined);
+        expect($b('div').foo).toBe(undefined);
       });
     });
   });

--- a/test/parse.js
+++ b/test/parse.js
@@ -1,4 +1,3 @@
-var expect = require('expect.js');
 var parse = require('../lib/parse');
 var defaultOpts = require('../lib/options').default;
 
@@ -41,9 +40,9 @@ describe('parse', function () {
   describe('evaluate', function () {
     it('should parse basic empty tags: ' + basic, function () {
       var tag = parse(basic, defaultOpts, true).children[0];
-      expect(tag.type).to.equal('tag');
-      expect(tag.tagName).to.equal('html');
-      expect(tag.childNodes).to.have.length(2);
+      expect(tag.type).toBe('tag');
+      expect(tag.tagName).toBe('html');
+      expect(tag.childNodes).toHaveLength(2);
     });
 
     it('should handle sibling tags: ' + siblings, function () {
@@ -51,165 +50,164 @@ describe('parse', function () {
       var h2 = dom[0];
       var p = dom[1];
 
-      expect(dom).to.have.length(2);
-      expect(h2.tagName).to.equal('h2');
-      expect(p.tagName).to.equal('p');
+      expect(dom).toHaveLength(2);
+      expect(h2.tagName).toBe('h2');
+      expect(p.tagName).toBe('p');
     });
 
     it('should handle single tags: ' + single, function () {
       var tag = parse(single, defaultOpts, false).children[0];
-      expect(tag.type).to.equal('tag');
-      expect(tag.tagName).to.equal('br');
-      expect(tag.childNodes).to.be.empty();
+      expect(tag.type).toBe('tag');
+      expect(tag.tagName).toBe('br');
+      expect(tag.childNodes).toHaveLength(0);
     });
 
     it('should handle malformatted single tags: ' + singleWrong, function () {
       var tag = parse(singleWrong, defaultOpts, false).children[0];
-      expect(tag.type).to.equal('tag');
-      expect(tag.tagName).to.equal('br');
-      expect(tag.childNodes).to.be.empty();
+      expect(tag.type).toBe('tag');
+      expect(tag.tagName).toBe('br');
+      expect(tag.childNodes).toHaveLength(0);
     });
 
     it('should handle tags with children: ' + children, function () {
       var tag = parse(children, defaultOpts, true).children[0];
-      expect(tag.type).to.equal('tag');
-      expect(tag.tagName).to.equal('html');
-      expect(tag.childNodes).to.be.ok();
-      expect(tag.childNodes[1].tagName).to.equal('body');
-      expect(tag.childNodes[1].childNodes).to.have.length(1);
+      expect(tag.type).toBe('tag');
+      expect(tag.tagName).toBe('html');
+      expect(tag.childNodes).toBeTruthy();
+      expect(tag.childNodes[1].tagName).toBe('body');
+      expect(tag.childNodes[1].childNodes).toHaveLength(1);
     });
 
     it('should handle tags with children: ' + li, function () {
       var tag = parse(li, defaultOpts, false).children[0];
-      expect(tag.childNodes).to.have.length(1);
-      expect(tag.childNodes[0].data).to.equal('Durian');
+      expect(tag.childNodes).toHaveLength(1);
+      expect(tag.childNodes[0].data).toBe('Durian');
     });
 
     it('should handle tags with attributes: ' + attributes, function () {
       var attrs = parse(attributes, defaultOpts, false).children[0].attribs;
-      expect(attrs).to.be.ok();
-      expect(attrs.src).to.equal('hello.png');
-      expect(attrs.alt).to.equal('man waving');
+      expect(attrs).toBeTruthy();
+      expect(attrs.src).toBe('hello.png');
+      expect(attrs.alt).toBe('man waving');
     });
 
     it('should handle value-less attributes: ' + noValueAttribute, function () {
       var attrs = parse(noValueAttribute, defaultOpts, false).children[0]
         .attribs;
-      expect(attrs).to.be.ok();
-      expect(attrs.disabled).to.equal('');
+      expect(attrs).toBeTruthy();
+      expect(attrs.disabled).toBe('');
     });
 
     it('should handle comments: ' + comment, function () {
       var elem = parse(comment, defaultOpts, false).children[0];
-      expect(elem.type).to.equal('comment');
-      expect(elem.data).to.equal(' sexy ');
+      expect(elem.type).toBe('comment');
+      expect(elem.data).toBe(' sexy ');
     });
 
     it('should handle conditional comments: ' + conditional, function () {
       var elem = parse(conditional, defaultOpts, false).children[0];
-      expect(elem.type).to.equal('comment');
-      expect(elem.data).to.equal(
+      expect(elem.type).toBe('comment');
+      expect(elem.data).toBe(
         conditional.replace('<!--', '').replace('-->', '')
       );
     });
 
     it('should handle text: ' + text, function () {
       var text_ = parse(text, defaultOpts, false).children[0];
-      expect(text_.type).to.equal('text');
-      expect(text_.data).to.equal('lorem ipsum');
+      expect(text_.type).toBe('text');
+      expect(text_.data).toBe('lorem ipsum');
     });
 
     it('should handle script tags: ' + script, function () {
       var script_ = parse(script, defaultOpts, false).children[0];
-      expect(script_.type).to.equal('script');
-      expect(script_.tagName).to.equal('script');
-      expect(script_.attribs.type).to.equal('text/javascript');
-      expect(script_.childNodes).to.have.length(1);
-      expect(script_.childNodes[0].type).to.equal('text');
-      expect(script_.childNodes[0].data).to.equal('alert("hi world!");');
+      expect(script_.type).toBe('script');
+      expect(script_.tagName).toBe('script');
+      expect(script_.attribs.type).toBe('text/javascript');
+      expect(script_.childNodes).toHaveLength(1);
+      expect(script_.childNodes[0].type).toBe('text');
+      expect(script_.childNodes[0].data).toBe('alert("hi world!");');
     });
 
     it('should handle style tags: ' + style, function () {
       var style_ = parse(style, defaultOpts, false).children[0];
-      expect(style_.type).to.equal('style');
-      expect(style_.tagName).to.equal('style');
-      expect(style_.attribs.type).to.equal('text/css');
-      expect(style_.childNodes).to.have.length(1);
-      expect(style_.childNodes[0].type).to.equal('text');
-      expect(style_.childNodes[0].data).to.equal(' h2 { color:blue; } ');
+      expect(style_.type).toBe('style');
+      expect(style_.tagName).toBe('style');
+      expect(style_.attribs.type).toBe('text/css');
+      expect(style_.childNodes).toHaveLength(1);
+      expect(style_.childNodes[0].type).toBe('text');
+      expect(style_.childNodes[0].data).toBe(' h2 { color:blue; } ');
     });
 
     it('should handle directives: ' + directive, function () {
       var elem = parse(directive, defaultOpts, true).children[0];
-      expect(elem.type).to.equal('directive');
-      expect(elem.data).to.equal('!DOCTYPE html ""');
-      expect(elem.tagName).to.equal('!doctype');
+      expect(elem.type).toBe('directive');
+      expect(elem.data).toBe('!DOCTYPE html ""');
+      expect(elem.tagName).toBe('!doctype');
     });
   });
 
   describe('.parse', function () {
     // root test utility
     function rootTest(root) {
-      expect(root.tagName).to.equal('root');
+      expect(root.tagName).toBe('root');
 
-      // Should exist but be null
-      expect(root.nextSibling).to.be(null);
-      expect(root.previousSibling).to.be(null);
-      expect(root.parentNode).to.be(null);
+      expect(root.nextSibling).toBe(null);
+      expect(root.previousSibling).toBe(null);
+      expect(root.parentNode).toBe(null);
 
       var child = root.childNodes[0];
-      expect(child.parentNode).to.be(root);
+      expect(child.parentNode).toBe(root);
     }
 
     it('should add root to: ' + basic, function () {
       var root = parse(basic, defaultOpts, true);
       rootTest(root);
-      expect(root.childNodes).to.have.length(1);
-      expect(root.childNodes[0].tagName).to.equal('html');
+      expect(root.childNodes).toHaveLength(1);
+      expect(root.childNodes[0].tagName).toBe('html');
     });
 
     it('should add root to: ' + siblings, function () {
       var root = parse(siblings, defaultOpts, false);
       rootTest(root);
-      expect(root.childNodes).to.have.length(2);
-      expect(root.childNodes[0].tagName).to.equal('h2');
-      expect(root.childNodes[1].tagName).to.equal('p');
-      expect(root.childNodes[1].parent).to.equal(root);
+      expect(root.childNodes).toHaveLength(2);
+      expect(root.childNodes[0].tagName).toBe('h2');
+      expect(root.childNodes[1].tagName).toBe('p');
+      expect(root.childNodes[1].parent).toBe(root);
     });
 
     it('should add root to: ' + comment, function () {
       var root = parse(comment, defaultOpts, false);
       rootTest(root);
-      expect(root.childNodes).to.have.length(1);
-      expect(root.childNodes[0].type).to.equal('comment');
+      expect(root.childNodes).toHaveLength(1);
+      expect(root.childNodes[0].type).toBe('comment');
     });
 
     it('should add root to: ' + text, function () {
       var root = parse(text, defaultOpts, false);
       rootTest(root);
-      expect(root.childNodes).to.have.length(1);
-      expect(root.childNodes[0].type).to.equal('text');
+      expect(root.childNodes).toHaveLength(1);
+      expect(root.childNodes[0].type).toBe('text');
     });
 
     it('should add root to: ' + scriptEmpty, function () {
       var root = parse(scriptEmpty, defaultOpts, false);
       rootTest(root);
-      expect(root.childNodes).to.have.length(1);
-      expect(root.childNodes[0].type).to.equal('script');
+      expect(root.childNodes).toHaveLength(1);
+      expect(root.childNodes[0].type).toBe('script');
     });
 
     it('should add root to: ' + styleEmpty, function () {
       var root = parse(styleEmpty, defaultOpts, false);
       rootTest(root);
-      expect(root.childNodes).to.have.length(1);
-      expect(root.childNodes[0].type).to.equal('style');
+      expect(root.childNodes).toHaveLength(1);
+      expect(root.childNodes[0].type).toBe('style');
     });
 
     it('should add root to: ' + directive, function () {
       var root = parse(directive, defaultOpts, true);
       rootTest(root);
-      expect(root.childNodes).to.have.length(2);
-      expect(root.childNodes[0].type).to.equal('directive');
+      expect(root.childNodes).toHaveLength(2);
+      expect(root.childNodes[0].type).toBe('directive');
     });
 
     it('should expose the DOM level 1 API', function () {
@@ -220,46 +218,46 @@ describe('parse', function () {
       ).childNodes[0];
       var childNodes = root.childNodes;
 
-      expect(childNodes).to.have.length(3);
+      expect(childNodes).toHaveLength(3);
 
-      expect(root.tagName).to.be('div');
-      expect(root.firstChild).to.be(childNodes[0]);
-      expect(root.lastChild).to.be(childNodes[2]);
+      expect(root.tagName).toBe('div');
+      expect(root.firstChild).toBe(childNodes[0]);
+      expect(root.lastChild).toBe(childNodes[2]);
 
-      expect(childNodes[0].tagName).to.be('a');
-      expect(childNodes[0].previousSibling).to.be(null);
-      expect(childNodes[0].nextSibling).to.be(childNodes[1]);
-      expect(childNodes[0].parentNode).to.be(root);
-      expect(childNodes[0].childNodes).to.have.length(0);
-      expect(childNodes[0].firstChild).to.be(null);
-      expect(childNodes[0].lastChild).to.be(null);
+      expect(childNodes[0].tagName).toBe('a');
+      expect(childNodes[0].previousSibling).toBe(null);
+      expect(childNodes[0].nextSibling).toBe(childNodes[1]);
+      expect(childNodes[0].parentNode).toBe(root);
+      expect(childNodes[0].childNodes).toHaveLength(0);
+      expect(childNodes[0].firstChild).toBe(null);
+      expect(childNodes[0].lastChild).toBe(null);
 
-      expect(childNodes[1].tagName).to.be('span');
-      expect(childNodes[1].previousSibling).to.be(childNodes[0]);
-      expect(childNodes[1].nextSibling).to.be(childNodes[2]);
-      expect(childNodes[1].parentNode).to.be(root);
-      expect(childNodes[1].childNodes).to.have.length(0);
-      expect(childNodes[1].firstChild).to.be(null);
-      expect(childNodes[1].lastChild).to.be(null);
+      expect(childNodes[1].tagName).toBe('span');
+      expect(childNodes[1].previousSibling).toBe(childNodes[0]);
+      expect(childNodes[1].nextSibling).toBe(childNodes[2]);
+      expect(childNodes[1].parentNode).toBe(root);
+      expect(childNodes[1].childNodes).toHaveLength(0);
+      expect(childNodes[1].firstChild).toBe(null);
+      expect(childNodes[1].lastChild).toBe(null);
 
-      expect(childNodes[2].tagName).to.be('p');
-      expect(childNodes[2].previousSibling).to.be(childNodes[1]);
-      expect(childNodes[2].nextSibling).to.be(null);
-      expect(childNodes[2].parentNode).to.be(root);
-      expect(childNodes[2].childNodes).to.have.length(0);
-      expect(childNodes[2].firstChild).to.be(null);
-      expect(childNodes[2].lastChild).to.be(null);
+      expect(childNodes[2].tagName).toBe('p');
+      expect(childNodes[2].previousSibling).toBe(childNodes[1]);
+      expect(childNodes[2].nextSibling).toBe(null);
+      expect(childNodes[2].parentNode).toBe(root);
+      expect(childNodes[2].childNodes).toHaveLength(0);
+      expect(childNodes[2].firstChild).toBe(null);
+      expect(childNodes[2].lastChild).toBe(null);
     });
 
     it('Should parse less than or equal sign sign', function () {
       var root = parse('<i>A</i><=<i>B</i>', defaultOpts, false);
       var childNodes = root.childNodes;
 
-      expect(childNodes[0].tagName).to.be('i');
-      expect(childNodes[0].childNodes[0].data).to.be('A');
-      expect(childNodes[1].data).to.be('<=');
-      expect(childNodes[2].tagName).to.be('i');
-      expect(childNodes[2].childNodes[0].data).to.be('B');
+      expect(childNodes[0].tagName).toBe('i');
+      expect(childNodes[0].childNodes[0].data).toBe('A');
+      expect(childNodes[1].data).toBe('<=');
+      expect(childNodes[2].tagName).toBe('i');
+      expect(childNodes[2].childNodes[0].data).toBe('B');
     });
 
     it('Should ignore unclosed CDATA', function () {
@@ -270,44 +268,44 @@ describe('parse', function () {
       );
       var childNodes = root.childNodes;
 
-      expect(childNodes[0].tagName).to.be('a');
-      expect(childNodes[1].tagName).to.be('script');
-      expect(childNodes[1].childNodes[0].data).to.be('foo //<![CDATA[ bar');
-      expect(childNodes[2].tagName).to.be('b');
+      expect(childNodes[0].tagName).toBe('a');
+      expect(childNodes[1].tagName).toBe('script');
+      expect(childNodes[1].childNodes[0].data).toBe('foo //<![CDATA[ bar');
+      expect(childNodes[2].tagName).toBe('b');
     });
 
     it('Should add <head> to documents', function () {
       var root = parse('<html></html>', defaultOpts, true);
       var childNodes = root.childNodes;
 
-      expect(childNodes[0].tagName).to.be('html');
-      expect(childNodes[0].childNodes[0].tagName).to.be('head');
+      expect(childNodes[0].tagName).toBe('html');
+      expect(childNodes[0].childNodes[0].tagName).toBe('head');
     });
 
     it('Should implicitly create <tr> around <td>', function () {
       var root = parse('<table><td>bar</td></tr></table>', defaultOpts, false);
       var childNodes = root.childNodes;
 
-      expect(childNodes[0].tagName).to.be('table');
-      expect(childNodes[0].childNodes.length).to.be(1);
-      expect(childNodes[0].childNodes[0].tagName).to.be('tbody');
-      expect(childNodes[0].childNodes[0].childNodes[0].tagName).to.be('tr');
+      expect(childNodes[0].tagName).toBe('table');
+      expect(childNodes[0].childNodes.length).toBe(1);
+      expect(childNodes[0].childNodes[0].tagName).toBe('tbody');
+      expect(childNodes[0].childNodes[0].childNodes[0].tagName).toBe('tr');
       expect(
         childNodes[0].childNodes[0].childNodes[0].childNodes[0].tagName
-      ).to.be('td');
+      ).toBe('td');
       expect(
         childNodes[0].childNodes[0].childNodes[0].childNodes[0].childNodes[0]
           .data
-      ).to.be('bar');
+      ).toBe('bar');
     });
 
     it('Should parse custom tag <line>', function () {
       var root = parse('<line>test</line>', defaultOpts, false);
       var childNodes = root.childNodes;
 
-      expect(childNodes.length).to.be(1);
-      expect(childNodes[0].tagName).to.be('line');
-      expect(childNodes[0].childNodes[0].data).to.be('test');
+      expect(childNodes.length).toBe(1);
+      expect(childNodes[0].tagName).toBe('line');
+      expect(childNodes[0].childNodes[0].data).toBe('test');
     });
 
     it('Should properly parse misnested table tags', function () {
@@ -318,12 +316,12 @@ describe('parse', function () {
       );
       var childNodes = root.childNodes;
 
-      expect(childNodes.length).to.be(3);
+      expect(childNodes.length).toBe(3);
 
       childNodes.forEach(function (child, i) {
-        expect(child.tagName).to.be('tr');
-        expect(child.childNodes[0].tagName).to.be('td');
-        expect(child.childNodes[0].childNodes[0].data).to.be('i' + (i + 1));
+        expect(child.tagName).toBe('tr');
+        expect(child.childNodes[0].tagName).toBe('td');
+        expect(child.childNodes[0].childNodes[0].data).toBe('i' + (i + 1));
       });
     });
 
@@ -335,30 +333,30 @@ describe('parse', function () {
       var root = parse(html, defaultOpts, false);
       var childNodes = root.childNodes;
 
-      expect(childNodes[0].attribs.style).to.be(expectedAttr);
+      expect(childNodes[0].attribs.style).toBe(expectedAttr);
     });
 
     it('Should treat <xmp> tag content as text', function () {
       var root = parse('<xmp><h2></xmp>', defaultOpts, false);
       var childNodes = root.childNodes;
 
-      expect(childNodes[0].childNodes[0].data).to.be('<h2>');
+      expect(childNodes[0].childNodes[0].data).toBe('<h2>');
     });
 
     it('Should correctly parse malformed numbered entities', function () {
       var root = parse('<p>z&#</p>', defaultOpts, false);
       var childNodes = root.childNodes;
 
-      expect(childNodes[0].childNodes[0].data).to.be('z&#');
+      expect(childNodes[0].childNodes[0].data).toBe('z&#');
     });
 
     it('Should correctly parse mismatched headings', function () {
       var root = parse('<h2>Test</h3><div></div>', defaultOpts, false);
       var childNodes = root.childNodes;
 
-      expect(childNodes.length).to.be(2);
-      expect(childNodes[0].tagName).to.be('h2');
-      expect(childNodes[1].tagName).to.be('div');
+      expect(childNodes.length).toBe(2);
+      expect(childNodes[0].tagName).toBe('h2');
+      expect(childNodes[1].tagName).toBe('div');
     });
 
     it('Should correctly parse tricky <pre> content', function () {
@@ -369,9 +367,9 @@ describe('parse', function () {
       );
       var childNodes = root.childNodes;
 
-      expect(childNodes.length).to.be(1);
-      expect(childNodes[0].tagName).to.be('pre');
-      expect(childNodes[0].childNodes[0].data).to.be(
+      expect(childNodes.length).toBe(1);
+      expect(childNodes[0].tagName).toBe('pre');
+      expect(childNodes[0].childNodes[0].data).toBe(
         'A <- factor(A, levels = c("c","a","b"))\n'
       );
     });
@@ -384,8 +382,8 @@ describe('parse', function () {
       );
       var location = root.children[0].sourceCodeLocation;
 
-      expect(location).to.be.an('object');
-      expect(location.endOffset).to.be(12);
+      expect(typeof location).toBe('object');
+      expect(location.endOffset).toBe(12);
     });
   });
 });

--- a/test/xml.js
+++ b/test/xml.js
@@ -1,4 +1,3 @@
-var expect = require('expect.js');
 var cheerio = require('..');
 
 function xml(str, options) {
@@ -17,38 +16,38 @@ describe('render', function () {
     it('should render <media:thumbnail /> tags correctly', function () {
       var str =
         '<media:thumbnail url="http://www.foo.com/keyframe.jpg" width="75" height="50" time="12:05:01.123" />';
-      expect(xml(str)).to.equal(
+      expect(xml(str)).toBe(
         '<media:thumbnail url="http://www.foo.com/keyframe.jpg" width="75" height="50" time="12:05:01.123"/>'
       );
     });
 
     it('should render <link /> tags (RSS) correctly', function () {
       var str = '<link>http://www.github.com/</link>';
-      expect(xml(str)).to.equal('<link>http://www.github.com/</link>');
+      expect(xml(str)).toBe('<link>http://www.github.com/</link>');
     });
 
     it('should escape entities', function () {
       var str = '<tag attr="foo &amp; bar"/>';
-      expect(xml(str)).to.equal(str);
+      expect(xml(str)).toBe(str);
     });
 
     it('should render HTML as XML', function () {
       var $ = cheerio.load('<foo></foo>', null, false);
-      expect($.xml()).to.equal('<foo/>');
+      expect($.xml()).toBe('<foo/>');
     });
   });
 
   describe('(dom)', function () {
     it('should keep camelCase for new nodes', function () {
       var str = '<g><someElem someAttribute="something">hello</someElem></g>';
-      expect(dom(str, { xml: false })).to.equal(
+      expect(dom(str, { xml: false })).toBe(
         '<someelem someattribute="something">hello</someelem>'
       );
     });
 
     it('should keep camelCase for new nodes', function () {
       var str = '<g><someElem someAttribute="something">hello</someElem></g>';
-      expect(dom(str, { xml: true })).to.equal(
+      expect(dom(str, { xml: true })).toBe(
         '<someElem someAttribute="something">hello</someElem>'
       );
     });
@@ -57,7 +56,7 @@ describe('render', function () {
       var str = '<g><someElem someAttribute="something">hello</someElem></g>';
       var $ = cheerio.load('', { xml: false });
 
-      expect($(str).html()).to.equal(
+      expect($(str).html()).toBe(
         '<someelem someattribute="something">hello</someelem>'
       );
     });


### PR DESCRIPTION
Jest has the same minimum Node version as Mocha, but comes with a lot of batteries included (eg. coverage, assertions), which helps with making things more predictable.

Most of these changes were made using `jest-codemods`.