### PR TITLE
Simple parse for single elements

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -5,6 +5,7 @@ var DomUtils = require('htmlparser2').DomUtils;
 var parseWithHtmlparser2 = require('./parsers/htmlparser2').parse;
 var parseWithParse5 = require('./parsers/parse5').parse;
 var Document = require('domhandler').Document;
+var Element = require('domhandler').Element;
 
 /*
   Parser
@@ -12,6 +13,10 @@ var Document = require('domhandler').Document;
 exports = module.exports = function parse(content, options, isDocument) {
   if (typeof Buffer !== 'undefined' && Buffer.isBuffer(content)) {
     content = content.toString();
+  }
+
+  if (!isDocument) {
+    content = _parseSimple(content);
   }
 
   if (typeof content === 'string') {
@@ -37,6 +42,21 @@ exports = module.exports = function parse(content, options, isDocument) {
 
   return root;
 };
+
+// Attempts to match single html elements
+// like <..></..>, <../>, <..>
+var rsingleTag = /^<([a-z][^/\0>:\x20\t\r\n\f]*)[\x20\t\r\n\f]*\/?>(?:<\/\1>)?$/i;
+
+/**
+ * Parses one simple element and creates new element.
+ *
+ * @param {string} content - The new children.
+ * @returns {Element[] | string} The parent node.
+ */
+function _parseSimple(content) {
+  var parsed = typeof content === 'string' && rsingleTag.exec(content);
+  return parsed ? [new Element(parsed[1], {})] : content;
+}
 
 /**
  * Update the dom structure, for one changed layer.

--- a/test/api/manipulation.js
+++ b/test/api/manipulation.js
@@ -1577,6 +1577,13 @@ describe('$(...)', function () {
       expect($('li', item).html()).toBe('');
     });
 
+    it('() : should return empty string if nothing inside, with document', function () {
+      var item = '<html></html>';
+      var $obj = $(item);
+      expect($obj).toHaveLength(1);
+      expect($obj.html()).toBe('');
+    });
+
     it('(html) : should set the html for its children', function () {
       $fruits.html('<li class="durian">Durian</li>');
       var html = $fruits.html();

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -44,6 +44,13 @@ describe('cheerio', function () {
     expect($h2[0].tagName).toBe('h2');
   });
 
+  it('should be able to create html without a root or context, html tag', function () {
+    var $tag = cheerio('<html>');
+    expect($tag).not.toHaveLength(0);
+    expect($tag).toHaveLength(1);
+    expect($tag[0].tagName).toBe('html');
+  });
+
   it('should be able to create complicated html', function () {
     var $script = cheerio(script);
     expect($script).not.toHaveLength(0);

--- a/test/parse.js
+++ b/test/parse.js
@@ -149,7 +149,7 @@ describe('parse', function () {
   describe('.parse', function () {
     // root test utility
     function rootTest(root) {
-      expect(root.tagName).toBe('root');
+      expect(root.type).toBe('root');
 
       expect(root.nextSibling).toBe(null);
       expect(root.previousSibling).toBe(null);


### PR DESCRIPTION
It parses single `<x></x>, <x/>, <x>` style elements.
Currently `cheerio('<html></html>')` gives you empty result.

jQuery acts same way and may help solving #1045