### PR TITLE
cheerio-select 1.1.0 -> 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1548,9 +1548,9 @@
       "dev": true
     },
     "cheerio-select": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.1.0.tgz",
-      "integrity": "sha512-hOcy3Ps4lg6tMWM/q2NL5ItM+BTt1C8TNbtb9ZGscqDbGhKX0TzLRy9QJ2/KVlmmEbMjCNBublWdO4TPz51SdA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.2.0.tgz",
+      "integrity": "sha512-qK21OAtG1KvkwSgERrmGrATsZgtBC33whyFFMDZUULbKjLKuP0gGEppmPxWqkY7oyXJINhq/z8wVxKn+DZsw5g==",
       "requires": {
         "css-select": "^3.1.2",
         "css-what": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "node": ">= 0.12"
   },
   "dependencies": {
-    "cheerio-select": "^1.1.0",
+    "cheerio-select": "^1.2.0",
     "dom-serializer": "~1.2.0",
     "domhandler": "^4.0.0",
     "htmlparser2": "^6.0.0",

--- a/test/api/traversing.js
+++ b/test/api/traversing.js
@@ -576,9 +576,9 @@ describe('$(...)', function () {
     it('(selector, filter) : Multiple-filtered parentsUntil check', function () {
       var result = $('.orange').parentsUntil('html', 'ul,body');
       expect(result).toHaveLength(3);
-      expect(result.eq(0).prop('tagName')).toBe('BODY');
+      expect(result.eq(0).attr('id')).toBe('fruits');
       expect(result.eq(1).attr('id')).toBe('food');
-      expect(result.eq(2).attr('id')).toBe('fruits');
+      expect(result.eq(2).prop('tagName')).toBe('BODY');
     });
 
     it('() : should return empty object when called on an empty object', function () {


### PR DESCRIPTION
Same as #1729 except I updated failed test

apparently order of objects should be correct this time.