### PR TITLE
Prettier: JSDoc comments needs formatting

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,8 +24,8 @@ exports.text = staticMethods.text;
 exports.xml = staticMethods.xml;
 
 /**
- * In order to promote consistency with the jQuery library, users are
- * encouraged to instead use the static method of the same name.
+ * In order to promote consistency with the jQuery library, users are encouraged
+ * to instead use the static method of the same name.
  *
  * @deprecated
  * @example
@@ -39,8 +39,8 @@ exports.xml = staticMethods.xml;
 exports.contains = staticMethods.contains;
 
 /**
- * In order to promote consistency with the jQuery library, users are
- * encouraged to instead use the static method of the same name.
+ * In order to promote consistency with the jQuery library, users are encouraged
+ * to instead use the static method of the same name.
  *
  * @deprecated
  * @example
@@ -52,9 +52,9 @@ exports.contains = staticMethods.contains;
 exports.merge = staticMethods.merge;
 
 /**
- * In order to promote consistency with the jQuery library, users are
- * encouraged to instead use the static method of the same name as it is
- * defined on the "loaded" Cheerio factory function.
+ * In order to promote consistency with the jQuery library, users are encouraged
+ * to instead use the static method of the same name as it is defined on the
+ * "loaded" Cheerio factory function.
  *
  * @deprecated See {@link static/parseHTML}.
  * @example

--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -103,7 +103,7 @@ function setAttr(el, name, value) {
  * @see {@link https://api.jquery.com/attr/}
  *
  * @returns {string | Cheerio} If `value` is specified the instance itself,
- *   otherwise the attribute's value.
+ *     otherwise the attribute's value.
  */
 exports.attr = function (name, value) {
   // Set the value (with attr map support)
@@ -180,7 +180,7 @@ function setProp(el, name, value) {
  * @see {@link https://api.jquery.com/prop/}
  *
  * @returns {string | Cheerio} If `value` is specified the instance itself,
- *   otherwise the prop's value.
+ *     otherwise the prop's value.
  */
 exports.prop = function (name, value) {
   if (typeof name === 'string' && value === undefined) {
@@ -325,7 +325,7 @@ function readData(el, name) {
  * @see {@link https://api.jquery.com/data/}
  *
  * @returns {string | Cheerio | undefined} If `value` is specified the instance
- *   itself, otherwise the data attribute's value.
+ *     itself, otherwise the data attribute's value.
  */
 exports.data = function (name, value) {
   var elem = this[0];
@@ -369,7 +369,7 @@ exports.data = function (name, value) {
  * @param {string | string[]} [value] - If specified new value.
  * @see {@link https://api.jquery.com/val/}
  * @returns {string | Cheerio | undefined} If a new `value` is specified the
- *   instance itself, otherwise the value.
+ *     instance itself, otherwise the value.
  */
 exports.val = function (value) {
   var querying = arguments.length === 0;
@@ -555,8 +555,8 @@ exports.addClass = function (value) {
 };
 
 /**
- * Removes one or more space-separated classes from the selected elements. If
- * no `className` is defined, all classes will be removed. Also accepts a
+ * Removes one or more space-separated classes from the selected elements. If no
+ * `className` is defined, all classes will be removed. Also accepts a
  * `function` like jQuery.
  *
  * @example

--- a/lib/api/css.js
+++ b/lib/api/css.js
@@ -6,8 +6,8 @@ var domEach = require('../utils').domEach;
 var toString = Object.prototype.toString;
 
 /**
- * Get the value of a style property for the first element in the set of
- * matched elements or set one or more CSS properties for every matched element.
+ * Get the value of a style property for the first element in the set of matched
+ * elements or set one or more CSS properties for every matched element.
  *
  * @param {string | object} prop - The name of the property.
  * @param {string} [val] - If specified the new value.

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -22,8 +22,7 @@ var DomUtils = require('htmlparser2').DomUtils;
  *
  * @private
  *
- * @param {Cheerio | string | Cheerio[] | string[]} [elem] - Elements to make
- *   an array of.
+ * @param {Cheerio | string | Cheerio[] | string[]} [elem] - Elements to make an array of.
  * @param {boolean} [clone] - Optionally clone nodes.
  * @returns {Node[]} The array of nodes.
  */
@@ -308,7 +307,7 @@ function _wrap(insert) {
  *
  * @function
  * @param {Cheerio} wrapper - The DOM structure to wrap around each element in
- *   the selection.
+ *     the selection.
  * @see {@link https://api.jquery.com/wrap/}
  */
 exports.wrap = _wrap(function (el, elInsertLocation, wrapperDom) {
@@ -359,7 +358,7 @@ exports.wrap = _wrap(function (el, elInsertLocation, wrapperDom) {
  *
  * @function
  * @param {Cheerio} wrapper - The DOM structure to wrap around the content of
- *   each element in the selection.
+ *     each element in the selection.
  * @see {@link https://api.jquery.com/wrapInner/}
  */
 exports.wrapInner = _wrap(function (el, elInsertLocation, wrapperDom) {
@@ -394,7 +393,8 @@ exports.wrapInner = _wrap(function (el, elInsertLocation, wrapperDom) {
  *   //   </div>
  *
  * @param {string} [selector] - A selector to check the parent element against.
- *   If an element's parent does not match the selector, the element won't be unwrapped.
+ *     If an element's parent does not match the selector, the element won't be
+ *     unwrapped.
  * @see {@link https://api.jquery.com/unwrap/}
  * @returns {Cheerio} The instance itself, for chaining.
  */
@@ -409,8 +409,8 @@ exports.unwrap = function (selector) {
 };
 
 /**
- * The .wrapAll() function can take any string or object that could be passed
- * to the $() function to specify a DOM structure. This structure may be nested
+ * The .wrapAll() function can take any string or object that could be passed to
+ * the $() function to specify a DOM structure. This structure may be nested
  * several levels deep, but should contain only one inmost element. The
  * structure will be wrapped around all of the elements in the set of matched
  * elements, as a single group.
@@ -448,7 +448,7 @@ exports.unwrap = function (selector) {
  *   //   <strong>Strong</strong>
  *
  * @param {Cheerio} wrapper - The DOM structure to wrap around all matched
- *   elements in the selection.
+ *     elements in the selection.
  * @see {@link https://api.jquery.com/wrapAll/}
  * @returns {Cheerio} The instance itself.
  */
@@ -835,10 +835,10 @@ exports.toString = function () {
  *   //    Pear
  *
  * @param {string | Function} [str] - If specified replacement for the selected
- *   element's contents.
+ *     element's contents.
  * @see {@link https://api.jquery.com/text/}
  * @returns {Cheerio | string} The instance itself when setting text, otherwise
- *   the rendered document.
+ *     the rendered document.
  */
 exports.text = function (str) {
   // If `str` is undefined, act as a "getter"

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -229,8 +229,7 @@ exports.closest = function (selector) {
 };
 
 /**
- * Gets the next sibling of the first selected element, optionally filtered by
- * a selector.
+ * Gets the next sibling of the first selected element, optionally filtered by a selector.
  *
  * @example
  *   $('.apple').next().hasClass('orange');

--- a/lib/static.js
+++ b/lib/static.js
@@ -115,7 +115,7 @@ exports.text = function (elems) {
  *
  * @param {string} data - Markup that will be parsed.
  * @param {any | boolean} [context] - Will be ignored. If it is a boolean it
- *   will be used as the value of `keepScripts`.
+ *     will be used as the value of `keepScripts`.
  * @param {boolean} [keepScripts] - If false all scripts will be removed.
  * @see {@link https://api.jquery.com/jQuery.parseHTML/}
  *

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -59,8 +59,8 @@ exports.domEach = function (cheerio, fn) {
 };
 
 /**
- * Create a deep copy of the given DOM structure. Sets the parents of the
- * copies of the passed nodes to `null`.
+ * Create a deep copy of the given DOM structure. Sets the parents of the copies
+ * of the passed nodes to `null`.
  *
  * @private
  *

--- a/test/api/deprecated.js
+++ b/test/api/deprecated.js
@@ -239,9 +239,9 @@ describe('deprecated APIs', function () {
     });
 
     /**
-     * The `.xml` static method defined on the "loaded" Cheerio factory
-     * function is deprecated. Users are encouraged to instead use the `xml`
-     * function exported by the Cheerio module.
+     * The `.xml` static method defined on the "loaded" Cheerio factory function
+     * is deprecated. Users are encouraged to instead use the `xml` function
+     * exported by the Cheerio module.
      *
      * @example
      *   cheerio.xml($.root());


### PR DESCRIPTION
new Prettier JSDoc plugin version reformats long comments and linter do fail now because it.