### PR TITLE
chore(ci): Deploy to GitHub Actions directly

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,29 +1,58 @@
-name: Deploy to GitHub Pages
-on:
-  push:
-    branches:
-      - main
+name: Deploy TypeDoc docs to GitHub Pages
 
-env:
-  FORCE_COLOR: 2
-  NODE: 16
+# Based on https://raw.githubusercontent.com/actions/starter-workflows
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: [$default-branch]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
 
 jobs:
-  deploy:
-    name: Deploy to GitHub Pages
+  # Build job
+  build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3.4.1
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3.4.1
         with:
-          node-version: '${{ env.NODE }}'
+          node-version: '16'
           cache: 'npm'
-      - run: npm ci
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v1
+      - name: Install dependencies
+        run: npm ci
       - name: Build docs
         run: npm run build:docs
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: docs
-          cname: cheerio.js.org
+          path: ./docs
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -10,6 +10,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  FORCE_COLOR: 2
+  NODE: 16
+
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
@@ -31,7 +35,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3.4.1
         with:
-          node-version: '16'
+          node-version: '${{ env.NODE }}'
           cache: 'npm'
       - name: Setup Pages
         id: pages


### PR DESCRIPTION
No need to go through a `gh-pages` branch.