### PR TITLE
Change how html string will be treated

### DIFF
--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -5,7 +5,7 @@
 var parse = require('./parse');
 var defaultOptions = require('./options').default;
 var flattenOptions = require('./options').flatten;
-var isHtml = require('./utils').isHtml;
+var getHtml = require('./utils').getHtml;
 
 /*
  * The API
@@ -54,9 +54,11 @@ var Cheerio = (module.exports = function (selector, context, root, options) {
     this._root = Cheerio.call(this, root);
   }
 
+  var match;
+
   // $(<html>)
-  if (typeof selector === 'string' && isHtml(selector)) {
-    selector = parse(selector, this.options, false).children;
+  if (typeof selector === 'string' && (match = getHtml(selector)) !== null) {
+    selector = parse(match, this.options, false).children;
   }
 
   // $($)
@@ -78,9 +80,9 @@ var Cheerio = (module.exports = function (selector, context, root, options) {
   if (!context) {
     context = this._root;
   } else if (typeof context === 'string') {
-    if (isHtml(context)) {
+    if ((match = getHtml(context)) !== null) {
       // $('li', '<ul>...</ul>')
-      context = parse(context, this.options, false);
+      context = parse(match, this.options, false);
       context = Cheerio.call(this, context);
     } else {
       // $('li', 'ul')

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -83,8 +83,8 @@ exports.cloneDom = function (dom) {
   return clone;
 };
 
-/** A simple way to check for HTML strings or ID strings. */
-var quickExpr = /^(?:[^#<]*(<[\w\W]+>)[^>]*$|#([\w-]*)$)/;
+/** A simple way to check for HTML strings. */
+var quickExpr = /^\s*(<[\w\W]+>)[^>]*$/;
 
 /**
  * Check if string is HTML.
@@ -105,6 +105,28 @@ exports.isHtml = function (str) {
   }
 
   // Run the regex
+  return quickExpr.test(str);
+};
+
+/**
+ * Check if string is HTML and return it.
+ *
+ * @private
+ *
+ * @param {string} str - String to check.
+ * @returns {string} Returns 'str' or html part from 'str'.
+ */
+exports.getHtml = function (str) {
+  // Faster than running regex, if str starts with `<` and ends with `>`, assume it's HTML
+  if (
+    str.charAt(0) === '<' &&
+    str.charAt(str.length - 1) === '>' &&
+    str.length >= 3
+  ) {
+    return str;
+  }
+
+  // Run the regex
   var match = quickExpr.exec(str);
-  return !!(match && match[1]);
+  return match ? match[1] : null;
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -84,7 +84,7 @@ exports.cloneDom = function (dom) {
 };
 
 /** A simple way to check for HTML strings. */
-var quickExpr = /^\s*(<[\w\W]+>)[^>]*$/;
+var quickExpr = /^\s*(<[\w\W]+>[^>]*?)\s*$/;
 
 /**
  * Check if string is HTML.


### PR DESCRIPTION
When jQuery tests html string they later use that matched string as html string, but cheerio discards it and uses original.
``` javascript
jQuery('\n<div></div>\n')
//=> [div]
cheerio('\n<div></div>\n')
//=> [text,div,text]
```
[L39](https://github.com/jquery/jquery/blob/8969732518470a7f8e654d5bc5be0b0076cb0b87/src/core/init.js#L39)