### PR TITLE
ESLint: enable `no-implicit-coercion` rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,7 @@
         "null": "ignore"
       }
     ],
+    "no-implicit-coercion": 2,
     "no-lonely-if": 2,
     "no-proto": 2,
     "curly": [2, "multi-line"],

--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -81,7 +81,7 @@ function setAttr(el, name, value) {
   if (value === null) {
     removeAttribute(el, name);
   } else {
-    el.attribs[name] = value + '';
+    el.attribs[name] = String(value);
   }
 }
 

--- a/lib/api/css.js
+++ b/lib/api/css.js
@@ -97,7 +97,7 @@ function getCss(el, prop) {
  */
 function stringify(obj) {
   return Object.keys(obj || {}).reduce(function (str, prop) {
-    return (str += '' + (str ? ' ' : '') + prop + ': ' + obj[prop] + ';');
+    return (str += String(str ? ' ' : '') + prop + ': ' + obj[prop] + ';');
   }, '');
 }
 

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -802,7 +802,7 @@ exports.html = function (str) {
 
     var content = str.cheerio
       ? str.clone().get()
-      : parse('' + str, opts, false).children;
+      : parse(String(str), opts, false).children;
 
     updateDOM(content, el);
   });

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -773,7 +773,7 @@ exports.last = function () {
  * @returns {Cheerio} The element at the `i`th position.
  */
 exports.eq = function (i) {
-  i = +i;
+  i = Number(i);
 
   // Use the first identity optimization if possible
   if (i === 0 && this.length <= 1) return this;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -107,5 +107,5 @@ exports.isHtml = function (str) {
 
   // Run the regex
   var match = quickExpr.exec(str);
-  return !!(match && match[1]);
+  return Boolean(match && match[1]);
 };


### PR DESCRIPTION
Not sure if we should go with this patch since it can potentially affect performance. That being said, it's used inconsistently right now. There are places with explicit coercion and others without.

The rule is configurable but I went with the defaults: https://eslint.org/docs/rules/no-implicit-coercion