### PR TITLE
dependabot: update GitHub Actions too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,9 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: wednesday
+      time: '12:00'


### PR DESCRIPTION
I went with a weekly schedule on Wednesday, but feel free to let me know or edit the PR to adapt it to your needs.

BTW, have you thought about using `versioning-strategy: increase` for the npm check?