### PR TITLE
Filter text nodes in find function

### DIFF
--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -52,7 +52,9 @@ exports.find = function (selectorOrHaystack) {
   var elems = reSiblingSelector.test(selectorOrHaystack)
     ? context
     : context.reduce(function (newElems, elem) {
-        return newElems.concat(elem.children.filter(isTag));
+        return Array.isArray(elem.children)
+          ? newElems.concat(elem.children.filter(isTag))
+          : newElems;
       }, []);
 
   var options = Object.assign({ context: context }, this.options);

--- a/test/api/traversing.js
+++ b/test/api/traversing.js
@@ -29,6 +29,12 @@ describe('$(...)', function () {
       expect($('#fruits').find('.apple')[0].attribs['class']).toBe('apple');
     });
 
+    // #1679 - text tags not filtered
+    it('(single) : should filter out text nodes', function () {
+      var $root = $('<html>\n' + fruits.replace(/></g, '>\n<') + '\n</html>');
+      expect($root.find('.apple')[0].attribs['class']).toBe('apple');
+    });
+
     it('(many) : should find all matching descendant', function () {
       expect($('#fruits').find('li')).toHaveLength(3);
     });


### PR DESCRIPTION
It seems **lodash** filter returns new empty array even when collection is undefined.

Should fix #1679