### PR TITLE
root will be overwritten

### DIFF
--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -77,8 +77,8 @@ var Cheerio = (module.exports = function (selector, context, root, options) {
   }
 
   // If we don't have a context, maybe we have a root, from loading
-  if (!context && this._root && this._root.length) {
-    context = Cheerio.merge(this, this._root);
+  if (!context) {
+    context = this._root;
   } else if (typeof context === 'string') {
     if (isHtml(context)) {
       // $('li', '<ul>...</ul>')

--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -53,7 +53,7 @@ var Cheerio = (module.exports = function (selector, context, root, options) {
 
   if (root) {
     if (typeof root === 'string') root = parse(root, this.options, false);
-    this._root = Cheerio.call(this, root);
+    this._root = new Cheerio(root);
   }
 
   // $(<html>)
@@ -77,8 +77,8 @@ var Cheerio = (module.exports = function (selector, context, root, options) {
   }
 
   // If we don't have a context, maybe we have a root, from loading
-  if (!context) {
-    context = this._root;
+  if (!context && this._root && this._root.length) {
+    context = Cheerio.merge(this, this._root);
   } else if (typeof context === 'string') {
     if (isHtml(context)) {
       // $('li', '<ul>...</ul>')
@@ -89,9 +89,9 @@ var Cheerio = (module.exports = function (selector, context, root, options) {
       selector = context + ' ' + selector;
       context = this._root;
     }
-  } else if (!context.cheerio) {
+  } else if (context && typeof context === 'object') {
     // $('li', node), $('li', [nodes])
-    context = Cheerio.call(this, context);
+    context = context.cheerio ? context : Cheerio.call(this, context);
   }
 
   // If we still don't have a context, return

--- a/test/api/traversing.js
+++ b/test/api/traversing.js
@@ -1180,6 +1180,13 @@ describe('$(...)', function () {
           expect($selection[0]).toBe($fruits[0]);
           expect($selection[1]).toBe($orange[0]);
         });
+        it('is root object preserved', function () {
+          var $selection = $('<div></div>').add('#fruits');
+
+          expect($selection).toHaveLength(2);
+          expect($selection.eq(0).is('div')).toBe(true);
+          expect($selection.eq(1).is($fruits.eq(0))).toBe(true);
+        });
       });
       describe('matched elements', function () {
         it('occur before the current selection', function () {

--- a/test/api/traversing.js
+++ b/test/api/traversing.js
@@ -1126,7 +1126,7 @@ describe('$(...)', function () {
     });
   });
 
-  describe('.add', function () {
+  describe('.add (...)', function () {
     var $fruits;
     var $apple;
     var $orange;
@@ -1144,81 +1144,82 @@ describe('$(...)', function () {
       $sweetcorn = $('.sweetcorn');
     });
 
-    describe('(selector', function () {
-      describe(') :', function () {
-        describe('matched element', function () {
-          it('occurs before current selection', function () {
-            var $selection = $orange.add('.apple');
+    describe('( selector ) :', function () {
+      describe('matched element', function () {
+        it('occurs before current selection', function () {
+          var $selection = $orange.add('.apple');
 
-            expect($selection).toHaveLength(2);
-            expect($selection[0]).toBe($apple[0]);
-            expect($selection[1]).toBe($orange[0]);
-          });
-          it('is identical to the current selection', function () {
-            var $selection = $orange.add('.orange');
-
-            expect($selection).toHaveLength(1);
-            expect($selection[0]).toBe($orange[0]);
-          });
-          it('occurs after current selection', function () {
-            var $selection = $orange.add('.pear');
-
-            expect($selection).toHaveLength(2);
-            expect($selection[0]).toBe($orange[0]);
-            expect($selection[1]).toBe($pear[0]);
-          });
-          it('contains the current selection', function () {
-            var $selection = $orange.add('#fruits');
-
-            expect($selection).toHaveLength(2);
-            expect($selection[0]).toBe($fruits[0]);
-            expect($selection[1]).toBe($orange[0]);
-          });
-          it('is a child of the current selection', function () {
-            var $selection = $fruits.add('.orange');
-
-            expect($selection).toHaveLength(2);
-            expect($selection[0]).toBe($fruits[0]);
-            expect($selection[1]).toBe($orange[0]);
-          });
+          expect($selection).toHaveLength(2);
+          expect($selection[0]).toBe($apple[0]);
+          expect($selection[1]).toBe($orange[0]);
         });
-        describe('matched elements', function () {
-          it('occur before the current selection', function () {
-            var $selection = $pear.add('.apple, .orange');
+        it('is identical to the current selection', function () {
+          var $selection = $orange.add('.orange');
 
-            expect($selection).toHaveLength(3);
-            expect($selection[0]).toBe($apple[0]);
-            expect($selection[1]).toBe($orange[0]);
-            expect($selection[2]).toBe($pear[0]);
-          });
-          it('include the current selection', function () {
-            var $selection = $pear.add('#fruits li');
+          expect($selection).toHaveLength(1);
+          expect($selection[0]).toBe($orange[0]);
+        });
+        it('occurs after current selection', function () {
+          var $selection = $orange.add('.pear');
 
-            expect($selection).toHaveLength(3);
-            expect($selection[0]).toBe($apple[0]);
-            expect($selection[1]).toBe($orange[0]);
-            expect($selection[2]).toBe($pear[0]);
-          });
-          it('occur after the current selection', function () {
-            var $selection = $apple.add('.orange, .pear');
+          expect($selection).toHaveLength(2);
+          expect($selection[0]).toBe($orange[0]);
+          expect($selection[1]).toBe($pear[0]);
+        });
+        it('contains the current selection', function () {
+          var $selection = $orange.add('#fruits');
 
-            expect($selection).toHaveLength(3);
-            expect($selection[0]).toBe($apple[0]);
-            expect($selection[1]).toBe($orange[0]);
-            expect($selection[2]).toBe($pear[0]);
-          });
-          it('occur within the current selection', function () {
-            var $selection = $fruits.add('#fruits li');
+          expect($selection).toHaveLength(2);
+          expect($selection[0]).toBe($fruits[0]);
+          expect($selection[1]).toBe($orange[0]);
+        });
+        it('is a child of the current selection', function () {
+          var $selection = $fruits.add('.orange');
 
-            expect($selection).toHaveLength(4);
-            expect($selection[0]).toBe($fruits[0]);
-            expect($selection[1]).toBe($apple[0]);
-            expect($selection[2]).toBe($orange[0]);
-            expect($selection[3]).toBe($pear[0]);
-          });
+          expect($selection).toHaveLength(2);
+          expect($selection[0]).toBe($fruits[0]);
+          expect($selection[1]).toBe($orange[0]);
         });
       });
-      it(', context)', function () {
+      describe('matched elements', function () {
+        it('occur before the current selection', function () {
+          var $selection = $pear.add('.apple, .orange');
+
+          expect($selection).toHaveLength(3);
+          expect($selection[0]).toBe($apple[0]);
+          expect($selection[1]).toBe($orange[0]);
+          expect($selection[2]).toBe($pear[0]);
+        });
+        it('include the current selection', function () {
+          var $selection = $pear.add('#fruits li');
+
+          expect($selection).toHaveLength(3);
+          expect($selection[0]).toBe($apple[0]);
+          expect($selection[1]).toBe($orange[0]);
+          expect($selection[2]).toBe($pear[0]);
+        });
+        it('occur after the current selection', function () {
+          var $selection = $apple.add('.orange, .pear');
+
+          expect($selection).toHaveLength(3);
+          expect($selection[0]).toBe($apple[0]);
+          expect($selection[1]).toBe($orange[0]);
+          expect($selection[2]).toBe($pear[0]);
+        });
+        it('occur within the current selection', function () {
+          var $selection = $fruits.add('#fruits li');
+
+          expect($selection).toHaveLength(4);
+          expect($selection[0]).toBe($fruits[0]);
+          expect($selection[1]).toBe($apple[0]);
+          expect($selection[2]).toBe($orange[0]);
+          expect($selection[3]).toBe($pear[0]);
+        });
+      });
+    });
+
+    describe('( selector, context ) :', function () {
+      it('with context', function () {
         var $selection = $fruits.add('li', '#vegetables');
         expect($selection).toHaveLength(3);
         expect($selection[0]).toBe($fruits[0]);

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -266,6 +266,15 @@ describe('cheerio', function () {
       expect(lis).toHaveLength(3);
     });
 
+    it('should preserve root content', function () {
+      var $ = cheerio.load(fruits);
+      // root should not be overwritten
+      var el = $('<div></div>');
+      expect(Object.is(el, el._root)).toBe(false);
+      // query has to have results
+      expect($('li', 'ul')).toHaveLength(3);
+    });
+
     it('should allow loading a pre-parsed DOM', function () {
       var dom = htmlparser2.parseDOM(food);
       var $ = cheerio.load(dom);


### PR DESCRIPTION
root will be overwritten if you parse new html content.

lets say you 
``` js
const $ = cheerio.load(html);

const el = $('<div></div>').add('#fruits');
// should return 2 elements but instead you get just one
```
turns out since `el._root` & `el` are same instance. if you add `div` into dom you effectively overwriting `root`. Now when you plan make query against that old root you get empty results since new empty `div` wont have old content.


