### PR TITLE
Parsing HTML content inside <noscript> tags

### DIFF
--- a/lib/load.js
+++ b/lib/load.js
@@ -28,6 +28,7 @@ exports.load = function (content, options, isDocument) {
   }
 
   options = Object.assign({}, defaultOptions, flattenOptions(options));
+  options.scriptingEnabled = !!options.scriptingEnabled;
 
   if (typeof isDocument === 'undefined') isDocument = true;
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -3,6 +3,7 @@
 exports.default = {
   xml: false,
   decodeEntities: true,
+  scriptingEnabled: false,
 };
 
 var xmlModeDefault = { _useHtmlParser2: true, xmlMode: true };

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -428,35 +428,38 @@ describe('cheerio', function () {
   describe('parse5 options', function () {
     var noscript = fixtures.noscript;
 
-    // should parse noscript tags only with false option value
+    // should parse noscript tags by default
     test('{scriptingEnabled: ???}', function () {
       var opt = 'scriptingEnabled';
       var options = {};
       var result;
 
-      // [default] scriptingEnabled: true - tag contains one text element
-      result = cheerio.load(noscript)('noscript');
+      // scriptingEnabled: true - tag contains one text element
+      options[opt] = true;
+      result = cheerio.load(noscript, options)('noscript');
       expect(result).toHaveLength(1);
       expect(result[0].children).toHaveLength(1);
       expect(result[0].children[0].type).toBe('text');
 
-      // scriptingEnabled: false - content of noscript will parsed
-      options[opt] = false;
-      result = cheerio.load(fixtures.noscript, options)('noscript');
+      // [default] scriptingEnabled: false - content of noscript will parsed
+      // options[opt] = false;
+      result = cheerio.load(noscript)('noscript');
       expect(result).toHaveLength(1);
       expect(result[0].children).toHaveLength(2);
       expect(result[0].children[0].type).toBe('comment');
       expect(result[0].children[1].type).toBe('tag');
       expect(result[0].children[1].name).toBe('a');
 
-      // scriptingEnabled: ??? - should acts as true
-      var values = [undefined, null, 0, ''];
+      // scriptingEnabled: ??? - should act as false
+      var values = [false, undefined, null, 0, ''];
       for (var val of values) {
         options[opt] = val;
         result = cheerio.load(noscript, options)('noscript');
         expect(result).toHaveLength(1);
-        expect(result[0].children).toHaveLength(1);
-        expect(result[0].children[0].type).toBe('text');
+        expect(result[0].children).toHaveLength(2);
+        expect(result[0].children[0].type).toBe('comment');
+        expect(result[0].children[1].type).toBe('tag');
+        expect(result[0].children[1].name).toBe('a');
       }
     });
 


### PR DESCRIPTION
The `scriptingEnabled` flag was added to parse5 in version 5.0.0 [parse5: ParserOptions](https://github.com/inikulin/parse5/blob/master/packages/parse5/docs/options/parser-options.md)  

`scriptingEnabled=true` will parse `<script>` tags as javascript and `<noscript>` tags as raw text.
`scriptingEnabled=false` will parse `<script>` tags as raw text and `<noscript>` tags as HTML.

The later is the preferred default behavior for cheerio. As we do not want to execute the javascript, but do want to view the page as a scripts-disabled browser would.

See #1105 for discussion on this issue.