### PR TITLE
Fix .add

### DIFF
--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -902,14 +902,8 @@ exports.end = function () {
  */
 exports.add = function (other, context) {
   var selection = this._make(other, context);
-  var contents = uniqueSort(selection.get().concat(this.get()));
-
-  for (var i = 0; i < contents.length; ++i) {
-    selection[i] = contents[i];
-  }
-  selection.length = contents.length;
-
-  return selection;
+  var contents = uniqueSort(this.get().concat(selection.get()));
+  return this._make(contents);
 };
 
 /**

--- a/test/api/traversing.js
+++ b/test/api/traversing.js
@@ -1383,6 +1383,21 @@ describe('$(...)', function () {
           expect($selection[3]).toBe($pear[0]);
         });
       });
+
+      it('modifying nested selections should not impact the parent [#834]', function () {
+        var apple_pear = $apple.add($pear);
+
+        // applies red to apple and pear
+        apple_pear.addClass('red');
+
+        expect($apple.hasClass('red')).toBe(true); // this is true
+        expect($pear.hasClass('red')).toBe(true); // this is true
+
+        // applies green to pear... AND should not affect apple
+        $pear.addClass('green');
+        expect($pear.hasClass('green')).toBe(true); //currently this is true
+        expect($apple.hasClass('green')).toBe(false); // and this is true!
+      });
     });
   });
 

--- a/test/api/traversing.js
+++ b/test/api/traversing.js
@@ -1396,7 +1396,7 @@ describe('$(...)', function () {
         // applies green to pear... AND should not affect apple
         $pear.addClass('green');
         expect($pear.hasClass('green')).toBe(true); //currently this is true
-        expect($apple.hasClass('green')).toBe(false); // and this is true!
+        expect($apple.hasClass('green')).toBe(false); // and this should be false!
       });
     });
   });


### PR DESCRIPTION
if **other** is **cheerio object**, `_make` will return it as unchanged. So if `add` changes something there it also affects original **other** object.

Should fix #834 