### PR TITLE
Fixed parsing content in .html function

### DIFF
--- a/lib/api/manipulation.js
+++ b/lib/api/manipulation.js
@@ -797,7 +797,7 @@ exports.html = function (str) {
     return html(this[0].children, this.options);
   }
 
-  var opts = Object.apply({}, this.options); // keep main options
+  var opts = Object.assign({}, this.options); // keep main options
 
   return domEach(this, function (_, el) {
     el.children.forEach(function (child) {


### PR DESCRIPTION
Hi, I've noticed that calling .html(<content>) when using the `htmlparser2` mode will crash. This will fix that. Thanks