### PR TITLE
some cases htmlparser2 cant be used for html rendering

### DIFF
--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -797,7 +797,7 @@ exports.html = function (str) {
     return html(this[0].children, this.options);
   }
 
-  var opts = Object.apply({}, this.options); // keep main options
+  var opts = Object.assign({}, this.options); // keep main options
 
   return domEach(this, function (_, el) {
     el.children.forEach(function (child) {


### PR DESCRIPTION
small fix that allows using htmlparser2 for html rendering, when html string was provided.