### PR TITLE
.html() send context to parse5

### DIFF
--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -753,12 +753,14 @@ exports.html = function (str) {
     return html(this[0].children, this.options);
   }
 
-  var opts = this.options;
+  var opts = Object.apply({}, this.options); // keep main options
 
   return domEach(this, function (_, el) {
     el.children.forEach(function (child) {
       child.next = child.prev = child.parent = null;
     });
+
+    opts.context = el;
 
     var content = str.cheerio
       ? str.clone().get()

--- a/lib/parsers/parse5.js
+++ b/lib/parsers/parse5.js
@@ -2,12 +2,16 @@ var parse5 = require('parse5');
 var htmlparser2Adapter = require('parse5-htmlparser2-tree-adapter');
 
 exports.parse = function (content, options, isDocument) {
-  var parse = isDocument ? parse5.parse : parse5.parseFragment;
-
-  return parse(content, {
+  var opts = {
     treeAdapter: htmlparser2Adapter,
     sourceCodeLocationInfo: options.sourceCodeLocationInfo,
-  });
+  };
+
+  var context = options.context;
+
+  return isDocument
+    ? parse5.parse(content, opts)
+    : parse5.parseFragment(context, content, opts);
 };
 
 exports.render = function (dom) {

--- a/test/api/manipulation.js
+++ b/test/api/manipulation.js
@@ -1611,6 +1611,19 @@ describe('$(...)', function () {
       $remove.replaceWith($children);
       expect($fruits.children()).toHaveLength(4);
     });
+
+    it('(script value) : should add content as text', function () {
+      var $data = '<a><b>';
+      var $script = $('<script>').html($data);
+
+      expect($script).toHaveLength(1);
+      expect($script[0].type).toBe('script');
+      expect($script[0].name).toBe('script');
+
+      expect($script[0].children).toHaveLength(1);
+      expect($script[0].children[0].type).toBe('text');
+      expect($script[0].children[0].data).toBe($data);
+    });
   });
 
   describe('.toString', function () {


### PR DESCRIPTION
using proper context when parsing in .html() 

It solves #1083