### PR TITLE
refactor(utils): Simplify `quickExpr`

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -84,8 +84,13 @@ exports.cloneDom = function (dom) {
   return clone;
 };
 
-/** A simple way to check for HTML strings or ID strings. */
-var quickExpr = /^(?:[^#<]*(<[\w\W]+>)[^>]*$|#([\w-]*)$)/;
+/**
+ * A simple way to check for HTML strings. Tests for a `<` within a string,
+ * immediate followed by a letter and eventually followed by a `>`.
+ *
+ * @private
+ */
+var quickExpr = /<[a-zA-Z][^]*>/;
 
 /**
  * Check if string is HTML.
@@ -96,16 +101,6 @@ var quickExpr = /^(?:[^#<]*(<[\w\W]+>)[^>]*$|#([\w-]*)$)/;
  * @returns {boolean} Indicates if `str` is HTML.
  */
 exports.isHtml = function (str) {
-  // Faster than running regex, if str starts with `<` and ends with `>`, assume it's HTML
-  if (
-    str.charAt(0) === '<' &&
-    str.charAt(str.length - 1) === '>' &&
-    str.length >= 3
-  ) {
-    return true;
-  }
-
   // Run the regex
-  var match = quickExpr.exec(str);
-  return !!(match && match[1]);
+  return quickExpr.test(str);
 };

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -220,7 +220,7 @@ describe('cheerio', function () {
   });
 
   it('should gracefully degrade on complex, unmatched queries', function () {
-    var $elem = cheerio('Eastern States Cup #8-fin&nbsp;<br>Downhill&nbsp;');
+    var $elem = cheerio('Eastern States Cup #8-fin&nbsp;<1br>Downhill&nbsp;');
     expect($elem).toHaveLength(0);
   });
 
@@ -407,6 +407,12 @@ describe('cheerio', function () {
       expect(utils.isHtml('<html>')).toBe(true);
       expect(utils.isHtml('\n<html>\n')).toBe(true);
       expect(utils.isHtml('#main')).toBe(false);
+      expect(utils.isHtml('\n<p>foo<p>bar\n')).toBe(true);
+      expect(utils.isHtml('dog<p>fox<p>cat')).toBe(true);
+      expect(utils.isHtml('<p>fox<p>cat')).toBe(true);
+      expect(utils.isHtml('\n<p>fox<p>cat\n')).toBe(true);
+      expect(utils.isHtml('#<p>fox<p>cat#')).toBe(true);
+      expect(utils.isHtml('<123>')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Now allows a `#` before the string.

BREAKING: Now requires a letter directly after the `<`. Both parsers would have parsed this as text before.

@5saviahv #1699 was a great find, thanks for opening it! I wasn't sure about the actual implementation, here is my take; with it, we still allow text around the actual string, but ban things that definitely aren't tags (see breaking).