### PR TITLE
expose parse5 option scriptingEnabled

### DIFF
--- a/lib/parsers/parse5.js
+++ b/lib/parsers/parse5.js
@@ -4,6 +4,10 @@ var htmlparser2Adapter = require('parse5-htmlparser2-tree-adapter');
 
 exports.parse = function (content, options, isDocument) {
   var opts = {
+    scriptingEnabled:
+      typeof options.scriptingEnabled === 'boolean'
+        ? options.scriptingEnabled
+        : true,
     treeAdapter: htmlparser2Adapter,
     sourceCodeLocationInfo: options.sourceCodeLocationInfo,
   };

--- a/test/__fixtures__/fixtures.js
+++ b/test/__fixtures__/fixtures.js
@@ -84,3 +84,13 @@ exports.forms = [
   '<form id="textarea"><textarea name="fruits">Apple\nOrange</textarea></form>',
   '<form id="spaces"><input type="text" name="fruit" value="Blood orange" /></form>',
 ].join('');
+
+exports.noscript = [
+  '</body>',
+  '<noscript>',
+  '<!-- anchor linking to external file -->',
+  '<a href="https://github.com/cheeriojs/cheerio">External Link</a>',
+  '</noscript>',
+  '<p>Rocks!</p>',
+  '</body>',
+].join('');

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -413,7 +413,7 @@ describe('cheerio', function () {
   describe('parse5 options', function () {
     var noscript = fixtures.noscript;
 
-    // should parse nodata only with false option value
+    // should parse noscript tags only with false option value
     test('{scriptingEnabled: ???}', function () {
       var opt = 'scriptingEnabled';
       var options = {};

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -409,4 +409,68 @@ describe('cheerio', function () {
       expect(utils.isHtml('#main')).toBe(false);
     });
   });
+
+  describe('parse5 options', function () {
+    var noscript = fixtures.noscript;
+
+    // should parse nodata only with false option value
+    test('{scriptingEnabled: ???}', function () {
+      var opt = 'scriptingEnabled';
+      var options = {};
+      var result;
+
+      // [default] scriptingEnabled: true - tag contains one text element
+      result = cheerio.load(noscript)('noscript');
+      expect(result).toHaveLength(1);
+      expect(result[0].children).toHaveLength(1);
+      expect(result[0].children[0].type).toBe('text');
+
+      // scriptingEnabled: false - content of noscript will parsed
+      options[opt] = false;
+      result = cheerio.load(fixtures.noscript, options)('noscript');
+      expect(result).toHaveLength(1);
+      expect(result[0].children).toHaveLength(2);
+      expect(result[0].children[0].type).toBe('comment');
+      expect(result[0].children[1].type).toBe('tag');
+      expect(result[0].children[1].name).toBe('a');
+
+      // scriptingEnabled: ??? - should acts as true
+      var values = [undefined, null, 0, ''];
+      for (var val of values) {
+        options[opt] = val;
+        result = cheerio.load(noscript, options)('noscript');
+        expect(result).toHaveLength(1);
+        expect(result[0].children).toHaveLength(1);
+        expect(result[0].children[0].type).toBe('text');
+      }
+    });
+
+    // should contain location data only with truthful option value
+    test('{sourceCodeLocationInfo: ???}', function () {
+      var prop = 'sourceCodeLocation';
+      var opt = 'sourceCodeLocationInfo';
+      var options = {};
+      var result;
+      var i;
+
+      // Location data should not be present
+      var values = [undefined, null, 0, false, ''];
+      for (i = 0; i < values.length; i++) {
+        options[opt] = values[i];
+        result = cheerio.load(noscript, options)('noscript');
+        expect(result).toHaveLength(1);
+        expect(result[0]).not.toHaveProperty(prop);
+      }
+
+      // Location data should be present
+      values = [true, 1, 'test'];
+      for (i = 0; i < values.length; i++) {
+        options[opt] = values[i];
+        result = cheerio.load(noscript, options)('noscript');
+        expect(result).toHaveLength(1);
+        expect(result[0]).toHaveProperty(prop);
+        expect(typeof result[0][prop]).toBe('object');
+      }
+    });
+  });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -228,6 +228,9 @@ declare namespace cheerio {
 
     /** Enable location support for parse5 */
     sourceCodeLocationInfo?: boolean;
+
+    /** Disable scripting in parse5, so noscript tags would be parsed */
+    scriptingEnabled?: boolean;
   }
 
   interface Selector {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -35,6 +35,14 @@ $ = cheerio.load(html, {
 });
 
 $ = cheerio.load(html, {
+  scriptingEnabled: false,
+});
+
+$ = cheerio.load(html, {
+  sourceCodeLocationInfo: true,
+});
+
+$ = cheerio.load(html, {
   normalizeWhitespace: true,
   withStartIndices: true,
   withEndIndices: true,


### PR DESCRIPTION
Expose [scriptingEnabled](https://github.com/inikulin/parse5/blob/master/packages/parse5/docs/options/parser-options.md#optional-scriptingenabled) option. It would accept `false` value only, all other cases it should stay true.

``` html
<noscript><link rel="stylesheet" href="/css/noscript.css"></noscript>
```
It should help parse some documents where `noscript` elements are used. 
If **true** (_default_) all html code inside `noscript` elements will treated as text,
if **false** all html code inside `noscript` elements will treated as html and parsed accordingly.

#1105