### PR TITLE
Object.assign is not compatible with node v0.12

### DIFF
--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -246,7 +246,7 @@ function setData(el, name, value) {
     el.data = {};
   }
 
-  if (typeof name === 'object') Object.assign(el.data, name);
+  if (typeof name === 'object') utils.assign(el.data, name);
   else if (typeof name === 'string' && value !== undefined) {
     el.data[name] = value;
   }

--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -57,7 +57,7 @@ exports.find = function (selectorOrHaystack) {
           : newElems;
       }, []);
 
-  var options = Object.assign({ context: context }, this.options);
+  var options = utils.assign({ context: context }, this.options);
 
   return this._make(select.select(selectorOrHaystack, elems, options));
 };

--- a/lib/cheerio.js
+++ b/lib/cheerio.js
@@ -7,6 +7,7 @@ var parse = require('./parse');
 var defaultOptions = require('./options').default;
 var flattenOptions = require('./options').flatten;
 var isHtml = require('./utils').isHtml;
+var assign = require('./utils').assign;
 
 /*
  * The API
@@ -41,7 +42,7 @@ var Cheerio = (module.exports = function (selector, context, root, options) {
   }
 
   this.length = 0;
-  this.options = Object.assign(
+  this.options = assign(
     {},
     defaultOptions,
     this.options,
@@ -140,7 +141,7 @@ Cheerio.prototype[Symbol.iterator] = Array.prototype[Symbol.iterator];
 
 // Plug in the API
 api.forEach(function (mod) {
-  Object.assign(Cheerio.prototype, mod);
+  assign(Cheerio.prototype, mod);
 });
 
 function isNode(obj) {

--- a/lib/load.js
+++ b/lib/load.js
@@ -5,6 +5,7 @@
  */
 var defaultOptions = require('./options').default;
 var flattenOptions = require('./options').flatten;
+var assign = require('./utils').assign;
 var staticMethods = require('./static');
 var Cheerio = require('./cheerio');
 var parse = require('./parse');
@@ -27,7 +28,7 @@ exports.load = function (content, options, isDocument) {
     throw new Error('cheerio.load() expects a string');
   }
 
-  options = Object.assign({}, defaultOptions, flattenOptions(options));
+  options = assign({}, defaultOptions, flattenOptions(options));
 
   if (typeof isDocument === 'undefined') isDocument = true;
 
@@ -37,7 +38,7 @@ exports.load = function (content, options, isDocument) {
     if (!(this instanceof initialize)) {
       return new initialize(selector, context, r, opts);
     }
-    opts = Object.assign({}, options, opts);
+    opts = assign({}, options, opts);
     return Cheerio.call(this, selector, context, r || root, opts);
   }
 
@@ -54,7 +55,7 @@ exports.load = function (content, options, isDocument) {
   initialize.prototype._originalRoot = root;
 
   // Add in the static methods
-  Object.assign(initialize, staticMethods, exports);
+  assign(initialize, staticMethods, exports);
 
   // Add in the root
   initialize._root = root;

--- a/lib/options.js
+++ b/lib/options.js
@@ -5,12 +5,13 @@ exports.default = {
   decodeEntities: true,
 };
 
+var assign = require('./utils').assign;
 var xmlModeDefault = { _useHtmlParser2: true, xmlMode: true };
 
 exports.flatten = function (options) {
   return options && options.xml
     ? typeof options.xml === 'boolean'
       ? xmlModeDefault
-      : Object.assign({}, xmlModeDefault, options.xml)
+      : assign({}, xmlModeDefault, options.xml)
     : options;
 };

--- a/lib/static.js
+++ b/lib/static.js
@@ -5,6 +5,7 @@
  */
 var defaultOptions = require('./options').default;
 var flattenOptions = require('./options').flatten;
+var assign = require('./utils').assign;
 var select = require('cheerio-select').select;
 var renderWithParse5 = require('./parsers/parse5').render;
 var renderWithHtmlparser2 = require('./parsers/htmlparser2').render;
@@ -57,7 +58,7 @@ exports.html = function (dom, options) {
 
   // Sometimes `$.html()` is used without preloading html,
   // so fallback non-existing options to the default ones.
-  options = Object.assign(
+  options = assign(
     {},
     defaultOptions,
     this ? this._options : {},
@@ -74,7 +75,7 @@ exports.html = function (dom, options) {
  * @returns {string} THe rendered document.
  */
 exports.xml = function (dom) {
-  var options = Object.assign({}, this._options, { xmlMode: true });
+  var options = assign({}, this._options, { xmlMode: true });
 
   return render(this, dom, options);
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,6 +15,40 @@ var domhandler = require('domhandler');
 exports.isTag = htmlparser2.DomUtils.isTag;
 
 /**
+ * Method copies all enumerable own properties from one or more source objects
+ * to a target object. It returns the target object. Equal with Object.assign
+ * uses polyfill, if it's not existing.
+ *
+ * @private
+ *
+ * @param {object} target - DOM node to check.
+ * @returns {object} - Target object.
+ */
+exports.assign = Object.assign
+  ? Object.assign
+  : function assign(target) {
+      if (target === null || target === undefined) {
+        throw new TypeError('Cannot convert undefined or null to object');
+      }
+
+      var to = Object(target);
+
+      for (var index = 1; index < arguments.length; index++) {
+        var nextSource = arguments[index];
+
+        if (nextSource !== null && nextSource !== undefined) {
+          for (var nextKey in nextSource) {
+            // Avoid bugs when hasOwnProperty is shadowed
+            if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+              to[nextKey] = nextSource[nextKey];
+            }
+          }
+        }
+      }
+      return to;
+    };
+
+/**
  * Convert a string to camel case notation.
  *
  * @private


### PR DESCRIPTION
After writing out `lodash` - function `_.assign` was replaced with `Object.assign`, but this is not compatible with node v0.12