### PR TITLE
add after, before, slice arguments into jsdoc.

### DIFF
--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -602,7 +602,7 @@ exports.insertAfter = function (target) {
  *   //      <li class="pear">Pear</li>
  *   //    </ul>
  *
- * @param {string | Element | Element[] | Cheerio | Function} content - HTML
+ * @param {...(string | Element | Element[] | Cheerio | Function)} content - HTML
  *   string, DOM element, array of DOM elements or Cheerio to insert before
  *   each element in the set of matched elements.
  * @see {@link https://api.jquery.com/before/}

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -499,9 +499,9 @@ exports.wrapAll = function (wrapper) {
  *   //      <li class="pear">Pear</li>
  *   //    </ul>
  *
- * @param {string | Element | Element[] | Cheerio | Function} content - HTML string, DOM
- *     element, array of DOM elements or Cheerio to insert after each element
- *     in the set of matched elements.
+ * @param {string | Element | Element[] | Cheerio | Function} content - HTML
+ *   string, DOM element, array of DOM elements or Cheerio to insert after each
+ *   element in the set of matched elements.
  * @see {@link https://api.jquery.com/after/}
  *
  * @returns {Cheerio} The instance itself.
@@ -602,9 +602,9 @@ exports.insertAfter = function (target) {
  *   //      <li class="pear">Pear</li>
  *   //    </ul>
  *
- * @param {string | Element | Element[] | Cheerio | Function} content - HTML string, DOM
- *     element, array of DOM elements or Cheerio to insert before each element
- *     in the set of matched elements.
+ * @param {string | Element | Element[] | Cheerio | Function} content - HTML
+ *   string, DOM element, array of DOM elements or Cheerio to insert before
+ *   each element in the set of matched elements.
  * @see {@link https://api.jquery.com/before/}
  *
  * @returns {Cheerio} The instance itself.

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -499,9 +499,9 @@ exports.wrapAll = function (wrapper) {
  *   //      <li class="pear">Pear</li>
  *   //    </ul>
  *
- * @param {string | Element | Element[] | Cheerio | Function} content - HTML
- *   string, DOM element, array of DOM elements or Cheerio to insert after each
- *   element in the set of matched elements.
+ * @param {...(string | Element | Element[] | Cheerio | Function)} content -
+ *   HTML string, DOM element, array of DOM elements or Cheerio to insert after
+ *   each element in the set of matched elements.
  * @see {@link https://api.jquery.com/after/}
  *
  * @returns {Cheerio} The instance itself.

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -484,6 +484,8 @@ exports.wrapAll = function (wrapper) {
   return this;
 };
 
+/*eslint-disable jsdoc/check-param-names*/
+
 /**
  * Insert content next to each element in the set of matched elements.
  *
@@ -497,6 +499,9 @@ exports.wrapAll = function (wrapper) {
  *   //      <li class="pear">Pear</li>
  *   //    </ul>
  *
+ * @param {string | Element | Element[] | Cheerio | Function} content - HTML string, DOM
+ *     element, array of DOM elements or Cheerio to insert after each element
+ *     in the set of matched elements.
  * @see {@link https://api.jquery.com/after/}
  *
  * @returns {Cheerio} The instance itself.
@@ -528,6 +533,8 @@ exports.after = function () {
     uniqueSplice(siblings, index + 1, 0, dom, parent);
   });
 };
+
+/*eslint-enable jsdoc/check-param-names*/
 
 /**
  * Insert every element in the set of matched elements after the target.
@@ -580,6 +587,8 @@ exports.insertAfter = function (target) {
   return this.constructor.call(this.constructor, this._makeDomArray(clones));
 };
 
+/*eslint-disable jsdoc/check-param-names*/
+
 /**
  * Insert content previous to each element in the set of matched elements.
  *
@@ -593,6 +602,9 @@ exports.insertAfter = function (target) {
  *   //      <li class="pear">Pear</li>
  *   //    </ul>
  *
+ * @param {string | Element | Element[] | Cheerio | Function} content - HTML string, DOM
+ *     element, array of DOM elements or Cheerio to insert before each element
+ *     in the set of matched elements.
  * @see {@link https://api.jquery.com/before/}
  *
  * @returns {Cheerio} The instance itself.
@@ -624,6 +636,8 @@ exports.before = function () {
     uniqueSplice(siblings, index, 0, dom, parent);
   });
 };
+
+/*eslint-enable jsdoc/check-param-names*/
 
 /**
  * Insert every element in the set of matched elements before the target.

--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -602,9 +602,9 @@ exports.insertAfter = function (target) {
  *   //      <li class="pear">Pear</li>
  *   //    </ul>
  *
- * @param {...(string | Element | Element[] | Cheerio | Function)} content - HTML
- *   string, DOM element, array of DOM elements or Cheerio to insert before
- *   each element in the set of matched elements.
+ * @param {...(string | Element | Element[] | Cheerio | Function)} content -
+ *   HTML string, DOM element, array of DOM elements or Cheerio to insert
+ *   before each element in the set of matched elements.
  * @see {@link https://api.jquery.com/before/}
  *
  * @returns {Cheerio} The instance itself.

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -10,6 +10,7 @@ var utils = require('../utils');
 var domEach = utils.domEach;
 var uniqueSort = require('htmlparser2').DomUtils.uniqueSort;
 var isTag = utils.isTag;
+var slice = Array.prototype.slice;
 var reSiblingSelector = /^\s*[~+]/;
 
 /**
@@ -805,7 +806,7 @@ exports.eq = function (i) {
  */
 exports.get = function (i) {
   if (i == null) {
-    return Array.prototype.slice.call(this);
+    return slice.call(this);
   }
   return this[i < 0 ? this.length + i : i];
 };
@@ -845,7 +846,7 @@ exports.index = function (selectorOrNeedle) {
 };
 
 /**
- * Gets the elements matching the specified range.
+ * Gets the elements matching the specified range (0-based position).
  *
  * @example
  *   $('li').slice(1).eq(0).text();
@@ -854,12 +855,17 @@ exports.index = function (selectorOrNeedle) {
  *   $('li').slice(1, 2).length;
  *   //=> 1
  *
+ * @param {number} [start] - An position at which the elements begin to be
+ *     selected. If negative, it indicates an offset from the end of the set.
+ * @param {number} [end] - An position at which the elements stop being selected.
+ *     If negative, it indicates an offset from the end of the set. If omitted,
+ *     the range continues until the end of the set.
  * @see {@link https://api.jquery.com/slice/}
  *
  * @returns {Cheerio} The elements matching the specified range.
  */
-exports.slice = function () {
-  return this._make([].slice.apply(this, arguments));
+exports.slice = function (start, end) {
+  return this._make(slice.call(this, start, end));
 };
 
 function traverseParents(self, elem, selector, limit) {

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -856,10 +856,10 @@ exports.index = function (selectorOrNeedle) {
  *   //=> 1
  *
  * @param {number} [start] - An position at which the elements begin to be
- *     selected. If negative, it indicates an offset from the end of the set.
- * @param {number} [end] - An position at which the elements stop being selected.
- *     If negative, it indicates an offset from the end of the set. If omitted,
- *     the range continues until the end of the set.
+ *   selected. If negative, it indicates an offset from the end of the set.
+ * @param {number} [end] - An position at which the elements stop being
+ *   selected. If negative, it indicates an offset from the end of the set. If
+ *   omitted, the range continues until the end of the set.
  * @see {@link https://api.jquery.com/slice/}
  *
  * @returns {Cheerio} The elements matching the specified range.


### PR DESCRIPTION
according to documentation functions [after](https://cheerio.js.org/Cheerio.html#after), [before](https://cheerio.js.org/Cheerio.html#before), [slice](https://cheerio.js.org/Cheerio.html#slice) doesnt have arguments, added argument definitions.