### PR TITLE
fix(package): Allow imports of `cheerio/lib/utils`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,10 @@
     "./lib/slim": {
       "require": "./lib/slim.js",
       "import": "./lib/esm/slim.js"
+    },
+    "./lib/utils": {
+      "require": "./lib/utils.js",
+      "import": "./lib/esm/utils.js"
     }
   },
   "files": [


### PR DESCRIPTION
As used by Enzyme here (and which broke after upgrading Cheerio):

https://github.com/enzymejs/enzyme/blob/master/packages/enzyme/src/Utils.js#L11

Fixes #2600