### PR TITLE
refactor: Have `load` export a function

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -166,7 +166,7 @@ Cheerio's selector implementation is nearly identical to jQuery's, so the API is
 
 `selector` searches within the `context` scope which searches within the `root` scope. `selector` and `context` can be a string expression, DOM Element, array of DOM elements, or cheerio object. `root` is typically the HTML document string.
 
-This selector method is the starting point for traversing and manipulating the document. Like jQuery, it's the primary method for selecting elements in the document, but unlike jQuery it's built on top of the CSSSelect library, which implements most of the Sizzle selectors.
+This selector method is the starting point for traversing and manipulating the document. Like jQuery, it's the primary method for selecting elements in the document.
 
 ```js
 $('.apple', '#fruits').text();

--- a/src/__tests__/deprecated.spec.ts
+++ b/src/__tests__/deprecated.spec.ts
@@ -58,7 +58,7 @@ describe('deprecated APIs', () => {
 
       // #1674 - merge, wont accept Cheerio object
       it('should be a able merge array and cheerio object', () => {
-        const ret = cheerio.merge(new cheerio(), ['elem1', 'elem2'] as any);
+        const ret = cheerio.merge(cheerio(), ['elem1', 'elem2'] as any);
         expect(typeof ret).toBe('object');
         expect(ret).toHaveLength(2);
       });
@@ -202,7 +202,8 @@ describe('deprecated APIs', () => {
     describe('.root', () => {
       it('returns an empty selection', () => {
         const $empty = cheerio.root();
-        expect($empty).toHaveLength(0);
+        expect($empty).toHaveLength(1);
+        expect($empty[0].children).toHaveLength(0);
       });
     });
   });

--- a/src/api/forms.spec.ts
+++ b/src/api/forms.spec.ts
@@ -1,5 +1,5 @@
 import cheerio from '../../src';
-import type { CheerioAPI } from '../cheerio';
+import type { CheerioAPI } from '../load';
 import { forms } from '../__fixtures__/fixtures';
 
 describe('$(...)', () => {

--- a/src/api/forms.ts
+++ b/src/api/forms.ts
@@ -1,5 +1,5 @@
 import type { Node } from 'domhandler';
-import type { Cheerio, CheerioAPI } from '../cheerio';
+import type { Cheerio } from '../cheerio';
 import { isTag } from '../utils';
 
 /*
@@ -54,9 +54,8 @@ export function serializeArray<T extends Node>(
   this: Cheerio<T>
 ): SerializedField[] {
   // Resolve all form elements from either forms or collections of form elements
-  const Cheerio = this.constructor as CheerioAPI;
   return this.map((_, elem) => {
-    const $elem = Cheerio(elem);
+    const $elem = this._make(elem);
     if (isTag(elem) && elem.name === 'form') {
       return $elem.find(submittableSelector).toArray();
     }
@@ -72,7 +71,7 @@ export function serializeArray<T extends Node>(
       // Convert each of the elements to its value(s)
     )
     .map<Node, SerializedField>((_, elem) => {
-      const $elem = Cheerio(elem);
+      const $elem = this._make(elem);
       const name = $elem.attr('name') as string; // We have filtered for elements with a name before.
       // If there is no value set (e.g. `undefined`, `null`), then default value to empty
       const value = $elem.val() ?? '';

--- a/src/api/manipulation.spec.ts
+++ b/src/api/manipulation.spec.ts
@@ -1,5 +1,5 @@
 import { load } from '../../src';
-import type { CheerioAPI, Cheerio } from '../cheerio';
+import type { CheerioAPI, Cheerio } from '..';
 import { fruits, divcontainers, mixedText } from '../__fixtures__/fixtures';
 import type { Node, Element } from 'domhandler';
 

--- a/src/api/manipulation.ts
+++ b/src/api/manipulation.ts
@@ -168,7 +168,7 @@ export function appendTo<T extends Node>(
   this: Cheerio<T>,
   target: BasicAcceptedElems<Node>
 ): Cheerio<T> {
-  const appendTarget = isCheerio(target) ? target : this._make(target, null);
+  const appendTarget = isCheerio(target) ? target : this._make(target);
 
   appendTarget.append(this);
 
@@ -200,7 +200,7 @@ export function prependTo<T extends Node>(
   this: Cheerio<T>,
   target: BasicAcceptedElems<Node>
 ): Cheerio<T> {
-  const prependTarget = isCheerio(target) ? target : this._make(target, null);
+  const prependTarget = isCheerio(target) ? target : this._make(target);
 
   prependTarget.prepend(this);
 
@@ -638,7 +638,7 @@ export function insertAfter<T extends Node>(
   target: BasicAcceptedElems<Node>
 ): Cheerio<T> {
   if (typeof target === 'string') {
-    target = this._make<Node>(target, null);
+    target = this._make<Node>(target);
   }
 
   this.remove();
@@ -751,7 +751,7 @@ export function insertBefore<T extends Node>(
   this: Cheerio<T>,
   target: BasicAcceptedElems<Node>
 ): Cheerio<T> {
-  const targetArr = this._make<Node>(target, null);
+  const targetArr = this._make<Node>(target);
 
   this.remove();
 

--- a/src/api/manipulation.ts
+++ b/src/api/manipulation.ts
@@ -168,9 +168,7 @@ export function appendTo<T extends Node>(
   this: Cheerio<T>,
   target: BasicAcceptedElems<Node>
 ): Cheerio<T> {
-  const appendTarget = isCheerio(target)
-    ? target
-    : this._make(target, null, this._originalRoot);
+  const appendTarget = isCheerio(target) ? target : this._make(target, null);
 
   appendTarget.append(this);
 
@@ -202,9 +200,7 @@ export function prependTo<T extends Node>(
   this: Cheerio<T>,
   target: BasicAcceptedElems<Node>
 ): Cheerio<T> {
-  const prependTarget = isCheerio(target)
-    ? target
-    : this._make(target, null, this._originalRoot);
+  const prependTarget = isCheerio(target) ? target : this._make(target, null);
 
   prependTarget.prepend(this);
 
@@ -642,7 +638,7 @@ export function insertAfter<T extends Node>(
   target: BasicAcceptedElems<Node>
 ): Cheerio<T> {
   if (typeof target === 'string') {
-    target = this._make<Node>(target, null, this._originalRoot);
+    target = this._make<Node>(target, null);
   }
 
   this.remove();
@@ -755,7 +751,7 @@ export function insertBefore<T extends Node>(
   this: Cheerio<T>,
   target: BasicAcceptedElems<Node>
 ): Cheerio<T> {
-  const targetArr = this._make<Node>(target, null, this._originalRoot);
+  const targetArr = this._make<Node>(target, null);
 
   this.remove();
 

--- a/src/api/traversing.spec.ts
+++ b/src/api/traversing.spec.ts
@@ -1,5 +1,5 @@
 import cheerio from '../../src';
-import type { CheerioAPI, Cheerio } from '../cheerio';
+import { CheerioAPI, Cheerio } from '../cheerio';
 import { Node, Element, isText } from 'domhandler';
 import {
   food,
@@ -689,7 +689,7 @@ describe('$(...)', () => {
     it('() : should return an empty array', () => {
       const result = $('.orange').closest();
       expect(result).toHaveLength(0);
-      expect(result).toBeInstanceOf(cheerio);
+      expect(result).toBeInstanceOf(Cheerio);
     });
 
     it('(selector) : should find the closest element that matches the selector, searching through its ancestors and itself', () => {

--- a/src/api/traversing.spec.ts
+++ b/src/api/traversing.spec.ts
@@ -1238,6 +1238,13 @@ describe('$(...)', () => {
         expect($selection[0]).toBe($fruits[0]);
         expect($selection[1]).toBe($orange[0]);
       });
+      it('is root object preserved', () => {
+        const $selection = $('<div></div>').add('#fruits');
+
+        expect($selection).toHaveLength(2);
+        expect($selection.eq(0).is('div')).toBe(true);
+        expect($selection.eq(1).is($fruits.eq(0))).toBe(true);
+      });
     });
     describe('(selector) matched elements :', () => {
       it('occur before the current selection', () => {

--- a/src/api/traversing.spec.ts
+++ b/src/api/traversing.spec.ts
@@ -1,5 +1,6 @@
 import cheerio from '../../src';
-import { CheerioAPI, Cheerio } from '../cheerio';
+import { Cheerio } from '../cheerio';
+import type { CheerioAPI } from '../load';
 import { Node, Element, isText } from 'domhandler';
 import {
   food,

--- a/src/api/traversing.ts
+++ b/src/api/traversing.ts
@@ -8,6 +8,7 @@ import { Node, Element, hasChildren } from 'domhandler';
 import type { Cheerio } from '../cheerio';
 import * as select from 'cheerio-select';
 import { domEach, isTag, isCheerio } from '../utils';
+import { contains } from '../static';
 import { DomUtils } from 'htmlparser2';
 import type { FilterFunction, AcceptedFilters } from '../types';
 const { uniqueSort } = DomUtils;
@@ -42,7 +43,6 @@ export function find<T extends Node>(
   const context: Node[] = this.toArray();
 
   if (typeof selectorOrHaystack !== 'string') {
-    const { contains } = this.constructor as typeof Cheerio;
     const haystack = isCheerio(selectorOrHaystack)
       ? selectorOrHaystack.get()
       : [selectorOrHaystack];

--- a/src/api/traversing.ts
+++ b/src/api/traversing.ts
@@ -941,9 +941,25 @@ export function get<T>(this: Cheerio<T>, i: number): T;
 export function get<T>(this: Cheerio<T>): T[];
 export function get<T>(this: Cheerio<T>, i?: number): T | T[] {
   if (i == null) {
-    return Array.prototype.slice.call(this);
+    return this.toArray();
   }
   return this[i < 0 ? this.length + i : i];
+}
+
+/**
+ * Retrieve all the DOM elements contained in the jQuery set as an array.
+ *
+ * @example
+ *
+ * ```js
+ * $('li').toArray();
+ * //=> [ {...}, {...}, {...} ]
+ * ```
+ *
+ * @returns The contained items.
+ */
+export function toArray<T>(this: Cheerio<T>): T[] {
+  return Array.prototype.slice.call(this);
 }
 
 /**

--- a/src/cheerio.spec.ts
+++ b/src/cheerio.spec.ts
@@ -270,6 +270,15 @@ describe('cheerio', () => {
       expect(lis).toHaveLength(3);
     });
 
+    it('should preserve root content', () => {
+      const $ = cheerio.load(fruits);
+      // Root should not be overwritten
+      const el = $('<div></div>');
+      expect(Object.is(el, el._root)).toBe(false);
+      // Query has to have results
+      expect($('li', 'ul')).toHaveLength(3);
+    });
+
     it('should allow loading a pre-parsed DOM', () => {
       const dom = parseDOM(food);
       const $ = cheerio.load(dom);

--- a/src/cheerio.spec.ts
+++ b/src/cheerio.spec.ts
@@ -215,11 +215,6 @@ describe('cheerio', () => {
     expect($elem.eq(1).attr('class')).toBe('orange');
   });
 
-  it('should gracefully degrade on complex, unmatched queries', () => {
-    const $elem = cheerio('Eastern States Cup #8-fin&nbsp;<1br>Downhill&nbsp;');
-    expect($elem).toHaveLength(0);
-  });
-
   it('(extended Array) should not interfere with prototype methods (issue #119)', () => {
     const extended: any = [];
     extended.find = extended.children = extended.each = function () {

--- a/src/cheerio.ts
+++ b/src/cheerio.ts
@@ -20,7 +20,7 @@ export class Cheerio<T> implements ArrayLike<T> {
   length = 0;
   [index: number]: T;
 
-  options!: InternalOptions;
+  options: InternalOptions;
   /**
    * The root of the document. Can be overwritten by using the `root` argument
    * of the constructor.

--- a/src/cheerio.ts
+++ b/src/cheerio.ts
@@ -45,13 +45,6 @@ export class Cheerio<T> implements ArrayLike<T> {
   _root: Cheerio<Document> | undefined;
   /** @function */
   find!: typeof Traversing.find;
-  /**
-   * The root the document was originally loaded with. Same as the static
-   * `_root` property.
-   *
-   * @private
-   */
-  _originalRoot: Document | undefined;
 
   /**
    * The root the document was originally loaded with. Set in `.load`.
@@ -145,14 +138,14 @@ export class Cheerio<T> implements ArrayLike<T> {
       : typeof context === 'string'
       ? isHtml(context)
         ? // $('li', '<ul>...</ul>')
-          new Cheerio(parse(context, this.options, false))
+          this._make(parse(context, this.options, false))
         : // $('li', 'ul')
           ((search = `${context} ${search}`), this._root)
       : isCheerio(context)
       ? // $('li', $)
         context
       : // $('li', node), $('li', [nodes])
-        new Cheerio(context);
+        this._make(context);
 
     // If we still don't have a context, return
     if (!searchContext) return this;
@@ -175,13 +168,12 @@ export class Cheerio<T> implements ArrayLike<T> {
    */
   _make<T>(
     dom: Cheerio<T> | T[] | T | string,
-    context?: BasicAcceptedElems<Node> | null,
-    root: BasicAcceptedElems<Document> | undefined = this._root
+    context?: BasicAcceptedElems<Node> | null
   ): Cheerio<T> {
     const cheerio = new (this.constructor as any)(
       dom,
       context,
-      root,
+      undefined,
       this.options
     );
     cheerio.prevObject = this;

--- a/src/cheerio.ts
+++ b/src/cheerio.ts
@@ -8,7 +8,7 @@ import {
 import { isHtml, isCheerio } from './utils';
 import type { Node, Document, Element } from 'domhandler';
 import * as Static from './static';
-import type { load } from './load';
+import type * as Load from './load';
 import { SelectorType, BasicAcceptedElems } from './types';
 
 import * as Attributes from './api/attributes';
@@ -22,6 +22,9 @@ type TraversingType = typeof Traversing;
 type ManipulationType = typeof Manipulation;
 type CssType = typeof Css;
 type FormsType = typeof Forms;
+
+type StaticType = typeof Static;
+type LoadType = typeof Load;
 
 /*
  * The API
@@ -69,7 +72,7 @@ export class Cheerio<T> implements ArrayLike<T> {
   public static root = Static.root;
   public static contains = Static.contains;
   public static merge = Static.merge;
-  public static load: typeof load;
+  public static load: typeof Load.load;
 
   /** Mimic jQuery's prototype alias for plugin authors. */
   public static fn = Cheerio.prototype;
@@ -222,19 +225,31 @@ function isNode(obj: any): obj is Node {
   );
 }
 
-type CheerioClassType = typeof Cheerio;
-
 /**
  * Wrapper around the `Cheerio` class, making it possible to create a new
  * instance without using `new`.
  */
-export interface CheerioAPI extends CheerioClassType {
+export interface CheerioAPI extends StaticType, LoadType {
   <T extends Node, S extends string>(
     selector?: S | BasicAcceptedElems<T>,
     context?: BasicAcceptedElems<Node> | null,
     root?: BasicAcceptedElems<Document>,
     options?: CheerioOptions
   ): Cheerio<S extends SelectorType ? Element : T>;
+
+  /**
+   * The root the document was originally loaded with. Set in `.load`.
+   *
+   * @private
+   */
+  _root: Document | undefined;
+
+  /**
+   * The options the document was originally loaded with. Set in `.load`.
+   *
+   * @private
+   */
+  _options: InternalOptions | undefined;
 }
 
 // Make it possible to call Cheerio without using `new`.

--- a/src/cheerio.ts
+++ b/src/cheerio.ts
@@ -87,7 +87,7 @@ export class Cheerio<T> implements ArrayLike<T> {
   constructor(
     selector?: T extends Node ? BasicAcceptedElems<T> : Cheerio<T> | T[],
     context?: BasicAcceptedElems<Node> | null,
-    root?: BasicAcceptedElems<Document>,
+    root?: BasicAcceptedElems<Document> | null,
     options?: CheerioOptions
   ) {
     if (!(this instanceof Cheerio)) {
@@ -107,7 +107,7 @@ export class Cheerio<T> implements ArrayLike<T> {
 
     if (root) {
       if (typeof root === 'string') root = parse(root, this.options, false);
-      this._root = (Cheerio as any).call(this, root);
+      this._root = new (this.constructor as typeof Cheerio)(root, null, null);
     }
 
     // $($)

--- a/src/cheerio.ts
+++ b/src/cheerio.ts
@@ -32,7 +32,7 @@ type LoadType = typeof Load;
 const api = [Attributes, Traversing, Manipulation, Css, Forms];
 
 export class Cheerio<T> implements ArrayLike<T> {
-  length!: number;
+  length = 0;
   [index: number]: T;
 
   options!: InternalOptions;
@@ -86,15 +86,8 @@ export class Cheerio<T> implements ArrayLike<T> {
     root?: BasicAcceptedElems<Document> | null,
     options?: CheerioOptions
   ) {
-    if (!(this instanceof Cheerio)) {
-      return new Cheerio(selector, context, root, options);
-    }
-
-    this.length = 0;
-
     this.options = {
       ...defaultOptions,
-      ...this.options,
       ...flattenOptions(options),
     };
 

--- a/src/cheerio.ts
+++ b/src/cheerio.ts
@@ -1,14 +1,8 @@
 import parse from './parse';
-import {
-  CheerioOptions,
-  InternalOptions,
-  default as defaultOptions,
-} from './options';
+import { InternalOptions, default as defaultOptions } from './options';
 import { isHtml, isCheerio } from './utils';
-import type { Node, Document, Element } from 'domhandler';
-import * as Static from './static';
-import type * as Load from './load';
-import { SelectorType, BasicAcceptedElems } from './types';
+import type { Node, Document } from 'domhandler';
+import { BasicAcceptedElems } from './types';
 
 import * as Attributes from './api/attributes';
 import * as Traversing from './api/traversing';
@@ -21,9 +15,6 @@ type TraversingType = typeof Traversing;
 type ManipulationType = typeof Manipulation;
 type CssType = typeof Css;
 type FormsType = typeof Forms;
-
-type StaticType = typeof Static;
-type LoadType = typeof Load;
 
 export class Cheerio<T> implements ArrayLike<T> {
   length = 0;
@@ -189,34 +180,4 @@ function isNode(obj: any): obj is Node {
     obj.type === 'text' ||
     obj.type === 'comment'
   );
-}
-
-/**
- * Wrapper around the `Cheerio` class, making it possible to create a new
- * instance without using `new`.
- */
-export interface CheerioAPI extends StaticType, LoadType {
-  <T extends Node, S extends string>(
-    selector?: S | BasicAcceptedElems<T>,
-    context?: BasicAcceptedElems<Node> | null,
-    root?: BasicAcceptedElems<Document>,
-    options?: CheerioOptions
-  ): Cheerio<S extends SelectorType ? Element : T>;
-
-  /**
-   * The root the document was originally loaded with. Set in `.load`.
-   *
-   * @private
-   */
-  _root: Document | undefined;
-
-  /**
-   * The options the document was originally loaded with. Set in `.load`.
-   *
-   * @private
-   */
-  _options: InternalOptions | undefined;
-
-  /** Mimic jQuery's prototype alias for plugin authors. */
-  fn: typeof Cheerio.prototype;
 }

--- a/src/cheerio.ts
+++ b/src/cheerio.ts
@@ -126,7 +126,7 @@ export class Cheerio<T> implements ArrayLike<T> {
    */
   _make<T>(
     dom: Cheerio<T> | T[] | T | string,
-    context?: BasicAcceptedElems<Node> | null
+    context?: BasicAcceptedElems<Node>
   ): Cheerio<T> {
     const cheerio = new (this.constructor as any)(
       dom,

--- a/src/cheerio.ts
+++ b/src/cheerio.ts
@@ -185,22 +185,6 @@ export class Cheerio<T> implements ArrayLike<T> {
 
     return cheerio;
   }
-
-  /**
-   * Retrieve all the DOM elements contained in the jQuery set as an array.
-   *
-   * @example
-   *
-   * ```js
-   * $('li').toArray();
-   * //=> [ {...}, {...}, {...} ]
-   * ```
-   *
-   * @returns The contained items.
-   */
-  toArray(): T[] {
-    return this.get();
-  }
 }
 
 export interface Cheerio<T>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import Cheerio from './cheerio';
-
 /**
  * The main types of Cheerio objects.
  *
@@ -26,9 +24,6 @@ export type { Node, NodeWithChildren, Element, Document } from 'domhandler';
 
 export * from './load';
 import { load } from './load';
-
-// We add this here, to avoid a cyclic depenency
-Cheerio.load = load;
 
 /**
  * The default cheerio instance.

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
  *
  * @category Cheerio
  */
-export type { Cheerio, CheerioAPI } from './cheerio';
+export type { Cheerio } from './cheerio';
 /**
  * Types used in signatures of Cheerio methods.
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,6 @@
 import Cheerio from './cheerio';
 
 /**
- * The default cheerio instance.
- *
- * @deprecated Use the function returned by `load` instead.
- */
-export default Cheerio;
-
-/**
  * The main types of Cheerio objects.
  *
  * @category Cheerio
@@ -33,8 +26,17 @@ export type { Node, NodeWithChildren, Element, Document } from 'domhandler';
 
 export * from './load';
 import { load } from './load';
+
 // We add this here, to avoid a cyclic depenency
 Cheerio.load = load;
+
+/**
+ * The default cheerio instance.
+ *
+ * @deprecated Use the function returned by `load` instead.
+ */
+export default load([]);
+
 import * as staticMethods from './static';
 
 /**

--- a/src/load.ts
+++ b/src/load.ts
@@ -45,7 +45,7 @@ export function load(
         ? string | Cheerio<T> | T[] | T
         : Cheerio<T> | T[],
       context?: string | Cheerio<Node> | Node[] | Node,
-      r: string | Cheerio<Document> | Document = root,
+      r: string | Cheerio<Document> | Document | null = root,
       opts?: CheerioOptions
     ) {
       // @ts-expect-error Using `this` before calling the constructor.

--- a/src/load.ts
+++ b/src/load.ts
@@ -8,11 +8,10 @@ import * as staticMethods from './static';
 import { Cheerio } from './cheerio';
 import parse from './parse';
 import type { Node, Document, Element } from 'domhandler';
-import * as Static from './static';
 import type * as Load from './load';
 import { SelectorType, BasicAcceptedElems } from './types';
 
-type StaticType = typeof Static;
+type StaticType = typeof staticMethods;
 type LoadType = typeof Load;
 
 /**
@@ -51,26 +50,22 @@ export interface CheerioAPI extends StaticType, LoadType {
  * introduce `<html>`, `<head>`, and `<body>` elements; set `isDocument` to
  * `false` to switch to fragment mode and disable this.
  *
- * See the README section titled "Loading" for additional usage information.
- *
  * @param content - Markup to be loaded.
  * @param options - Options for the created instance.
  * @param isDocument - Allows parser to be switched to fragment mode.
  * @returns The loaded document.
+ * @see {@link https://cheerio.js.org#loading} for additional usage information.
  */
 export function load(
   content: string | Node | Node[] | Buffer,
   options?: CheerioOptions | null,
-  isDocument?: boolean
+  isDocument = true
 ): CheerioAPI {
   if ((content as string | null) == null) {
     throw new Error('cheerio.load() expects a string');
   }
 
   const internalOpts = { ...defaultOptions, ...flattenOptions(options) };
-
-  if (typeof isDocument === 'undefined') isDocument = true;
-
   const root = parse(content, internalOpts, isDocument);
 
   /** Create an extended class here, so that extensions only live on one instance. */

--- a/src/load.ts
+++ b/src/load.ts
@@ -56,12 +56,6 @@ export function load(
     }
   }
 
-  /*
-   * Keep a reference to the top-level scope so we can chain methods that implicitly
-   * resolve selectors; e.g. $("<span>").(".bar"), which otherwise loses ._root
-   */
-  initialize.prototype._originalRoot = root;
-
   // Add in the static methods
   Object.assign(initialize, staticMethods, { load });
 

--- a/src/load.ts
+++ b/src/load.ts
@@ -15,10 +15,38 @@ type StaticType = typeof staticMethods;
 type LoadType = typeof Load;
 
 /**
- * Wrapper around the `Cheerio` class, making it possible to create a new
- * instance without using `new`.
+ * A querying function, bound to a document created from the provided markup.
+ *
+ * Also provides several helper methods for dealing with the document as a whole.
  */
 export interface CheerioAPI extends StaticType, LoadType {
+  /**
+   * This selector method is the starting point for traversing and manipulating
+   * the document. Like jQuery, it's the primary method for selecting elements
+   * in the document.
+   *
+   * `selector` searches within the `context` scope which searches within the
+   * `root` scope.
+   *
+   * @example
+   *
+   * ```js
+   * $('.apple', '#fruits').text();
+   * //=> Apple
+   *
+   * $('ul .pear').attr('class');
+   * //=> pear
+   *
+   * $('li[class=orange]').html();
+   * //=> Orange
+   * ```
+   *
+   * @param selector - Either a selector to look for within the document, or the
+   *   contents of a new Cheerio instance.
+   * @param context - Either a selector to look for within the root, or the
+   *   contents of the document to query.
+   * @param root - Optional HTML document string.
+   */
   <T extends Node, S extends string>(
     selector?: S | BasicAcceptedElems<T>,
     context?: BasicAcceptedElems<Node> | null,

--- a/src/load.ts
+++ b/src/load.ts
@@ -1,12 +1,49 @@
 import {
   CheerioOptions,
+  InternalOptions,
   default as defaultOptions,
   flatten as flattenOptions,
 } from './options';
 import * as staticMethods from './static';
-import { CheerioAPI, Cheerio } from './cheerio';
+import { Cheerio } from './cheerio';
 import parse from './parse';
-import type { Node, Document } from 'domhandler';
+import type { Node, Document, Element } from 'domhandler';
+import * as Static from './static';
+import type * as Load from './load';
+import { SelectorType, BasicAcceptedElems } from './types';
+
+type StaticType = typeof Static;
+type LoadType = typeof Load;
+
+/**
+ * Wrapper around the `Cheerio` class, making it possible to create a new
+ * instance without using `new`.
+ */
+export interface CheerioAPI extends StaticType, LoadType {
+  <T extends Node, S extends string>(
+    selector?: S | BasicAcceptedElems<T>,
+    context?: BasicAcceptedElems<Node> | null,
+    root?: BasicAcceptedElems<Document>,
+    options?: CheerioOptions
+  ): Cheerio<S extends SelectorType ? Element : T>;
+
+  /**
+   * The root the document was originally loaded with.
+   *
+   * @private
+   */
+  _root: Document;
+
+  /**
+   * The options the document was originally loaded with.
+   *
+   * @private
+   */
+  _options: InternalOptions;
+
+  /** Mimic jQuery's prototype alias for plugin authors. */
+  fn: typeof Cheerio.prototype;
+}
 
 /**
  * Create a querying function, bound to a document created from the provided

--- a/src/static.spec.ts
+++ b/src/static.spec.ts
@@ -1,6 +1,5 @@
 import * as fixtures from './__fixtures__/fixtures';
-import cheerio from '.';
-import { CheerioAPI } from './cheerio';
+import cheerio, { CheerioAPI } from '.';
 
 describe('cheerio', () => {
   describe('.html', () => {

--- a/src/static.ts
+++ b/src/static.ts
@@ -20,7 +20,7 @@ import { render as renderWithHtmlparser2 } from './parsers/htmlparser2';
  * @returns The rendered document.
  */
 function render(
-  that: typeof Cheerio | undefined,
+  that: CheerioAPI | undefined,
   dom: ArrayLike<Node> | Node | string | undefined,
   options: InternalOptions
 ): string {
@@ -63,10 +63,7 @@ function isOptions(
  * @param options - Options for the renderer.
  * @returns The rendered document.
  */
-export function html(
-  this: typeof Cheerio | void,
-  options?: CheerioOptions
-): string;
+export function html(this: CheerioAPI | void, options?: CheerioOptions): string;
 /**
  * Renders the document.
  *
@@ -75,12 +72,12 @@ export function html(
  * @returns The rendered document.
  */
 export function html(
-  this: typeof Cheerio | void,
+  this: CheerioAPI | void,
   dom?: string | ArrayLike<Node> | Node,
   options?: CheerioOptions
 ): string;
 export function html(
-  this: typeof Cheerio | void,
+  this: CheerioAPI | void,
   dom?: string | ArrayLike<Node> | Node | CheerioOptions,
   options?: CheerioOptions
 ): string {
@@ -119,7 +116,7 @@ export function html(
  * @returns THe rendered document.
  */
 export function xml(
-  this: typeof Cheerio,
+  this: CheerioAPI,
   dom?: string | ArrayLike<Node> | Node
 ): string {
   const options = { ...this._options, xmlMode: true };
@@ -134,7 +131,7 @@ export function xml(
  * @returns The rendered document.
  */
 export function text(
-  this: typeof Cheerio | void,
+  this: CheerioAPI | void,
   elements?: ArrayLike<Node>
 ): string {
   const elems = elements ? elements : this ? this.root() : [];
@@ -170,14 +167,14 @@ export function text(
  * @see {@link https://api.jquery.com/jQuery.parseHTML/}
  */
 export function parseHTML(
-  this: typeof Cheerio,
+  this: CheerioAPI,
   data: string,
   context?: unknown | boolean,
   keepScripts?: boolean
 ): Node[];
-export function parseHTML(this: typeof Cheerio, data?: '' | null): null;
+export function parseHTML(this: CheerioAPI, data?: '' | null): null;
 export function parseHTML(
-  this: typeof Cheerio,
+  this: CheerioAPI,
   data?: string | null,
   context?: unknown | boolean,
   keepScripts = typeof context === 'boolean' ? context : false
@@ -219,7 +216,7 @@ export function parseHTML(
  * @returns Cheerio instance wrapping the root node.
  * @alias Cheerio.root
  */
-export function root(this: typeof Cheerio): Cheerio<Document> {
+export function root(this: CheerioAPI): Cheerio<Document> {
   const fn = (this as unknown) as CheerioAPI;
   return fn(this._root);
 }

--- a/src/static.ts
+++ b/src/static.ts
@@ -217,8 +217,7 @@ export function parseHTML(
  * @alias Cheerio.root
  */
 export function root(this: CheerioAPI): Cheerio<Document> {
-  const fn = (this as unknown) as CheerioAPI;
-  return fn(this._root);
+  return this(this._root);
 }
 
 /**

--- a/src/static.ts
+++ b/src/static.ts
@@ -1,4 +1,4 @@
-import type { CheerioAPI, Cheerio } from './cheerio';
+import type { CheerioAPI, Cheerio } from '.';
 import { Node, Document } from 'domhandler';
 import {
   InternalOptions,
@@ -24,20 +24,18 @@ function render(
   dom: ArrayLike<Node> | Node | string | undefined,
   options: InternalOptions
 ): string {
-  if (!dom) {
-    if (that?._root?.children) {
-      dom = that._root.children;
-    } else {
-      return '';
-    }
-  } else if (typeof dom === 'string') {
-    dom = select(dom, that?._root ?? [], options);
-  }
+  const toRender = dom
+    ? typeof dom === 'string'
+      ? select(dom, that?._root ?? [], options)
+      : dom
+    : that?._root.children;
+
+  if (!toRender) return '';
 
   return options.xmlMode || options._useHtmlParser2
     ? // FIXME: Pull in new version of dom-serializer to fix this.
-      renderWithHtmlparser2(dom as Node[], options)
-    : renderWithParse5(dom);
+      renderWithHtmlparser2(toRender as Node[], options)
+    : renderWithParse5(toRender);
 }
 
 /**
@@ -96,7 +94,7 @@ export function html(
    * Sometimes `$.html()` is used without preloading html,
    * so fallback non-existing options to the default ones.
    */
-  options = {
+  const opts = {
     ...defaultOptions,
     ...(this ? this._options : {}),
     ...flattenOptions(options ?? {}),
@@ -105,7 +103,7 @@ export function html(
   return render(
     this || undefined,
     dom as string | Cheerio<Node> | Node | undefined,
-    options
+    opts
   );
 }
 


### PR DESCRIPTION
This removes quite a few currently necessary hacks.

__BREAKING CHANGES__

Low potential for breakages:
- Removed the internal `_originalRoot` property. Some methods, such as `appendTo`, can now have their roots overwritten by passing the `root` property to `CheerioAPI`.
- The `default` export now has a surrounding `Document`, without any contents.