### PR TITLE
Cheerio breaks some symbols

### DIFF
--- a/src/__tests__/xml.spec.ts
+++ b/src/__tests__/xml.spec.ts
@@ -61,5 +61,17 @@ describe('render', () => {
         '<someelem someattribute="something">hello</someelem>'
       );
     });
+
+    it('reproduce broken case with symbol', () => {
+      const str =
+        '<div id="special-characters-test">저는 7년 동안 한국에서 살았어요</div>';
+      const buffered = Buffer.from(str).toString('binary');
+      const $ = cheerio.load(buffered);
+      const out = Buffer.from($.html(), 'binary').toString('utf-8');
+
+      expect(out).toBe(
+        '<html><head></head><body><div id="special-characters-test">저는 7년 동안 한국에서 살았어요</div></body></html>'
+      );
+    });
   });
 });


### PR DESCRIPTION
We have upgraded our module from cheerio `0.22` to `v1.0.0-rc.10` and faced with the issue where cheerio breaks some symbols.

We are converting our html to the binary and then pass html to the cheerio. After this we are converting html back.
It was working fine in 0.22, but doesn't work now in latest RC.

I've created a reproduced in this PR. 

@fb55 do you have any ideas why it started to happen?