### PR TITLE
fix jsdoc so wrap & wrapInner would be shown as methods

### DIFF
--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -305,6 +305,7 @@ function _wrap(insert) {
  *   //     </div>
  *   //   </ul>
  *
+ * @function
  * @param {Cheerio} wrapper - The DOM structure to wrap around each element in
  *     the selection.
  * @see {@link https://api.jquery.com/wrap/}
@@ -355,6 +356,7 @@ exports.wrap = _wrap(function (el, elInsertLocation, wrapperDom) {
  *   //     </li>
  *   //   </ul>
  *
+ * @function
  * @param {Cheerio} wrapper - The DOM structure to wrap around the content of
  *     each element in the selection.
  * @see {@link https://api.jquery.com/wrapInner/}


### PR DESCRIPTION
fix **jsdoc** so **wrap** & **wrapInner** would be shown as methods