### PR TITLE
fix(traversing): Fix filter for `{prev,next}Until`

### DIFF
--- a/lib/api/traversing.js
+++ b/lib/api/traversing.js
@@ -181,9 +181,9 @@ exports.parentsUntil = function (selector, filter) {
       }
     }, this);
 
-  return this._make(
-    filter ? select.filter(filter, parentNodes, this.options) : parentNodes
-  );
+  return filter
+    ? exports.filter.call(parentNodes, filter, this)
+    : this._make(parentNodes);
 };
 
 /**
@@ -314,7 +314,7 @@ exports.nextUntil = function (selector, filterSelector) {
   var untilNodes;
 
   if (typeof selector === 'string') {
-    untilNode = select.select(selector, this.nextAll().get(), this.options)[0];
+    untilNodes = this.nextAll(selector).toArray();
   } else if (selector && selector.cheerio) {
     untilNodes = selector.get();
   } else if (selector) {
@@ -432,7 +432,7 @@ exports.prevUntil = function (selector, filterSelector) {
   var untilNodes;
 
   if (typeof selector === 'string') {
-    untilNode = select.select(selector, this.prevAll().get(), this.options)[0];
+    untilNodes = this.prevAll(selector).toArray();
   } else if (selector && selector.cheerio) {
     untilNodes = selector.get();
   } else if (selector) {

--- a/test/api/traversing.js
+++ b/test/api/traversing.js
@@ -4,6 +4,7 @@ var food = require('../__fixtures__/fixtures').food;
 var fruits = require('../__fixtures__/fixtures').fruits;
 var drinks = require('../__fixtures__/fixtures').drinks;
 var text = require('../__fixtures__/fixtures').text;
+var forms = require('../__fixtures__/fixtures').forms;
 
 describe('$(...)', function () {
   var $;
@@ -266,6 +267,13 @@ describe('$(...)', function () {
       expect(elems[0].attribs['class']).toBe('orange');
     });
 
+    it('(selector) : should support selector matching multiple elements', function () {
+      var elems = $('#disabled', forms).nextUntil('option, #unnamed');
+      expect(elems).toHaveLength(2);
+      expect(elems[0].attribs['id']).toBe('submit');
+      expect(elems[1].attribs['id']).toBe('select');
+    });
+
     it('(selector not sibling) : should return all following siblings', function () {
       var elems = $('.apple').nextUntil('#vegetables');
       expect(elems).toHaveLength(2);
@@ -402,6 +410,13 @@ describe('$(...)', function () {
       var elems = $('.pear').prevUntil('.apple');
       expect(elems).toHaveLength(1);
       expect(elems[0].attribs['class']).toBe('orange');
+    });
+
+    it('(selector) : should support selector matching multiple elements', function () {
+      var elems = $('#unnamed', forms).prevUntil('option, #disabled');
+      expect(elems).toHaveLength(2);
+      expect(elems[0].attribs['id']).toBe('select');
+      expect(elems[1].attribs['id']).toBe('submit');
     });
 
     it('(selector not sibling) : should return all preceding siblings', function () {


### PR DESCRIPTION
Continuation of #1708, fixing up `untilNodes` for `{prev,next}Until`.