### PR TITLE
refactor(traversing): Bump cheerio-select, adopt changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "1.0.0-rc.9",
       "license": "MIT",
       "dependencies": {
-        "cheerio-select": "^1.4.0",
+        "cheerio-select": "^1.5.0",
         "dom-serializer": "^1.3.2",
         "domhandler": "^4.2.0",
         "htmlparser2": "^6.1.0",
@@ -2185,15 +2185,15 @@
       }
     },
     "node_modules/cheerio-select": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.4.0.tgz",
-      "integrity": "sha512-sobR3Yqz27L553Qa7cK6rtJlMDbiKPdNywtR95Sj/YgfpLfy0u6CGJuaBKe5YE/vTc23SCRKxWSdlon/w6I/Ew==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.5.0.tgz",
+      "integrity": "sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==",
       "dependencies": {
-        "css-select": "^4.1.2",
-        "css-what": "^5.0.0",
+        "css-select": "^4.1.3",
+        "css-what": "^5.0.1",
         "domelementtype": "^2.2.0",
         "domhandler": "^4.2.0",
-        "domutils": "^2.6.0"
+        "domutils": "^2.7.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
@@ -2396,9 +2396,9 @@
       }
     },
     "node_modules/css-select": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.2.tgz",
-      "integrity": "sha512-nu5ye2Hg/4ISq4XqdLY2bEatAcLIdt3OYGFc9Tm9n7VSlFBcfRv0gBNksHRgSdUDQGtN3XrZ94ztW+NfzkFSUw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
+      "integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-what": "^5.0.0",
@@ -2411,9 +2411,9 @@
       }
     },
     "node_modules/css-what": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.0.tgz",
-      "integrity": "sha512-qxyKHQvgKwzwDWC/rGbT821eJalfupxYW2qbSJSAtdSTimsr/MlaGONoNLllaUPZWf8QnbcKM/kPVYUQuEKAFA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+      "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
       "engines": {
         "node": ">= 6"
       },
@@ -2629,9 +2629,9 @@
       }
     },
     "node_modules/domutils": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
-      "integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+      "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
       "dependencies": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
@@ -9682,15 +9682,15 @@
       "dev": true
     },
     "cheerio-select": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.4.0.tgz",
-      "integrity": "sha512-sobR3Yqz27L553Qa7cK6rtJlMDbiKPdNywtR95Sj/YgfpLfy0u6CGJuaBKe5YE/vTc23SCRKxWSdlon/w6I/Ew==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.5.0.tgz",
+      "integrity": "sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==",
       "requires": {
-        "css-select": "^4.1.2",
-        "css-what": "^5.0.0",
+        "css-select": "^4.1.3",
+        "css-what": "^5.0.1",
         "domelementtype": "^2.2.0",
         "domhandler": "^4.2.0",
-        "domutils": "^2.6.0"
+        "domutils": "^2.7.0"
       }
     },
     "ci-info": {
@@ -9853,9 +9853,9 @@
       }
     },
     "css-select": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.2.tgz",
-      "integrity": "sha512-nu5ye2Hg/4ISq4XqdLY2bEatAcLIdt3OYGFc9Tm9n7VSlFBcfRv0gBNksHRgSdUDQGtN3XrZ94ztW+NfzkFSUw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
+      "integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
       "requires": {
         "boolbase": "^1.0.0",
         "css-what": "^5.0.0",
@@ -9865,9 +9865,9 @@
       }
     },
     "css-what": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.0.tgz",
-      "integrity": "sha512-qxyKHQvgKwzwDWC/rGbT821eJalfupxYW2qbSJSAtdSTimsr/MlaGONoNLllaUPZWf8QnbcKM/kPVYUQuEKAFA=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+      "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg=="
     },
     "cssom": {
       "version": "0.4.4",
@@ -10025,9 +10025,9 @@
       }
     },
     "domutils": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
-      "integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+      "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
       "requires": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node": ">= 6"
   },
   "dependencies": {
-    "cheerio-select": "^1.4.0",
+    "cheerio-select": "^1.5.0",
     "dom-serializer": "^1.3.2",
     "domhandler": "^4.2.0",
     "htmlparser2": "^6.1.0",

--- a/src/cheerio.ts
+++ b/src/cheerio.ts
@@ -22,8 +22,7 @@ export class Cheerio<T> implements ArrayLike<T> {
 
   options: InternalOptions;
   /**
-   * The root of the document. Can be overwritten by using the `root` argument
-   * of the constructor.
+   * The root of the document. Can be set by using the `root` argument of the constructor.
    *
    * @private
    */


### PR DESCRIPTION
Querying can now be sped up in some cases by supplying the `root` of the document. Also, `filter` now accepts any node and no longer needs a `isTag` check.