### PR TITLE
Correct a typo in line 221 of Readme.md (begin line with "$", not "ch…

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -218,7 +218,7 @@ $.root().html();
 If you want to render the [`outerHTML`](https://developer.mozilla.org/en-US/docs/Web/API/Element/outerHTML) of a selection, you can use the `html` utility functon:
 
 ```js
-cheerio.html($('.pear'));
+$.html($('.pear'));
 //=> <li class="pear">Pear</li>
 ```
 


### PR DESCRIPTION
…eerio")

Lead to a TypeError before:

```
const $ = cheerio.load(`.......`);
console.log(cheerio.html($('......')));

TypeError: cheerio.html is not a function
```