### PR TITLE
fix(manipulation): `.html` should move passed nodes

### DIFF
--- a/src/api/manipulation.spec.ts
+++ b/src/api/manipulation.spec.ts
@@ -1770,6 +1770,13 @@ describe('$(...)', () => {
       expect(html).toBe('<li class="durian">Durian</li>');
     });
 
+    it('(elem) : should move the passed element (#940)', () => {
+      $('.apple').html($('.orange'));
+      expect($fruits.html()).toBe(
+        '<li class="apple"><li class="orange">Orange</li></li><li class="pear">Pear</li>'
+      );
+    });
+
     it('() : should allow element reinsertion', () => {
       const $children = $fruits.children();
 

--- a/src/api/manipulation.ts
+++ b/src/api/manipulation.ts
@@ -939,7 +939,7 @@ export function html<T extends Node>(
     opts.context = el;
 
     const content = isCheerio(str)
-      ? str.clone().get()
+      ? str.toArray()
       : parse(`${str}`, opts, false).children;
 
     updateDOM(content, el);


### PR DESCRIPTION
Fixes #940.