### PR TITLE
Export all interfaces in declaration file

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -274,5 +274,5 @@ declare namespace cheerio {
   }
 }
 
-declare const cheerioModule: cheerio.CheerioAPI;
-export = cheerioModule;
+declare const cheerio: cheerio.CheerioAPI;
+export = cheerio;


### PR DESCRIPTION
fixes #1540, fixes #1649 

**Note:** I don't know what I'm doing, but this fix *seems* to be working for my case

In these examples, the code compiles and the console.log output `Hello` as expected
```ts
import cheerio from 'cheerio';

const $: cheerio.Root = cheerio.load('<div>Hello</div>');
console.log($('div').text());
```
```ts
import cheerio, { Root } from 'cheerio';

const $: Root = cheerio.load('<div>Hello</div>');
console.log($('div').text());
```
```ts
import type { Root } from 'cheerio';
import cheerio from 'cheerio';

const $: Root = cheerio.load('<div>Hello</div>');
console.log($('div').text());
```

Tested with this tsconfig: https://gist.github.com/dominik-korsa/5888e24c196e50fa673154e030cf11ce

I wasn't able to test CommonJS (`require()`) syntax	