### PR TITLE
docs: remove example for removed option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -113,11 +113,7 @@ If you need to modify parsing options for XML input, you may pass an extra
 object to `.load()`:
 
 ```js
-const $ = cheerio.load('<ul id="fruits">...</ul>', {
-  xml: {
-    normalizeWhitespace: true,
-  },
-});
+const $ = cheerio.load('<ul id="fruits">...</ul>');
 ```
 
 The options in the `xml` object are taken directly from [htmlparser2](https://github.com/fb55/htmlparser2/wiki/Parser-options), therefore any options that can be used in `htmlparser2` are valid in cheerio as well. When `xml` is set, the default options are:

--- a/Readme.md
+++ b/Readme.md
@@ -113,7 +113,12 @@ If you need to modify parsing options for XML input, you may pass an extra
 object to `.load()`:
 
 ```js
-const $ = cheerio.load('<ul id="fruits">...</ul>');
+const $ = cheerio.load('<ul id="fruits">...</ul>', {
+  xml: {
+    xmlMode: true,
+    withStartIndices: true,
+  },
+});
 ```
 
 The options in the `xml` object are taken directly from [htmlparser2](https://github.com/fb55/htmlparser2/wiki/Parser-options), therefore any options that can be used in `htmlparser2` are valid in cheerio as well. When `xml` is set, the default options are:


### PR DESCRIPTION
I removed a code example about a deleted option.

The `normalizeWhitespace` property was extended from [domhandler](https://github.com/fb55/domhandler), but that package deprecated the property at [21a2f7](https://github.com/fb55/domhandler/commit/21a2f7b6a53c0c61e4c753589c5ba99e611529c9), and removed it at [6503e2](https://github.com/fb55/domhandler/commit/6503e2d22bc1896cfb9553296f761856dc68a27f) finally.

I can't find a replacement, so I just removed the property in README.md.