### PR TITLE
parent() may fail in functions

### DIFF
--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -86,7 +86,7 @@ exports.parent = function (selector) {
     }
   });
 
-  if (arguments.length) {
+  if (selector) {
     set = exports.filter.call(set, selector, this);
   }
 

--- a/test/api/traversing.js
+++ b/test/api/traversing.js
@@ -619,6 +619,12 @@ describe('$(...)', function () {
       expect(result[1].attribs.id).toBe('vegetables');
     });
 
+    it('(undefined) : should not throw an exception', function () {
+      expect(function () {
+        $('li').parent(undefined);
+      }).not.toThrow();
+    });
+
     it('() : should return an empty object for top-level elements', function () {
       var result = $('html').parent();
       expect(result).toHaveLength(0);


### PR DESCRIPTION
parent() don't work well in functions if selector is undefined

``` javascript
function getParent(el, parent) {
    return el.parent(parent).not('body');
}

var parent = getParent($('#rating span'))

```
In [.parent()](https://github.com/cheeriojs/cheerio/blob/703ec166d8b98aab714ad8930858bbefaed847b1/lib/api/traversing.js#L89) has condition:
``` javascript
...
  if (arguments.length) {
...
```
but it will fail if used like in function above, since `arguments.length` will be 1 even when `selector` is actually undefined.
