### PR TITLE
Add type for $.text() method

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -262,7 +262,7 @@ declare namespace cheerio {
       context?: Document,
       keepScripts?: boolean
     ): Document[];
-    
+
     text(): string;
     text(text: string): Cheerio;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -262,6 +262,9 @@ declare namespace cheerio {
       context?: Document,
       keepScripts?: boolean
     ): Document[];
+    
+    text(): string;
+    text(text: string): Cheerio;
 
     html(options?: CheerioParserOptions): string;
     html(


### PR DESCRIPTION
It appears there is a `$.text()` method that is not currently typed (at least this form: `text(): string;`).

Not sure if the `text(text: string): Cheerio;` form works... copied that from the Cheerio element declaration above.