### PR TITLE
Switch to GitHub Actions CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,6 +35,6 @@ jobs:
         run: npm ci
 
       - name: Run benchmarks
-        run: "node benchmark/benchmark.js --regex '^(?!.*highmem)'"
+        run: npm run benchmark
         env:
           BENCHMARK: true

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,6 +2,8 @@ name: Benchmark
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
 
 env:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Benchmark
 
 on:
   push:
@@ -10,7 +10,7 @@ env:
   NODE: 14.x
 
 jobs:
-  ci:
+  benchmark:
     runs-on: ubuntu-latest
 
     steps:
@@ -34,5 +34,7 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
-      - name: Run tests
-        run: npm run test:jest && npm run test:types
+      - name: Run benchmarks
+        run: "node benchmark/benchmark.js --regex '^(?!.*highmem)'"
+        env:
+          BENCHMARK: true

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   benchmark:
     runs-on: ubuntu-latest
+    if: "!contains(github.event.commits[0].message, '[bench skip]') || !contains(github.event.commits[0].message, '[skip bench]')"
 
     steps:
       - name: Clone repository

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,7 +9,7 @@ on:
 env:
   CI: true
   FORCE_COLOR: 2
-  NODE: 14.x
+  NODE: 14
 
 jobs:
   benchmark:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,5 +45,19 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
-      - name: Run tests
-        run: npm run test:jest && npm run test:types
+      - name: Run Jest
+        run: npm run test:jest
+        if: matrix.node != 14
+
+      - name: Run Jest with coverage
+        run: npm run test:jest:cov
+        if: matrix.node == 14
+
+      - name: Test types
+        run: npm run test:types
+
+      - name: Run Coveralls
+        uses: coverallsapp/github-action@master
+        if: matrix.node == 14
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+env:
+  CI: true
+  FORCE_COLOR: 2
+  NODE: 14.x
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '${{ env.NODE }}'
+
+      - name: Set up npm cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-v${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-v${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
+            ${{ runner.OS }}-node-v${{ env.NODE }}-
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+  benchmark:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '${{ env.NODE }}'
+
+      - name: Set up npm cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-v${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-v${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
+            ${{ runner.OS }}-node-v${{ env.NODE }}-
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Run benchmarks
+        run: "node benchmark/benchmark.js --regex '^(?!.*highmem)'"
+        env:
+          BENCHMARK: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,20 @@ on:
 env:
   CI: true
   FORCE_COLOR: 2
-  NODE: 14.x
 
 jobs:
-  ci:
+  run:
+    name: Node ${{ matrix.node }}
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node:
+          - 10
+          - 12
+          - 14
+          - 15
 
     steps:
       - name: Clone repository
@@ -20,16 +29,16 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '${{ env.NODE }}'
+          node-version: '${{ matrix.node }}'
 
       - name: Set up npm cache
         uses: actions/cache@v2
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-v${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-node-v${{ matrix.node }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            ${{ runner.OS }}-node-v${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
-            ${{ runner.OS }}-node-v${{ env.NODE }}-
+            ${{ runner.OS }}-node-v${{ matrix.node }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
+            ${{ runner.OS }}-node-v${{ matrix.node }}-
 
       - name: Install npm dependencies
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,6 @@ jobs:
         run: npm run test:jest:cov
         if: matrix.node == env.NODE_COV
 
-      - name: Test types
-        run: npm run test:types
-
       - name: Run Coveralls
         uses: coverallsapp/github-action@master
         if: matrix.node == env.NODE_COV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 env:
   CI: true
   FORCE_COLOR: 2
+  NODE_COV: 14 # The Node.js version to run coveralls on
 
 jobs:
   run:
@@ -47,17 +48,17 @@ jobs:
 
       - name: Run Jest
         run: npm run test:jest
-        if: matrix.node != 14
+        if: matrix.node != env.NODE_COV
 
       - name: Run Jest with coverage
         run: npm run test:jest:cov
-        if: matrix.node == 14
+        if: matrix.node == env.NODE_COV
 
       - name: Test types
         run: npm run test:types
 
       - name: Run Coveralls
         uses: coverallsapp/github-action@master
-        if: matrix.node == 14
+        if: matrix.node == env.NODE_COV
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - '!dependabot/**'
   pull_request:
     # The branches below must be a subset of the branches above
     branches:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ on:
 env:
   CI: true
   FORCE_COLOR: 2
-  NODE: 14.x
+  NODE: 14
 
 jobs:
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,3 +38,6 @@ jobs:
 
       - name: Run lint
         run: npm run lint
+
+      - name: Test types
+        run: npm run test:types

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,8 @@ name: Lint
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
 
 env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Lint
 
 on:
   push:
@@ -10,7 +10,7 @@ env:
   NODE: 14.x
 
 jobs:
-  ci:
+  lint:
     runs-on: ubuntu-latest
 
     steps:
@@ -34,5 +34,5 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
-      - name: Run tests
-        run: npm run test:jest && npm run test:types
+      - name: Run lint
+        run: npm run lint

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -4,6 +4,11 @@ on:
     branches:
       - main
 
+env:
+  CI: true
+  FORCE_COLOR: 2
+  NODE: 14
+
 jobs:
   deploy:
     name: Deploy to GitHub Pages
@@ -12,7 +17,15 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: '${{ env.NODE }}'
+      - name: Set up npm cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-v${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-v${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
+            ${{ runner.OS }}-node-v${{ env.NODE }}-
       - run: npm ci
       - name: Build JSDoc
         run: npm run build:docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-node_js:
-  - lts/*
-script: make travis-test
-matrix:
-  fast_finish: true
-  include:
-    - env: BENCHMARK=true
-      script: "node benchmark/benchmark.js --regex '^(?!.*highmem)'"

--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,8 @@ subl:
 test-cov:
 	@./node_modules/.bin/jest --coverage
 
-# Due to occasional unavailability of the code coverage reporting service, the
-# exit status of the command in this recipe may optionally be ignored.
-report-cov: test-cov
-	cat coverage/lcov.info | ./node_modules/.bin/coveralls || [ "$(OPTIONAL)" = "true" ]
-
 travis-test: OPTIONAL = true
-travis-test: lint types report-cov
+travis-test: lint types
 	@true
 
 bench:

--- a/Readme.md
+++ b/Readme.md
@@ -3,8 +3,8 @@
 <h5 align="center">Fast, flexible & lean implementation of core jQuery designed specifically for the server.</h5>
 
 <div align="center">
-  <a href="https://travis-ci.org/cheeriojs/cheerio">
-    <img src="https://img.shields.io/travis/cheeriojs/cheerio/main" alt="Travis CI">
+  <a href="https://github.com/cheeriojs/cheerio/actions?query=workflow%3ACI+branch%3Amain">
+    <img src="https://img.shields.io/github/workflow/status/cheeriojs/cheerio/CI/main" alt="Build Status">
   </a>
   <a href="https://coveralls.io/github/cheeriojs/cheerio">
     <img src="https://img.shields.io/coveralls/github/cheeriojs/cheerio/main" alt="Coverage">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1737,19 +1737,6 @@
         "yaml": "^1.10.0"
       }
     },
-    "coveralls": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.0.tgz",
-      "integrity": "sha512-sHxOu2ELzW8/NC1UP5XVLbZDzO4S3VxfFye3XYCznopHy02YjNkHcj5bKaVw2O7hVaBdBjEdQGpie4II1mWhuQ==",
-      "dev": true,
-      "requires": {
-        "js-yaml": "^3.13.1",
-        "lcov-parse": "^1.0.0",
-        "log-driver": "^1.2.7",
-        "minimist": "^1.2.5",
-        "request": "^2.88.2"
-      }
-    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -4164,12 +4151,6 @@
         "package-json": "^6.3.0"
       }
     },
-    "lcov-parse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
-      "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
-      "dev": true
-    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -4265,12 +4246,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-      "dev": true
-    },
-    "log-driver": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
     },
     "log-symbols": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   "devDependencies": {
     "@types/node": "^14.14.10",
     "benchmark": "^2.1.4",
-    "coveralls": "^3.0.2",
     "eslint": "^7.10.0",
     "eslint-config-prettier": "^7.0.0",
     "eslint-plugin-jsdoc": "^30.6.2",
@@ -59,6 +58,7 @@
   "scripts": {
     "test": "npm run lint && npm run test:jest && npm run test:types",
     "test:jest": "jest",
+    "test:jest:cov": "npm run test:jest -- --coverage",
     "test:types": "tsd",
     "lint": "npm run lint:es && npm run lint:prettier",
     "lint:es": "eslint .",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "format:prettier": "npm run format:prettier:raw -- --write",
     "format:prettier:raw": "prettier \"**/*.{js,ts,md,json,yml}\" --ignore-path .prettierignore",
     "build:docs": "jsdoc --configure jsdoc-config.json",
+    "benchmark": "node benchmark/benchmark.js --regex \"^(?!.*highmem)\"",
     "pre-commit": "lint-staged"
   },
   "prettier": {


### PR DESCRIPTION
It seems there are a few issues:

1. ~~.travis.yml was using `make travis-test` but that was using `@npm run test:lint` which doesn't exist; I changed it to `@npm run lint` but the makefile isn't up to date.~~ **EDIT**: I switched to `npm test` but IMHO the Makefile should be removed to avoid confusion since it's clearly broken
2. it seems `make travis-test` is failing; `test-cov` also doesn't seem to work. Happy to sort everything out as long as you give me some hints. My suggestion is to move everything to npm scripts only and Actions including coverage.
3. I added another job with `BENCHMARK=true` 
4. We can add further Node.js versions, OS etc. Let me know and I can take a stab at it later. I'd just split lint to a separate action or job and run it only once.

Notes:

1. since Actions don't currently support `LTS` tags, I explicitly set this to 14 in an env var
2. I added npm caching which is what Travis CI was doing by default

EDIT: it seems that `npm test` didn't even run on Travis CI hence why the failures weren't caught sooner.
