### PR TITLE
JSDocs: enable Markdown IDs

### DIFF
--- a/jsdoc-config.json
+++ b/jsdoc-config.json
@@ -5,6 +5,9 @@
     "recurse": true
   },
   "plugins": ["plugins/markdown"],
+  "markdown": {
+    "idInHeadings": true
+  },
   "source": {
     "include": ["index.js", "lib"]
   }


### PR DESCRIPTION
**Untested yet**

I need to check if there are any duplicate IDs and how the plugin handles that case.