### PR TITLE
remove node module caching dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 /**
  * @module cheerio
  * @borrows load.load as load
- * @borrows static.load as load
  * @borrows static.html as html
  * @borrows static.text as text
  * @borrows static.xml as xml

--- a/index.js
+++ b/index.js
@@ -1,14 +1,16 @@
 'use strict';
 /**
  * @module cheerio
+ * @borrows load.load as load
  * @borrows static.load as load
  * @borrows static.html as html
  * @borrows static.text as text
  * @borrows static.xml as xml
  */
-var staticMethods = require('./lib/static');
-
 exports = module.exports = require('./lib/cheerio');
+
+var staticMethods = require('./lib/static');
+var loadMethod = require('./lib/load');
 
 /**
  * An identifier describing the version of Cheerio which has been executed.
@@ -17,7 +19,7 @@ exports = module.exports = require('./lib/cheerio');
  */
 exports.version = require('./package.json').version;
 
-exports.load = staticMethods.load;
+exports.load = loadMethod.load;
 exports.html = staticMethods.html;
 exports.text = staticMethods.text;
 exports.xml = staticMethods.xml;

--- a/lib/load.js
+++ b/lib/load.js
@@ -1,0 +1,65 @@
+'use strict';
+/**
+ * @module cheerio/load
+ * @ignore
+ */
+var defaultOptions = require('./options').default;
+var flattenOptions = require('./options').flatten;
+var staticMethods = require('./static');
+var Cheerio = require('./cheerio');
+var parse = require('./parse');
+
+/**
+ * Create a querying function, bound to a document created from the provided
+ * markup. Note that similar to web browser contexts, this operation may
+ * introduce `<html>`, `<head>`, and `<body>` elements; set `isDocument` to
+ * `false` to switch to fragment mode and disable this.
+ *
+ * See the README section titled "Loading" for additional usage information.
+ *
+ * @param {string} content - Markup to be loaded.
+ * @param {object} [options] - Options for the created instance.
+ * @param {boolean} [isDocument] - Allows parser to be switched to fragment mode.
+ * @returns {Cheerio} - The loaded document.
+ */
+exports.load = function (content, options, isDocument) {
+  if (content === null || content === undefined) {
+    throw new Error('cheerio.load() expects a string');
+  }
+
+  options = Object.assign({}, defaultOptions, flattenOptions(options));
+
+  if (typeof isDocument === 'undefined') isDocument = true;
+
+  var root = parse(content, options, isDocument);
+
+  function initialize(selector, context, r, opts) {
+    if (!(this instanceof initialize)) {
+      return new initialize(selector, context, r, opts);
+    }
+    opts = Object.assign({}, options, opts);
+    return Cheerio.call(this, selector, context, r || root, opts);
+  }
+
+  // Ensure that selections created by the "loaded" `initialize` function are
+  // true Cheerio instances.
+  initialize.prototype = Object.create(Cheerio.prototype);
+  initialize.prototype.constructor = initialize;
+
+  // Mimic jQuery's prototype alias for plugin authors.
+  initialize.fn = initialize.prototype;
+
+  // Keep a reference to the top-level scope so we can chain methods that implicitly
+  // resolve selectors; e.g. $("<span>").(".bar"), which otherwise loses ._root
+  initialize.prototype._originalRoot = root;
+
+  // Add in the static methods
+  Object.assign(initialize, staticMethods, exports);
+
+  // Add in the root
+  initialize._root = root;
+  // store options
+  initialize._options = options;
+
+  return initialize;
+};

--- a/lib/static.js
+++ b/lib/static.js
@@ -8,64 +8,6 @@ var flattenOptions = require('./options').flatten;
 var select = require('cheerio-select').select;
 var renderWithParse5 = require('./parsers/parse5').render;
 var renderWithHtmlparser2 = require('./parsers/htmlparser2').render;
-var parse = require('./parse');
-
-/**
- * Create a querying function, bound to a document created from the provided
- * markup. Note that similar to web browser contexts, this operation may
- * introduce `<html>`, `<head>`, and `<body>` elements; set `isDocument` to
- * `false` to switch to fragment mode and disable this.
- *
- * See the README section titled "Loading" for additional usage information.
- *
- * @param {string} content - Markup to be loaded.
- * @param {object} [options] - Options for the created instance.
- * @param {boolean} [isDocument] - Allows parser to be switched to fragment mode.
- * @returns {Cheerio} - The loaded document.
- */
-exports.load = function (content, options, isDocument) {
-  if (content === null || content === undefined) {
-    throw new Error('cheerio.load() expects a string');
-  }
-
-  var Cheerio = require('./cheerio');
-
-  options = Object.assign({}, defaultOptions, flattenOptions(options));
-
-  if (typeof isDocument === 'undefined') isDocument = true;
-
-  var root = parse(content, options, isDocument);
-
-  function initialize(selector, context, r, opts) {
-    if (!(this instanceof initialize)) {
-      return new initialize(selector, context, r, opts);
-    }
-    opts = Object.assign({}, options, opts);
-    return Cheerio.call(this, selector, context, r || root, opts);
-  }
-
-  // Ensure that selections created by the "loaded" `initialize` function are
-  // true Cheerio instances.
-  initialize.prototype = Object.create(Cheerio.prototype);
-  initialize.prototype.constructor = initialize;
-
-  // Mimic jQuery's prototype alias for plugin authors.
-  initialize.fn = initialize.prototype;
-
-  // Keep a reference to the top-level scope so we can chain methods that implicitly
-  // resolve selectors; e.g. $("<span>").(".bar"), which otherwise loses ._root
-  initialize.prototype._originalRoot = root;
-
-  // Add in the static methods
-  Object.assign(initialize, exports);
-
-  // Add in the root
-  initialize._root = root;
-  // store options
-  initialize._options = options;
-
-  return initialize;
-};
 
 /**
  * Helper function to render a DOM.


### PR DESCRIPTION
- move **.load()** function own file so api methods could access other static functions early.
- load **load.js** file after cheerio object is built.

should solve #1311 & #1689

it passes rollup test