### PR TITLE
add property "textContent"

### DIFF
--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -6,6 +6,7 @@
  */
 
 var text = require('../static').text;
+var html = require('../static').html;
 var utils = require('../utils');
 var isTag = utils.isTag;
 var domEach = utils.domEach;
@@ -234,7 +235,7 @@ exports.prop = function (name, value) {
         return first ? first.name.toUpperCase() : first;
 
       case 'outerHTML':
-        return this.clone().wrap('<container />').parent().html();
+        return html(this, this._options);
 
       case 'textContent':
         return first ? _textContent([first]) : first;

--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -165,6 +165,38 @@ function setProp(el, name, value) {
 }
 
 /**
+ * Function tries mimic __Node.textContent__ behavior.
+ *
+ * @private
+ * @param {Element[]} elems - Array of elements against text elements are processed.
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent}
+ *
+ * @returns {null | string} - Content if element was not Document.
+ */
+function _textContent(elems) {
+  var ret = '';
+  for (var elem of elems) {
+    if (elem.type === 'text') ret += elem.data;
+    if (elem.children && elem.children.length) {
+      ret += _textContent(elem.children);
+    }
+  }
+  return ret;
+}
+
+/**
+ * Find first tag in elements.
+ *
+ * @private
+ * @param {Array | Cheerio} elems - Collection where we search elements.
+ * @returns {undefined | Element} - Returns first tag in Array or undefined if
+ *     it is not present.
+ */
+function _firstElementChild(elems) {
+  for (var el of elems) if (isTag(el)) return el;
+}
+
+/**
  * Method for getting and setting properties. Gets the property value for only
  * the first element in the matched set.
  *
@@ -184,6 +216,7 @@ function setProp(el, name, value) {
  */
 exports.prop = function (name, value) {
   if (typeof name === 'string' && value === undefined) {
+    var first = _firstElementChild(this);
     switch (name) {
       case 'style': {
         var property = this.css();
@@ -198,10 +231,13 @@ exports.prop = function (name, value) {
       }
       case 'tagName':
       case 'nodeName':
-        return this[0].name.toUpperCase();
+        return first ? first.name.toUpperCase() : first;
 
       case 'outerHTML':
         return this.clone().wrap('<container />').parent().html();
+
+      case 'textContent':
+        return first ? _textContent([first]) : first;
 
       case 'innerHTML':
         return this.html();

--- a/test/api/attributes.js
+++ b/test/api/attributes.js
@@ -242,6 +242,30 @@ describe('$(...)', function () {
       expect($a.prop('outerHTML')).toBe(outerHtml);
     });
 
+    it('("nodeName") : should return proper value', function () {
+      // simple tests
+      expect(checkbox.prop('nodeName')).toBe('INPUT');
+      expect(selectMenu.prop('nodeName')).toBe('SELECT');
+      expect($('ul').prop('nodeName')).toBeUndefined();
+      // test with whitespace (issue 1206)
+      var html = '<html>' + food + '</html>';
+      var qq = cheerio(html.replace(/></g, '>\t<'));
+      expect(qq.prop('nodeName')).toBe('UL');
+      expect(qq.prop('tagName')).toBe('UL');
+    });
+
+    it('("textContent") : should return proper value', function () {
+      var select5 = selectMenu.eq(5);
+      expect(select5.find('[selected]').prop('textContent')).toBe('2');
+      expect(select5.find(':not([selected])').prop('textContent')).toBe('1');
+      expect(select5.prop('textContent')).toBe('1234');
+      expect($('ul').prop('textContent')).toBeUndefined();
+      // test with whitespace
+      var html = '<html>' + food + '</html>';
+      var qq = cheerio(html.replace(/></g, '>\t<'));
+      expect(qq.find('ul').prop('textContent')).toBe('\tApple\tOrange\tPear\t');
+    });
+
     it('("innerHTML") : should render properly', function () {
       var $a = $('<div><a></a></div>');
 


### PR DESCRIPTION
- since `text()` function wont return **style** & **script** tag content, so this will give option by mimicking [textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) property.
- PR should also resolve #1206
