### PR TITLE
Fix types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -125,8 +125,8 @@ declare namespace cheerio {
 
     eq(index: number): Cheerio;
 
-    get(): any[];
-    get(index: number): any;
+    get(): Node[];
+    get(index: number): Node | undefined;
 
     index(): number;
     index(selector: string): number;
@@ -221,7 +221,7 @@ declare namespace cheerio {
 
     // Not Documented
 
-    toArray(): Element[];
+    toArray(): Node[];
   }
 
   interface CheerioParserOptions extends ParserOptions, DomHandlerOptions {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -125,8 +125,8 @@ declare namespace cheerio {
 
     eq(index: number): Cheerio;
 
-    get(): Node[];
-    get(index: number): Node | undefined;
+    get(): Element[];
+    get(index: number): Element | undefined;
 
     index(): number;
     index(selector: string): number;
@@ -221,7 +221,7 @@ declare namespace cheerio {
 
     // Not Documented
 
-    toArray(): Node[];
+    toArray(): Element[];
   }
 
   interface CheerioParserOptions extends ParserOptions, DomHandlerOptions {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,4 +1,5 @@
 import { expectType } from 'tsd';
+import { Element } from 'domhandler';
 import cheerio from '..';
 
 /*
@@ -19,7 +20,7 @@ cheerio(html);
 cheerio('ul', html);
 cheerio('li', 'ul', html);
 
-const $fromElement = cheerio.load($('ul').toString());
+const $fromElement = cheerio.load($('ul').get(0) as Element);
 
 if ($fromElement('ul > li').length !== 3) {
   throw new Error(

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -19,7 +19,7 @@ cheerio(html);
 cheerio('ul', html);
 cheerio('li', 'ul', html);
 
-const $fromElement = cheerio.load($('ul').get(0));
+const $fromElement = cheerio.load($('ul').toString());
 
 if ($fromElement('ul > li').length !== 3) {
   throw new Error(
@@ -248,7 +248,7 @@ $el.eq(0).text();
 $el.eq(-1).text();
 
 // .get( [i] )
-$el.get(0).tagName;
+$el.get(0)?.tagName;
 $el.get().length;
 
 // .index()


### PR DESCRIPTION
Hi there, first of all, thanks so much for Cheerio! Cool to be able to load an HTML string in anywhere and traverse so easily.

Shouldn't `.get()` always return either `Element[]`, an `Element` or `undefined?