### PR TITLE
fix(index): Bind static `html`, `xml`, and `text`

### DIFF
--- a/src/__tests__/deprecated.spec.ts
+++ b/src/__tests__/deprecated.spec.ts
@@ -7,20 +7,6 @@ import * as fixtures from '../__fixtures__/fixtures.js';
 import cheerio from '../index.js';
 
 describe('deprecated APIs', () => {
-  /**
-   * The `.parseHTML` method exported by the Cheerio module is deprecated.
-   *
-   * In order to promote consistency with the jQuery library, users are
-   * encouraged to instead use the static method of the same name as it is
-   * defined on the "loaded" Cheerio factory function.
-   *
-   * @example
-   *
-   * ```js
-   * const $ = cheerio.load('');
-   * $.parseHTML('<b>markup</b>');
-   * ```
-   */
   describe('cheerio module', () => {
     describe('.parseHTML', () => {
       it('(html) : should preserve content', () => {
@@ -29,21 +15,6 @@ describe('deprecated APIs', () => {
       });
     });
 
-    /**
-     * The `.merge` method exported by the Cheerio module is deprecated.
-     *
-     * In order to promote consistency with the jQuery library, users are
-     * encouraged to instead use the static method of the same name.
-     *
-     * @example
-     *
-     * ```js
-     * const $ = cheerio.load('');
-     *
-     * $.merge([1, 2], [3, 4]);
-     * //=> [1, 2, 3, 4]
-     * ```
-     */
     describe('.merge', () => {
       let arr1: ArrayLike<unknown>;
       let arr2: ArrayLike<unknown>;
@@ -139,24 +110,6 @@ describe('deprecated APIs', () => {
       });
     });
 
-    /**
-     * The `.contains` method exported by the Cheerio module is deprecated.
-     *
-     * In order to promote consistency with the jQuery library, users are
-     * encouraged to instead use the static method of the same name.
-     *
-     * @example
-     *
-     * ```js
-     * const $ = cheerio.load('<div><p></p></div>');
-     *
-     * $.contains($('div').get(0), $('p').get(0));
-     * //=> true
-     *
-     * $.contains($('p').get(0), $('div').get(0));
-     * //=> false
-     * ```
-     */
     describe('.contains', () => {
       let $: typeof cheerio;
 
@@ -186,19 +139,6 @@ describe('deprecated APIs', () => {
       });
     });
 
-    /**
-     * The `.root` method exported by the Cheerio module is deprecated.
-     *
-     * Users seeking to access the top-level element of a parsed document should
-     * instead use the `root` static method of a "loaded" Cheerio function.
-     *
-     * @example
-     *
-     * ```js
-     * const $ = cheerio.load('');
-     * $.root();
-     * ```
-     */
     describe('.root', () => {
       it('returns an empty selection', () => {
         const $empty = cheerio.root();
@@ -209,17 +149,6 @@ describe('deprecated APIs', () => {
   });
 
   describe('Cheerio function', () => {
-    /**
-     * The `.load` static method defined on the "loaded" Cheerio factory
-     * function is deprecated. Users are encouraged to instead use the `load`
-     * function exported by the Cheerio module.
-     *
-     * @example
-     *
-     * ```js
-     * const $ = cheerio.load('<h1>Hello, <span>world</span>.</h1>');
-     * ```
-     */
     it('.load', () => {
       const $1 = cheerio.load(fixtures.fruits);
       const $2 = $1.load('<div><p>Some <a>text</a>.</p></div>');

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,10 +1,28 @@
 import * as cheerio from './index.js';
 import * as statics from './static.js';
 
-describe('index', () => {
+describe('static method re-exports', () => {
   it('should export all static methods', () => {
     for (const key of Object.keys(statics) as (keyof typeof statics)[]) {
-      expect(cheerio[key]).toBe(statics[key]);
+      expect(typeof cheerio[key]).toBe(typeof statics[key]);
     }
+  });
+
+  it('should have a functional `html` that is bound to the default instance', () => {
+    expect(cheerio.html(cheerio.default('<div>test div</div>'))).toBe(
+      '<div>test div</div>'
+    );
+  });
+
+  it('should have a functional `xml` that is bound to the default instance', () => {
+    expect(cheerio.xml(cheerio.default('<div>test div</div>'))).toBe(
+      '<div>test div</div>'
+    );
+  });
+
+  it('should have a functional `text` that is bound to the default instance', () => {
+    expect(cheerio.text(cheerio.default('<div>test div</div>'))).toBe(
+      'test div'
+    );
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,22 +57,34 @@ export const load = getLoad(parse, (dom, options) =>
     : renderWithParse5(dom)
 );
 
+const defaultInstance = load([]);
+
 /**
  * The default cheerio instance.
  *
- * @deprecated Use the function returned by `load` instead.
+ * @deprecated Use the function returned by `load` instead. To access load, make
+ *   sure you are importing `* as cheerio` instead of this default export.
  */
-export default load([]);
-
-export { html, xml, text } from './static.js';
+export default defaultInstance;
 
 import * as staticMethods from './static.js';
 
+/** {@inheritdoc staticMethods.html}. */
+export const html = staticMethods.html.bind(defaultInstance);
+
+/** {@inheritdoc staticMethods.xml}. */
+export const xml = staticMethods.xml.bind(defaultInstance);
+
+/** {@inheritdoc staticMethods.text}. */
+export const text = staticMethods.text.bind(defaultInstance);
+
 /**
+ * The `.contains` method exported by the Cheerio module is deprecated.
+ *
  * In order to promote consistency with the jQuery library, users are encouraged
  * to instead use the static method of the same name.
  *
- * @deprecated
+ * @deprecated Use `contains` on the loaded instance instead.
  * @example
  *
  * ```js
@@ -90,10 +102,12 @@ import * as staticMethods from './static.js';
 export const { contains } = staticMethods;
 
 /**
+ * The `.merge` method exported by the Cheerio module is deprecated.
+ *
  * In order to promote consistency with the jQuery library, users are encouraged
  * to instead use the static method of the same name.
  *
- * @deprecated
+ * @deprecated Use `merge` on the loaded instance instead.
  * @example
  *
  * ```js
@@ -106,11 +120,13 @@ export const { contains } = staticMethods;
 export const { merge } = staticMethods;
 
 /**
+ * The `.parseHTML` method exported by the Cheerio module is deprecated.
+ *
  * In order to promote consistency with the jQuery library, users are encouraged
  * to instead use the static method of the same name as it is defined on the
  * "loaded" Cheerio factory function.
  *
- * @deprecated See {@link static/parseHTML}.
+ * @deprecated Use `parseHTML` on the loaded instance instead.
  * @example
  *
  * ```js
@@ -121,10 +137,12 @@ export const { merge } = staticMethods;
 export const { parseHTML } = staticMethods;
 
 /**
+ * The `.root` method exported by the Cheerio module is deprecated.
+ *
  * Users seeking to access the top-level element of a parsed document should
  * instead use the `root` static method of a "loaded" Cheerio function.
  *
- * @deprecated
+ * @deprecated Use `root` on the loaded instance instead.
  * @example
  *
  * ```js

--- a/src/load.ts
+++ b/src/load.ts
@@ -70,6 +70,18 @@ export interface CheerioAPI extends StaticType {
   /** Mimic jQuery's prototype alias for plugin authors. */
   fn: typeof Cheerio.prototype;
 
+  /**
+   * The `.load` static method defined on the "loaded" Cheerio factory function
+   * is deprecated. Users are encouraged to instead use the `load` function
+   * exported by the Cheerio module.
+   *
+   * @deprecated Use the `load` function exported by the Cheerio module.
+   * @example
+   *
+   * ```js
+   * const $ = cheerio.load('<h1>Hello, <span>world</span>.</h1>');
+   * ```
+   */
   load: ReturnType<typeof getLoad>;
 }
 


### PR DESCRIPTION
Fixes #2692

Also moves deprecation notes to the relevant definitions.