### PR TITLE
function .attr() - handle value undefined like jQuery 

### DIFF
--- a/lib/api/attributes.js
+++ b/lib/api/attributes.js
@@ -107,7 +107,7 @@ function setAttr(el, name, value) {
  */
 exports.attr = function (name, value) {
   // Set the value (with attr map support)
-  if (typeof name === 'object' || arguments.length > 1) {
+  if (typeof name === 'object' || value !== undefined) {
     if (typeof value === 'function') {
       return domEach(this, function (i, el) {
         setAttr(el, name, value.call(el, i, el.attribs[name]));
@@ -127,7 +127,7 @@ exports.attr = function (name, value) {
     });
   }
 
-  return getAttr(this[0], name);
+  return arguments.length > 1 ? this : getAttr(this[0], name);
 };
 
 /**

--- a/test/api/attributes.js
+++ b/test/api/attributes.js
@@ -149,7 +149,7 @@ describe('$(...)', function () {
     it('(chaining) setting attr to undefined returns a $', function () {
       var $pear = $('.pear').attr('foo', undefined);
       expect($('.pear')).toHaveLength(1);
-      expect($('.pear').attr('foo')).toBe('undefined'); // TODO this is stringified undefined
+      expect($('.pear').attr('foo')).toBeUndefined();
       expect($pear).toBeInstanceOf($);
     });
   });


### PR DESCRIPTION
function .attr() - handle value undefined like jQuery does it.

should fix #1664