### PR TITLE
simplify isHtml regex

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -84,7 +84,7 @@ exports.cloneDom = function (dom) {
   return clone;
 };
 
-/** A simple way to check for HTML strings. */
+// A simple way to check for HTML strings.
 var quickExpr = /^\s*(<[^]+>[^>]*?)\s*$/;
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -84,8 +84,8 @@ exports.cloneDom = function (dom) {
   return clone;
 };
 
-/** A simple way to check for HTML strings or ID strings. */
-var quickExpr = /^(?:[^#<]*(<[\w\W]+>)[^>]*$|#([\w-]*)$)/;
+/** A simple way to check for HTML strings. */
+var quickExpr = /^\s*(<[^]+>[^>]*?)\s*$/;
 
 /**
  * Check if string is HTML.
@@ -106,6 +106,5 @@ exports.isHtml = function (str) {
   }
 
   // Run the regex
-  var match = quickExpr.exec(str);
-  return !!(match && match[1]);
+  return quickExpr.test(str);
 };

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -407,6 +407,10 @@ describe('cheerio', function () {
       expect(utils.isHtml('<html>')).toBe(true);
       expect(utils.isHtml('\n<html>\n')).toBe(true);
       expect(utils.isHtml('#main')).toBe(false);
+      expect(utils.isHtml('\n<p>foo<p>bar\n')).toBe(true);
+      expect(utils.isHtml('dog<p>fox<p>cat')).toBe(false);
+      expect(utils.isHtml('<p>fox<p>cat')).toBe(true);
+      expect(utils.isHtml('\n<p>fox<p>cat\n')).toBe(true);
     });
   });
 });


### PR DESCRIPTION
- removed `#id` part from regex
- html may begin with whitespace, but can not start with some arbitrary characters so string like `html: <p>bar<p>foo` will fail, but `<p>bar<p>foo` will pass.
- since second regex case can't happen we can simplify test in function
- removed JSDoc comment from quickExpr, since it is not really accessible. 