### PR TITLE
fix(manipulation): Have `text` turn passed values to strings

### DIFF
--- a/src/api/manipulation.spec.ts
+++ b/src/api/manipulation.spec.ts
@@ -1901,6 +1901,11 @@ describe('$(...)', () => {
       expect(text).toBe('M&M');
     });
 
+    it('should turn passed values to strings', () => {
+      $('.apple').text(1 as any);
+      expect($('.apple')[0].childNodes[0]).toHaveProperty('data', '1');
+    });
+
     it('( undefined ) : should act as an accessor', () => {
       const $div = $('<div>test</div>');
       expect(typeof $div.text(undefined as any)).toBe('string');

--- a/src/api/manipulation.ts
+++ b/src/api/manipulation.ts
@@ -1004,7 +1004,7 @@ export function text<T extends Node>(
       child.next = child.prev = child.parent = null;
     });
 
-    const textNode = new Text(str);
+    const textNode = new Text(`${str}`);
 
     updateDOM(textNode, el);
   });


### PR DESCRIPTION
Fixes #2026