### PR TITLE
Enforce LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce Unix newlines
+* text=auto eol=lf


### PR DESCRIPTION
On Windows `autocrlf` is `true` which results in CRLF being using thus prettier was complaining. This should always use LF regardless of OS or git settings and should work on git >= 2.10.

Refs https://github.com/cheeriojs/cheerio/pull/1599#issuecomment-751354103