### PR TITLE
refactor(exports): Update exported values

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export type {
  *
  * @category DOM Node
  */
-export type { Node, NodeWithChildren, Element, Document } from 'domhandler';
+export type { Node, AnyNode, ParentNode, Element, Document } from 'domhandler';
 
 export type { CheerioAPI } from './load.js';
 import { getLoad } from './load.js';
@@ -83,7 +83,7 @@ import { filters, pseudos, aliases } from 'cheerio-select';
  */
 export const select = { filters, pseudos, aliases };
 
-export * from './static.js';
+export { html, xml, text } from './static.js';
 
 import * as staticMethods from './static.js';
 

--- a/src/slim.ts
+++ b/src/slim.ts
@@ -6,7 +6,8 @@ export type {
   CheerioOptions,
   HTMLParser2Options,
   Node,
-  NodeWithChildren,
+  AnyNode,
+  ParentNode,
   Element,
   Document,
 } from '.';


### PR DESCRIPTION
We now export `AnyNode`, as well as `ParentNode`. `NodeWithChildren` is no longer exported — please use `ParentNode` instead.

Also makes static exports explicit.