### PR TITLE
Fix wrong method used in `.map` tests

### DIFF
--- a/test/api/traversing.js
+++ b/test/api/traversing.js
@@ -703,9 +703,10 @@ describe('$(...)', function () {
       var args = [];
       var thisVals = [];
 
-      $fruits.each(function () {
+      $fruits.map(function () {
         args.push(Array.prototype.slice.call(arguments));
         thisVals.push(this);
+        return;
       });
 
       expect(args).toStrictEqual([


### PR DESCRIPTION
The added `return` is to prevent linter errors due to the rule `array-callback-return` (which is probably why the `.map` call was originally replaced with `.each`).

Closes #1705.