### PR TITLE
fix(text): Include script and style contents

### DIFF
--- a/src/__tests__/deprecated.spec.ts
+++ b/src/__tests__/deprecated.spec.ts
@@ -340,9 +340,9 @@ describe('deprecated APIs', () => {
         );
       });
 
-      it('(cheerio object) : should omit script tags', () => {
+      it('(cheerio object) : should not omit script tags', () => {
         const $ = cheerio.load('<script>console.log("test")</script>');
-        expect($.text()).toBe('');
+        expect($.text()).toBe('console.log("test")');
       });
 
       it('(cheerio object) : should omit style tags', () => {

--- a/src/__tests__/deprecated.spec.ts
+++ b/src/__tests__/deprecated.spec.ts
@@ -347,18 +347,9 @@ describe('deprecated APIs', () => {
 
       it('(cheerio object) : should omit style tags', () => {
         const $ = cheerio.load(
-          '<style type="text/css">.cf-hidden { display: none; } .cf-invisible { visibility: hidden; }</style>'
+          '<style type="text/css">.cf-hidden { display: none; }</style>'
         );
-        expect($.text()).toBe('');
-      });
-
-      it('(cheerio object) : should include text contents of children omitting style and script tags', () => {
-        const $ = cheerio.load(
-          '<body>Welcome <div>Hello, testing text function,<script>console.log("hello")</script></div><style type="text/css">.cf-hidden { display: none; }</style>End of messege</body>'
-        );
-        expect($.text()).toBe(
-          'Welcome Hello, testing text function,End of messege'
-        );
+        expect($.text()).toBe('.cf-hidden { display: none; }');
       });
     });
   });

--- a/src/api/attributes.spec.ts
+++ b/src/api/attributes.spec.ts
@@ -305,12 +305,36 @@ describe('$(...)', () => {
       expect($(script).prop('textContent')).toBe('A  var foo = "bar";B');
     });
 
+    it('("textContent") : should include style and script tags', () => {
+      const $ = cheerio.load(
+        '<body>Welcome <div>Hello, testing text function,<script>console.log("hello")</script></div><style type="text/css">.cf-hidden { display: none; }</style>End of message</body>'
+      );
+      expect($('body').prop('textContent')).toBe(
+        'Welcome Hello, testing text function,console.log("hello").cf-hidden { display: none; }End of message'
+      );
+      expect($('style').prop('textContent')).toBe(
+        '.cf-hidden { display: none; }'
+      );
+      expect($('script').prop('textContent')).toBe('console.log("hello")');
+    });
+
     it('("innerText") : should render properly', () => {
       expect(selectMenu.children().prop('innerText')).toBe(
         'Option not selected'
       );
 
       expect($(script).prop('innerText')).toBe('AB');
+    });
+
+    it('("innerText") : should omit style and script tags', () => {
+      const $ = cheerio.load(
+        '<body>Welcome <div>Hello, testing text function,<script>console.log("hello")</script></div><style type="text/css">.cf-hidden { display: none; }</style>End of message</body>'
+      );
+      expect($('body').prop('innerText')).toBe(
+        'Welcome Hello, testing text function,End of message'
+      );
+      expect($('style').prop('innerText')).toBe('');
+      expect($('script').prop('innerText')).toBe('');
     });
 
     it('(inherited properties) : prop should support inherited properties', () => {

--- a/src/static.spec.ts
+++ b/src/static.spec.ts
@@ -77,25 +77,16 @@ describe('cheerio', () => {
       );
     });
 
-    it('(cheerio object) : should omit script tags', () => {
+    it('(cheerio object) : should not omit script tags', () => {
       const $ = cheerio.load('<script>console.log("test")</script>');
-      expect(cheerio.text($.root())).toBe('');
+      expect(cheerio.text($.root())).toBe('console.log("test")');
     });
 
     it('(cheerio object) : should omit style tags', () => {
       const $ = cheerio.load(
-        '<style type="text/css">.cf-hidden { display: none; } .cf-invisible { visibility: hidden; }</style>'
+        '<style type="text/css">.cf-hidden { display: none; }</style>'
       );
-      expect($.text()).toBe('');
-    });
-
-    it('(cheerio object) : should include text contents of children omitting style and script tags', () => {
-      const $ = cheerio.load(
-        '<body>Welcome <div>Hello, testing text function,<script>console.log("hello")</script></div><style type="text/css">.cf-hidden { display: none; }</style>End of messege</body>'
-      );
-      expect(cheerio.text($.root())).toBe(
-        'Welcome Hello, testing text function,End of messege'
-      );
+      expect($.text()).toBe('.cf-hidden { display: none; }');
     });
 
     it('() : does not crash with `null` as `this` value', () => {

--- a/src/static.ts
+++ b/src/static.ts
@@ -1,13 +1,13 @@
 import type { BasicAcceptedElems } from './types.js';
 import type { CheerioAPI, Cheerio } from '.';
-import { AnyNode, Document, isText, hasChildren } from 'domhandler';
+import type { AnyNode, Document } from 'domhandler';
+import { textContent } from 'domutils';
 import {
   InternalOptions,
   CheerioOptions,
   default as defaultOptions,
   flatten as flattenOptions,
 } from './options.js';
-import { ElementType } from 'htmlparser2';
 
 /**
  * Helper function to render a DOM.
@@ -109,6 +109,10 @@ export function xml(
 /**
  * Render the document as text.
  *
+ * This returns the `textContent` of the passed elements. The result will
+ * include the contents of `script` and `stype` elements. To avoid this, use
+ * `.prop('innerText')` instead.
+ *
  * @param elements - Elements to render.
  * @returns The rendered document.
  */
@@ -121,15 +125,7 @@ export function text(
   let ret = '';
 
   for (let i = 0; i < elems.length; i++) {
-    const elem = elems[i];
-    if (isText(elem)) ret += elem.data;
-    else if (
-      hasChildren(elem) &&
-      elem.type !== ElementType.Script &&
-      elem.type !== ElementType.Style
-    ) {
-      ret += text(elem.children);
-    }
+    ret += textContent(elems[i]);
   }
 
   return ret;


### PR DESCRIPTION
Reverts #1018
Fixes #1050

To keep the current behaviour, you can use `.prop('innerText')` (added in #2214).