### PR TITLE
chore(test): Unify test structure, use `never`

### DIFF
--- a/src/__fixtures__/fixtures.ts
+++ b/src/__fixtures__/fixtures.ts
@@ -73,6 +73,14 @@ export const eleven = `
 </html>
 `;
 
+export const unwrapspans = [
+  '<div id=unwrap style="display: none;">',
+  '<div id=unwrap1><span class=unwrap>a</span><span class=unwrap>b</span></div>',
+  '<div id=unwrap2><span class=unwrap>c</span><span class=unwrap>d</span></div>',
+  '<div id=unwrap3><b><span class="unwrap unwrap3">e</span></b><b><span class="unwrap unwrap3">f</span></b></div>',
+  '</div>',
+].join('');
+
 export const inputs = [
   '<select id="one"><option value="option_not_selected">Option not selected</option><option value="option_selected" selected>Option selected</option></select>',
   '<select id="one-valueless"><option>Option not selected</option><option selected>Option selected</option></select>',

--- a/src/__tests__/deprecated.spec.ts
+++ b/src/__tests__/deprecated.spec.ts
@@ -16,52 +16,41 @@ describe('deprecated APIs', () => {
     });
 
     describe('.merge', () => {
-      let arr1: ArrayLike<unknown>;
-      let arr2: ArrayLike<unknown>;
-      beforeEach(() => {
-        arr1 = [1, 2, 3];
-        arr2 = [4, 5, 6];
-      });
-
       it('should be a function', () => {
         expect(typeof cheerio.merge).toBe('function');
       });
 
       // #1674 - merge, wont accept Cheerio object
       it('should be a able merge array and cheerio object', () => {
-        const ret = cheerio.merge(cheerio(), ['elem1', 'elem2'] as any);
+        const ret = cheerio.merge<unknown>(cheerio(), ['elem1', 'elem2']);
         expect(typeof ret).toBe('object');
         expect(ret).toHaveLength(2);
       });
 
-      it('(arraylike, arraylike) : should return an array', () => {
+      it('(arraylike, arraylike) : should modify the first array, but not the second', () => {
+        const arr1 = [1, 2, 3];
+        const arr2 = [4, 5, 6];
         const ret = cheerio.merge(arr1, arr2);
+
         expect(typeof ret).toBe('object');
         expect(Array.isArray(ret)).toBe(true);
-      });
-
-      it('(arraylike, arraylike) : should modify the first array', () => {
-        cheerio.merge(arr1, arr2);
+        expect(ret).toBe(arr1);
         expect(arr1).toHaveLength(6);
-      });
-
-      it('(arraylike, arraylike) : should not modify the second array', () => {
-        cheerio.merge(arr1, arr2);
         expect(arr2).toHaveLength(3);
       });
 
       it('(arraylike, arraylike) : should handle objects that arent arrays, but are arraylike', () => {
-        arr1 = {
+        const arr1: ArrayLike<string> = {
           length: 3,
-          [0]: 'a',
-          [1]: 'b',
-          [2]: 'c',
+          0: 'a',
+          1: 'b',
+          2: 'c',
         };
-        arr2 = {
+        const arr2 = {
           length: 3,
-          [0]: 'd',
-          [1]: 'e',
-          [2]: 'f',
+          0: 'd',
+          1: 'e',
+          2: 'f',
         };
 
         cheerio.merge(arr1, arr2);
@@ -73,30 +62,21 @@ describe('deprecated APIs', () => {
       });
 
       it('(?, ?) : should gracefully reject invalid inputs', () => {
-        let ret: ArrayLike<unknown> | undefined = cheerio.merge([4], 3 as any);
-        expect(ret).toBeFalsy();
-        ret = cheerio.merge({} as any, {} as any);
-        expect(ret).toBeFalsy();
-        ret = cheerio.merge([], {} as any);
-        expect(ret).toBeFalsy();
-        ret = cheerio.merge({} as any, []);
-        expect(ret).toBeFalsy();
-        let fakeArray1 = { length: 3, [0]: 'a', [1]: 'b', [3]: 'd' };
-        ret = cheerio.merge(fakeArray1, []);
-        expect(ret).toBeFalsy();
-        ret = cheerio.merge([], fakeArray1);
-        expect(ret).toBeFalsy();
-        fakeArray1 = {} as any;
-        fakeArray1.length = '7' as any;
-        ret = cheerio.merge(fakeArray1, []);
-        expect(ret).toBeFalsy();
-        fakeArray1.length = -1;
-        ret = cheerio.merge(fakeArray1, []);
-        expect(ret).toBeFalsy();
+        expect(cheerio.merge([4], 3 as never)).toBeUndefined();
+        expect(cheerio.merge({} as never, {} as never)).toBeUndefined();
+        expect(cheerio.merge([], {} as never)).toBeUndefined();
+        expect(cheerio.merge({} as never, [])).toBeUndefined();
+
+        const fakeArray = { length: 3, 0: 'a', 1: 'b', 3: 'd' };
+        expect(cheerio.merge(fakeArray, [])).toBeUndefined();
+        expect(cheerio.merge([], fakeArray)).toBeUndefined();
+
+        expect(cheerio.merge({ length: '7' } as never, [])).toBeUndefined();
+        expect(cheerio.merge({ length: -1 }, [])).toBeUndefined();
       });
 
       it('(?, ?) : should no-op on invalid inputs', () => {
-        const fakeArray1 = { length: 3, [0]: 'a', [1]: 'b', [3]: 'd' };
+        const fakeArray1 = { length: 3, 0: 'a', 1: 'b', 3: 'd' };
         cheerio.merge(fakeArray1, []);
         expect(fakeArray1).toHaveLength(3);
         expect(fakeArray1[0]).toBe('a');
@@ -171,6 +151,7 @@ describe('deprecated APIs', () => {
      * $('h1').html();
      * //=> '<h1>Hello, <span>world</span>.'
      * ```
+     *
      * @example <caption>To render the markup of an entire document, invoke the
      * `html` function exported by the Cheerio module with a "root"
      * selection.</caption>
@@ -228,6 +209,7 @@ describe('deprecated APIs', () => {
      * $('h1').text();
      * //=> 'Hello, world.'
      * ```
+     *
      * @example <caption>To render the text content of an entire document,
      * invoke the `text` function exported by the Cheerio module with a "root"
      * selection. </caption>

--- a/src/api/attributes.spec.ts
+++ b/src/api/attributes.spec.ts
@@ -1,5 +1,4 @@
-import cheerio from '../index.js';
-import type { Cheerio } from '../cheerio.js';
+import cheerio, { load, type CheerioAPI, type Cheerio } from '../index.js';
 import type { Element } from 'domhandler';
 import {
   script,
@@ -16,13 +15,13 @@ function withClass(attr: string) {
 }
 
 describe('$(...)', () => {
-  let $: typeof cheerio;
-
-  beforeEach(() => {
-    $ = cheerio.load(fruits);
-  });
-
   describe('.attr', () => {
+    let $: CheerioAPI;
+
+    beforeEach(() => {
+      $ = load(fruits);
+    });
+
     it('() : should get all the attributes', () => {
       const attrs = $('ul').attr();
       expect(attrs).toHaveProperty('id', 'fruits');
@@ -85,7 +84,7 @@ describe('$(...)', () => {
             id: 'apple',
             style: 'color:red;',
             'data-url': 'http://apple.com',
-          } as any,
+          } as never,
           () => ''
         )
       ).toThrow('Bad combination of arguments.');
@@ -128,7 +127,7 @@ describe('$(...)', () => {
 
     it('(key, value) : should coerce values to a string', () => {
       const $apple = $('.apple');
-      $apple.attr('data-test', 1 as any);
+      $apple.attr('data-test', 1 as never);
       expect($apple[0].attribs['data-test']).toBe('1');
       expect($apple.attr('data-test')).toBe('1');
     });
@@ -196,12 +195,11 @@ describe('$(...)', () => {
   });
 
   describe('.prop', () => {
+    let $: CheerioAPI;
     let checkbox: Cheerio<Element>;
-    let selectMenu: Cheerio<Element>;
 
     beforeEach(() => {
-      $ = cheerio.load(inputs);
-      selectMenu = $('select');
+      $ = load(inputs);
       checkbox = $('input[name=checkbox_on]');
     });
 
@@ -224,8 +222,8 @@ describe('$(...)', () => {
 
     it('(invalid key) : invalid prop should get undefined', () => {
       expect(checkbox.prop('lol')).toBeUndefined();
-      expect(checkbox.prop(4 as any)).toBeUndefined();
-      expect(checkbox.prop(true as any)).toBeUndefined();
+      expect(checkbox.prop(4 as never)).toBeUndefined();
+      expect(checkbox.prop(true as never)).toBeUndefined();
     });
 
     it('(key, value) : should set prop', () => {
@@ -278,7 +276,7 @@ describe('$(...)', () => {
           {
             id: 'check',
             checked: false,
-          } as any,
+          } as never,
           () => ''
         )
       ).toThrow('Bad combination of arguments.');
@@ -299,11 +297,11 @@ describe('$(...)', () => {
 
     it('(invalid element/tag) : prop should return undefined', () => {
       expect($(undefined).prop('prop')).toBeUndefined();
-      expect($(null as any).prop('prop')).toBeUndefined();
+      expect($(null as never).prop('prop')).toBeUndefined();
     });
 
     it('("href") : should resolve links with `baseURI`', () => {
-      const $ = cheerio.load(
+      const $ = load(
         `
           <a id="1" href="http://example.org">example1</a>
           <a id="2" href="//example.org">example2</a>
@@ -322,7 +320,7 @@ describe('$(...)', () => {
     });
 
     it('("src") : should resolve links with `baseURI`', () => {
-      const $ = cheerio.load(
+      const $ = load(
         `
           <img id="1" src="http://example.org/image.png">
           <iframe id="2" src="//example.org/page.html"></iframe>
@@ -362,7 +360,7 @@ describe('$(...)', () => {
     });
 
     it('("textContent") : should render properly', () => {
-      expect(selectMenu.children().prop('textContent')).toBe(
+      expect($('select').children().prop('textContent')).toBe(
         'Option not selected'
       );
 
@@ -372,7 +370,7 @@ describe('$(...)', () => {
     });
 
     it('("textContent") : should include style and script tags', () => {
-      const $ = cheerio.load(
+      const $ = load(
         '<body>Welcome <div>Hello, testing text function,<script>console.log("hello")</script></div><style type="text/css">.cf-hidden { display: none; }</style>End of message</body>'
       );
       expect($('body').prop('textContent')).toBe(
@@ -385,7 +383,7 @@ describe('$(...)', () => {
     });
 
     it('("innerText") : should render properly', () => {
-      expect(selectMenu.children().prop('innerText')).toBe(
+      expect($('select').children().prop('innerText')).toBe(
         'Option not selected'
       );
 
@@ -395,7 +393,7 @@ describe('$(...)', () => {
     });
 
     it('("innerText") : should omit style and script tags', () => {
-      const $ = cheerio.load(
+      const $ = load(
         '<body>Welcome <div>Hello, testing text function,<script>console.log("hello")</script></div><style type="text/css">.cf-hidden { display: none; }</style>End of message</body>'
       );
       expect($('body').prop('innerText')).toBe(
@@ -406,11 +404,11 @@ describe('$(...)', () => {
     });
 
     it('(inherited properties) : prop should support inherited properties', () => {
-      expect(selectMenu.prop('childNodes')).toBe(selectMenu[0].childNodes);
+      expect($('select').prop('childNodes')).toBe($('select')[0].childNodes);
     });
 
     it('(key) : should skip text nodes', () => {
-      const $text = cheerio.load(mixedText);
+      const $text = load(mixedText);
       const $body = $text($text('body')[0].children);
 
       expect($text($body[1]).prop('tagName')).toBeUndefined();
@@ -432,8 +430,10 @@ describe('$(...)', () => {
   });
 
   describe('.data', () => {
+    let $: CheerioAPI;
+
     beforeEach(() => {
-      $ = cheerio.load(chocolates);
+      $ = load(chocolates);
     });
 
     it('() : should get all data attributes initially declared in the markup', () => {
@@ -557,7 +557,7 @@ describe('$(...)', () => {
       const b = $('.linth').data('snack', 'chocoletti');
 
       expect(() => {
-        a.data(4 as any, 'throw');
+        a.data(4 as never, 'throw');
       }).not.toThrow();
       expect(a.data('balls')).toStrictEqual('giandor');
       expect(b.data('snack')).toStrictEqual('chocoletti');
@@ -577,12 +577,12 @@ describe('$(...)', () => {
         flop: 'Pippilotti Rist',
         top: 'Frigor',
         url: 'http://www.cailler.ch/',
-      })['0' as any] as any;
+      })[0] as never;
 
-      expect(data.id).toBe('Cailler');
-      expect(data.flop).toBe('Pippilotti Rist');
-      expect(data.top).toBe('Frigor');
-      expect(data.url).toBe('http://www.cailler.ch/');
+      expect(data).toHaveProperty('id', 'Cailler');
+      expect(data).toHaveProperty('flop', 'Pippilotti Rist');
+      expect(data).toHaveProperty('top', 'Frigor');
+      expect(data).toHaveProperty('url', 'http://www.cailler.ch/');
     });
 
     describe('(attr) : data-* attribute type coercion :', () => {
@@ -618,7 +618,7 @@ describe('$(...)', () => {
     });
 
     it('(key, value) : should skip text nodes', () => {
-      const $text = cheerio.load(mixedText);
+      const $text = load(mixedText);
       const $body = $text($text('body')[0].children);
 
       $body.data('snack', 'chocoletti');
@@ -628,8 +628,10 @@ describe('$(...)', () => {
   });
 
   describe('.val', () => {
+    let $: CheerioAPI;
+
     beforeEach(() => {
-      $ = cheerio.load(inputs);
+      $ = load(inputs);
     });
 
     it('(): on div should get undefined', () => {
@@ -727,6 +729,12 @@ describe('$(...)', () => {
   });
 
   describe('.removeAttr', () => {
+    let $: CheerioAPI;
+
+    beforeEach(() => {
+      $ = load(fruits);
+    });
+
     it('(key) : should remove a single attr', () => {
       const $fruits = $('#fruits');
       expect($fruits.attr('id')).not.toBeUndefined();
@@ -754,7 +762,7 @@ describe('$(...)', () => {
     });
 
     it('(key) : should skip text nodes', () => {
-      const $text = cheerio.load(mixedText);
+      const $text = load(mixedText);
       const $body = $text($text('body')[0].children);
 
       $body.addClass(() => 'test');
@@ -770,6 +778,12 @@ describe('$(...)', () => {
   });
 
   describe('.hasClass', () => {
+    let $: CheerioAPI;
+
+    beforeEach(() => {
+      $ = load(fruits);
+    });
+
     it('(valid class) : should return true', () => {
       const cls = $('.apple').hasClass('apple');
       expect(cls).toBe(true);
@@ -807,6 +821,12 @@ describe('$(...)', () => {
   });
 
   describe('.addClass', () => {
+    let $: CheerioAPI;
+
+    beforeEach(() => {
+      $ = load(fruits);
+    });
+
     it('(first class) : should add the class to the element', () => {
       const $fruits = $('#fruits');
       $fruits.addClass('fruits');
@@ -877,6 +897,12 @@ describe('$(...)', () => {
   });
 
   describe('.removeClass', () => {
+    let $: CheerioAPI;
+
+    beforeEach(() => {
+      $ = load(fruits);
+    });
+
     it('() : should remove all the classes', () => {
       $('.pear').addClass('fruit');
       $('.pear').removeClass();
@@ -989,7 +1015,7 @@ describe('$(...)', () => {
     });
 
     it('(fn) : should skip text nodes', () => {
-      const $text = cheerio.load(mixedText);
+      const $text = load(mixedText);
       const $body = $text($text('body')[0].children);
 
       $body.addClass(() => 'test');
@@ -1007,6 +1033,12 @@ describe('$(...)', () => {
   });
 
   describe('.toggleClass', () => {
+    let $: CheerioAPI;
+
+    beforeEach(() => {
+      $ = load(fruits);
+    });
+
     it('(class class) : should toggle multiple classes from the element', () => {
       $('.apple').addClass('fruit');
       expect($('.apple').hasClass('apple')).toBe(true);
@@ -1061,7 +1093,7 @@ describe('$(...)', () => {
     });
 
     it('(fn) : should toggle classes returned from the function', () => {
-      $ = cheerio.load(food);
+      const $ = load(food);
 
       $('.apple').addClass('fruit');
       $('.carrot').addClass('vegetable');
@@ -1088,7 +1120,7 @@ describe('$(...)', () => {
     });
 
     it('(fn) : should work with no initial class attribute', () => {
-      const $inputs = cheerio.load(inputs);
+      const $inputs = load(inputs);
       $inputs('input, select').toggleClass(function () {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- `get` should never return undefined here.
         return $inputs(this).get(0)!.tagName === 'select'
@@ -1100,7 +1132,7 @@ describe('$(...)', () => {
     });
 
     it('(fn) : should skip text nodes', () => {
-      const $text = cheerio.load(mixedText);
+      const $text = load(mixedText);
       const $body = $text($text('body')[0].children);
 
       $body.toggleClass(() => 'test');
@@ -1120,24 +1152,12 @@ describe('$(...)', () => {
       const original = $('.apple');
       const testAgainst = original.attr('class');
       expect(original.toggleClass().attr('class')).toStrictEqual(testAgainst);
-      expect(original.toggleClass(true as any).attr('class')).toStrictEqual(
-        testAgainst
-      );
-      expect(original.toggleClass(false as any).attr('class')).toStrictEqual(
-        testAgainst
-      );
-      expect(original.toggleClass(null as any).attr('class')).toStrictEqual(
-        testAgainst
-      );
-      expect(original.toggleClass(0 as any).attr('class')).toStrictEqual(
-        testAgainst
-      );
-      expect(original.toggleClass(1 as any).attr('class')).toStrictEqual(
-        testAgainst
-      );
-      expect(original.toggleClass({} as any).attr('class')).toStrictEqual(
-        testAgainst
-      );
+
+      for (const value of [undefined, true, false, null, 0, 1, {}]) {
+        expect(
+          original.toggleClass(value as never).attr('class')
+        ).toStrictEqual(testAgainst);
+      }
     });
   });
 });

--- a/src/api/css.spec.ts
+++ b/src/api/css.spec.ts
@@ -1,5 +1,4 @@
-import cheerio from '../index.js';
-import type { Cheerio } from '../cheerio.js';
+import cheerio, { load, type Cheerio } from '../index.js';
 import type { Element } from 'domhandler';
 import { mixedText } from '../__fixtures__/fixtures.js';
 
@@ -28,7 +27,7 @@ describe('$(...)', () => {
     });
 
     it('(prop, val) : should skip text nodes', () => {
-      const $text = cheerio.load(mixedText);
+      const $text = load(mixedText);
       const $body = $text($text('body')[0].children);
 
       $body.css('test', 'value');
@@ -46,7 +45,7 @@ describe('$(...)', () => {
 
     it('(any, val): should ignore unsupported prop types', () => {
       const el = cheerio('<li style="padding: 1px;">');
-      el.css(123 as any, 'test');
+      el.css(123 as never, 'test');
       expect(el.attr('style')).toBe('padding: 1px;');
     });
 
@@ -70,7 +69,7 @@ describe('$(...)', () => {
     });
 
     it('(prop): should return undefined for unmatched elements', () => {
-      const $ = cheerio.load('<li style="color:;position:absolute;">');
+      const $ = load('<li style="color:;position:absolute;">');
       expect($('ul').css('background-image')).toBeUndefined();
     });
 
@@ -82,9 +81,10 @@ describe('$(...)', () => {
     describe('(prop, function):', () => {
       let $el: Cheerio<Element>;
       beforeEach(() => {
-        $el = cheerio(
+        const $ = load(
           '<div style="margin: 0px;"></div><div style="margin: 1px;"></div><div style="margin: 2px;">'
-        ) as Cheerio<Element>;
+        );
+        $el = $('div');
       });
 
       it('should iterate over the selection', () => {
@@ -110,7 +110,7 @@ describe('$(...)', () => {
 
     it('(obj): should set each key and val', () => {
       const el = cheerio('<li style="padding: 0;"></li><li></li>');
-      el.css({ foo: 0 } as any);
+      el.css({ foo: 0 } as never);
       expect(el.eq(0).attr('style')).toBe('padding: 0; foo: 0;');
       expect(el.eq(1).attr('style')).toBe('foo: 0;');
     });

--- a/src/api/forms.spec.ts
+++ b/src/api/forms.spec.ts
@@ -1,5 +1,4 @@
-import cheerio from '../../src';
-import type { CheerioAPI } from '../load.js';
+import cheerio, { type CheerioAPI } from '../index.js';
 import { forms } from '../__fixtures__/fixtures.js';
 
 describe('$(...)', () => {

--- a/src/api/manipulation.spec.ts
+++ b/src/api/manipulation.spec.ts
@@ -1,6 +1,10 @@
-import { load } from '../../src';
-import type { CheerioAPI, Cheerio } from '../index.js';
-import { fruits, divcontainers, mixedText } from '../__fixtures__/fixtures.js';
+import { load, type CheerioAPI, type Cheerio } from '../index.js';
+import {
+  fruits,
+  divcontainers,
+  mixedText,
+  unwrapspans,
+} from '../__fixtures__/fixtures.js';
 import type { AnyNode, Element } from 'domhandler';
 
 describe('$(...)', () => {
@@ -342,13 +346,6 @@ describe('$(...)', () => {
 
   describe('.unwrap', () => {
     let $elem: CheerioAPI;
-    const unwrapspans = [
-      '<div id=unwrap style="display: none;">',
-      '<div id=unwrap1><span class=unwrap>a</span><span class=unwrap>b</span></div>',
-      '<div id=unwrap2><span class=unwrap>c</span><span class=unwrap>d</span></div>',
-      '<div id=unwrap3><b><span class="unwrap unwrap3">e</span></b><b><span class="unwrap unwrap3">f</span></b></div>',
-      '</div>',
-    ].join('');
 
     beforeEach(() => {
       $elem = load(unwrapspans);
@@ -542,7 +539,7 @@ describe('$(...)', () => {
     });
 
     it('(null) :  should do nothing', () => {
-      $fruits.append(null as any);
+      $fruits.append(null as never);
       expect($fruits.children()).toHaveLength(3);
     });
 
@@ -638,7 +635,7 @@ describe('$(...)', () => {
     });
 
     it('(fn) : should invoke the callback with the correct arguments and context', () => {
-      $fruits = $fruits.children();
+      const $fruits = $('#fruits').children();
       const args: [number, string][] = [];
       const thisValues: AnyNode[] = [];
 
@@ -657,7 +654,7 @@ describe('$(...)', () => {
     });
 
     it('(fn) : should add returned string as last child', () => {
-      $fruits = $fruits.children();
+      const $fruits = $('#fruits').children();
 
       $fruits.append(() => '<div class="first">');
 
@@ -671,7 +668,7 @@ describe('$(...)', () => {
     });
 
     it('(fn) : should add returned Cheerio object as last child', () => {
-      $fruits = $fruits.children();
+      const $fruits = $('#fruits').children();
 
       $fruits.append(() => $('<div class="second">'));
 
@@ -685,7 +682,7 @@ describe('$(...)', () => {
     });
 
     it('(fn) : should add returned Node as last child', () => {
-      $fruits = $fruits.children();
+      const $fruits = $('#fruits').children();
 
       $fruits.append(() => $('<div class="third">')[0]);
 
@@ -814,7 +811,7 @@ describe('$(...)', () => {
     it('(fn) : should invoke the callback with the correct arguments and context', () => {
       const args: [number, string][] = [];
       const thisValues: AnyNode[] = [];
-      $fruits = $fruits.children();
+      const $fruits = $('#fruits').children();
 
       $fruits.prepend(function (...myArgs) {
         args.push(myArgs);
@@ -831,7 +828,7 @@ describe('$(...)', () => {
     });
 
     it('(fn) : should add returned string as first child', () => {
-      $fruits = $fruits.children();
+      const $fruits = $('#fruits').children();
 
       $fruits.prepend(() => '<div class="first">');
 
@@ -845,7 +842,7 @@ describe('$(...)', () => {
     });
 
     it('(fn) : should add returned Cheerio object as first child', () => {
-      $fruits = $fruits.children();
+      const $fruits = $('#fruits').children();
 
       $fruits.prepend(() => $('<div class="second">'));
 
@@ -859,7 +856,7 @@ describe('$(...)', () => {
     });
 
     it('(fn) : should add returned Node as first child', () => {
-      $fruits = $fruits.children();
+      const $fruits = $('#fruits').children();
 
       $fruits.prepend(() => $('<div class="third">')[0]);
 
@@ -1022,7 +1019,7 @@ describe('$(...)', () => {
     it('(fn) : should invoke the callback with the correct arguments and context', () => {
       const args: [number, string][] = [];
       const thisValues: AnyNode[] = [];
-      $fruits = $fruits.children();
+      const $fruits = $('#fruits').children();
 
       $fruits.after(function (...myArgs) {
         args.push(myArgs);
@@ -1039,7 +1036,7 @@ describe('$(...)', () => {
     });
 
     it('(fn) : should add returned string as next sibling', () => {
-      $fruits = $fruits.children();
+      const $fruits = $('#fruits').children();
 
       $fruits.after(() => '<li class="first">');
 
@@ -1049,7 +1046,7 @@ describe('$(...)', () => {
     });
 
     it('(fn) : should add returned Cheerio object as next sibling', () => {
-      $fruits = $fruits.children();
+      const $fruits = $('#fruits').children();
 
       $fruits.after(() => $('<li class="second">'));
 
@@ -1059,7 +1056,7 @@ describe('$(...)', () => {
     });
 
     it('(fn) : should add returned element as next sibling', () => {
-      $fruits = $fruits.children();
+      const $fruits = $('#fruits').children();
 
       $fruits.after(() => $('<li class="third">')[0]);
 
@@ -1305,7 +1302,7 @@ describe('$(...)', () => {
     it('(fn) : should invoke the callback with the correct arguments and context', () => {
       const args: [number, string][] = [];
       const thisValues: AnyNode[] = [];
-      $fruits = $fruits.children();
+      const $fruits = $('#fruits').children();
 
       $fruits.before(function (...myArgs) {
         args.push(myArgs);
@@ -1322,7 +1319,7 @@ describe('$(...)', () => {
     });
 
     it('(fn) : should add returned string as previous sibling', () => {
-      $fruits = $fruits.children();
+      const $fruits = $('#fruits').children();
 
       $fruits.before(() => '<li class="first">');
 
@@ -1332,7 +1329,7 @@ describe('$(...)', () => {
     });
 
     it('(fn) : should add returned Cheerio object as previous sibling', () => {
-      $fruits = $fruits.children();
+      const $fruits = $('#fruits').children();
 
       $fruits.before(() => $('<li class="second">'));
 
@@ -1342,7 +1339,7 @@ describe('$(...)', () => {
     });
 
     it('(fn) : should add returned Node as previous sibling', () => {
-      $fruits = $fruits.children();
+      const $fruits = $('#fruits').children();
 
       $fruits.before(() => $('<li class="third">')[0]);
 
@@ -1729,13 +1726,11 @@ describe('$(...)', () => {
     });
 
     it('() : should get innerHTML even if its just text', () => {
-      const item = '<li class="pear">Pear</li>';
-      expect($('.pear', item).html()).toBe('Pear');
+      expect($('.pear', '<li class="pear">Pear</li>').html()).toBe('Pear');
     });
 
     it('() : should return empty string if nothing inside', () => {
-      const item = '<li></li>';
-      expect($('li', item).html()).toBe('');
+      expect($('li', '<li></li>').html()).toBe('');
     });
 
     it('(html) : should set the html for its children', () => {
@@ -1745,7 +1740,7 @@ describe('$(...)', () => {
     });
 
     it('(html) : should add new elements for each element in selection', () => {
-      $fruits = $('li');
+      const $fruits = $('li');
       $fruits.html('<li class="durian">Durian</li>');
       let tested = 0;
       $fruits.each(function () {
@@ -1902,13 +1897,13 @@ describe('$(...)', () => {
     });
 
     it('should turn passed values to strings', () => {
-      $('.apple').text(1 as any);
+      $('.apple').text(1 as never);
       expect($('.apple')[0].childNodes[0]).toHaveProperty('data', '1');
     });
 
     it('( undefined ) : should act as an accessor', () => {
       const $div = $('<div>test</div>');
-      expect(typeof $div.text(undefined as any)).toBe('string');
+      expect(typeof $div.text(undefined as never)).toBe('string');
       expect($div.text()).toBe('test');
     });
 
@@ -1920,7 +1915,7 @@ describe('$(...)', () => {
     it('( null ) : should convert to string', () => {
       expect(
         $('<div>')
-          .text(null as any)
+          .text(null as never)
           .text()
       ).toBe('null');
     });
@@ -1928,7 +1923,7 @@ describe('$(...)', () => {
     it('( 0 ) : should convert to string', () => {
       expect(
         $('<div>')
-          .text(0 as any)
+          .text(0 as never)
           .text()
       ).toBe('0');
     });

--- a/src/api/traversing.spec.ts
+++ b/src/api/traversing.spec.ts
@@ -1,6 +1,5 @@
-import cheerio from '../../src';
+import cheerio, { type CheerioAPI } from '../index.js';
 import { Cheerio } from '../cheerio.js';
-import type { CheerioAPI } from '../load.js';
 import { type AnyNode, type Element, type Text, isText } from 'domhandler';
 import {
   food,
@@ -601,27 +600,27 @@ describe('$(...)', () => {
     });
 
     it('() : should get all of the parents in logical order', () => {
-      let result = $('.orange').parents();
-      expect(result).toHaveLength(4);
-      expect(result[0].attribs).toHaveProperty('id', 'fruits');
-      expect(result[1].attribs).toHaveProperty('id', 'food');
-      expect(result[2].tagName).toBe('body');
-      expect(result[3].tagName).toBe('html');
-      result = $('#fruits').parents();
-      expect(result).toHaveLength(3);
-      expect(result[0].attribs).toHaveProperty('id', 'food');
-      expect(result[1].tagName).toBe('body');
-      expect(result[2].tagName).toBe('html');
+      const orange = $('.orange').parents();
+      expect(orange).toHaveLength(4);
+      expect(orange[0].attribs).toHaveProperty('id', 'fruits');
+      expect(orange[1].attribs).toHaveProperty('id', 'food');
+      expect(orange[2].tagName).toBe('body');
+      expect(orange[3].tagName).toBe('html');
+      const fruits = $('#fruits').parents();
+      expect(fruits).toHaveLength(3);
+      expect(fruits[0].attribs).toHaveProperty('id', 'food');
+      expect(fruits[1].tagName).toBe('body');
+      expect(fruits[2].tagName).toBe('html');
     });
 
     it('(selector) : should get all of the parents that match the selector in logical order', () => {
-      let result = $('.orange').parents('#fruits');
-      expect(result).toHaveLength(1);
-      expect(result[0].attribs).toHaveProperty('id', 'fruits');
-      result = $('.orange').parents('ul');
-      expect(result).toHaveLength(2);
-      expect(result[0].attribs).toHaveProperty('id', 'fruits');
-      expect(result[1].attribs).toHaveProperty('id', 'food');
+      const fruits = $('.orange').parents('#fruits');
+      expect(fruits).toHaveLength(1);
+      expect(fruits[0].attribs).toHaveProperty('id', 'fruits');
+      const uls = $('.orange').parents('ul');
+      expect(uls).toHaveLength(2);
+      expect(uls[0].attribs).toHaveProperty('id', 'fruits');
+      expect(uls[1].attribs).toHaveProperty('id', 'food');
     });
 
     it('() : should not break if the selector does not have any results', () => {
@@ -671,11 +670,11 @@ describe('$(...)', () => {
     });
 
     it('(selector) : should get all of the parents until selector', () => {
-      let result = $('.orange').parentsUntil('#food');
-      expect(result).toHaveLength(1);
-      expect(result[0].attribs).toHaveProperty('id', 'fruits');
-      result = $('.orange').parentsUntil('#fruits');
-      expect(result).toHaveLength(0);
+      const food = $('.orange').parentsUntil('#food');
+      expect(food).toHaveLength(1);
+      expect(food[0].attribs).toHaveProperty('id', 'fruits');
+      const fruits = $('.orange').parentsUntil('#fruits');
+      expect(fruits).toHaveLength(0);
     });
 
     it('(selector) : Less simple parentsUntil check with selector', () => {
@@ -763,12 +762,12 @@ describe('$(...)', () => {
     });
 
     it('(selector) : should filter the matched parent elements by the selector', () => {
-      let result = $('.orange').parent();
-      expect(result).toHaveLength(1);
-      expect(result[0].attribs).toHaveProperty('id', 'fruits');
-      result = $('li', food).parent('#fruits');
-      expect(result).toHaveLength(1);
-      expect(result[0].attribs).toHaveProperty('id', 'fruits');
+      const parents = $('.orange').parent();
+      expect(parents).toHaveLength(1);
+      expect(parents[0].attribs).toHaveProperty('id', 'fruits');
+      const fruits = $('li', food).parent('#fruits');
+      expect(fruits).toHaveLength(1);
+      expect(fruits[0].attribs).toHaveProperty('id', 'fruits');
     });
   });
 
@@ -781,12 +780,15 @@ describe('$(...)', () => {
 
     it('(selector) : should find the closest element that matches the selector, searching through its ancestors and itself', () => {
       expect($('.orange').closest('.apple')).toHaveLength(0);
-      let result = $('.orange', food).closest('#food') as Cheerio<Element>;
-      expect(result[0].attribs).toHaveProperty('id', 'food');
-      result = $('.orange', food).closest('ul') as Cheerio<Element>;
-      expect(result[0].attribs).toHaveProperty('id', 'fruits');
-      result = $('.orange', food).closest('li') as Cheerio<Element>;
-      expect(result[0].attribs).toHaveProperty('class', 'orange');
+      expect(
+        ($('.orange', food).closest('#food')[0] as Element).attribs
+      ).toHaveProperty('id', 'food');
+      expect(
+        ($('.orange', food).closest('ul')[0] as Element).attribs
+      ).toHaveProperty('id', 'fruits');
+      expect(
+        ($('.orange', food).closest('li')[0] as Element).attribs
+      ).toHaveProperty('class', 'orange');
     });
 
     it('(selector) : should find the closest element of each item, removing duplicates', () => {
@@ -1273,8 +1275,6 @@ describe('$(...)', () => {
     let $apple: Cheerio<Element>;
     let $orange: Cheerio<Element>;
     let $pear: Cheerio<Element>;
-    let $carrot: Cheerio<Element>;
-    let $sweetcorn: Cheerio<Element>;
 
     beforeEach(() => {
       $ = cheerio.load(food);
@@ -1282,8 +1282,6 @@ describe('$(...)', () => {
       $apple = $('.apple');
       $orange = $('.orange');
       $pear = $('.pear');
-      $carrot = $('.carrot');
-      $sweetcorn = $('.sweetcorn');
     });
 
     describe('(selector) matched element :', () => {
@@ -1369,8 +1367,8 @@ describe('$(...)', () => {
         const $selection = $fruits.add('li', '#vegetables');
         expect($selection).toHaveLength(3);
         expect($selection[0]).toBe($fruits[0]);
-        expect($selection[1]).toBe($carrot[0]);
-        expect($selection[2]).toBe($sweetcorn[0]);
+        expect($selection[1]).toBe($('.carrot')[0]);
+        expect($selection[2]).toBe($('.sweetcorn')[0]);
       });
     });
 

--- a/src/cheerio.spec.ts
+++ b/src/cheerio.spec.ts
@@ -1,10 +1,8 @@
 import { parseDOM } from 'htmlparser2';
-import cheerio from './index.js';
+import cheerio, { type Cheerio } from './index.js';
 import * as utils from './utils.js';
 import { fruits, food, noscript } from './__fixtures__/fixtures.js';
-import type { Cheerio } from './cheerio.js';
 import type { Element } from 'domhandler';
-import type { CheerioOptions } from './options.js';
 
 declare module './index.js' {
   interface Cheerio<T> {
@@ -32,7 +30,7 @@ function testAppleSelect($apple: ArrayLike<Element>) {
 
 describe('cheerio', () => {
   it('cheerio(null) should be empty', () => {
-    expect(cheerio(null as any)).toHaveLength(0);
+    expect(cheerio(null as never)).toHaveLength(0);
   });
 
   it('cheerio(undefined) should be empty', () => {
@@ -189,20 +187,16 @@ describe('cheerio', () => {
   });
 
   it('should be able to select immediate children: cheerio(".apple + .pear")', () => {
-    let $elem = cheerio('.apple + li', fruits);
-    expect($elem).toHaveLength(1);
-    $elem = cheerio('.apple + .pear', fruits);
-    expect($elem).toHaveLength(0);
-    $elem = cheerio('.apple + .orange', fruits);
+    expect(cheerio('.apple + li', fruits)).toHaveLength(1);
+    expect(cheerio('.apple + .pear', fruits)).toHaveLength(0);
+    const $elem = cheerio('.apple + .orange', fruits);
     expect($elem).toHaveLength(1);
     expect($elem.attr('class')).toBe('orange');
   });
 
   it('should be able to select immediate children: cheerio(".apple ~ .pear")', () => {
-    let $elem = cheerio('.apple ~ li', fruits);
-    expect($elem).toHaveLength(2);
-    $elem = cheerio('.apple ~ .pear', fruits);
-    expect($elem.attr('class')).toBe('pear');
+    expect(cheerio('.apple ~ li', fruits)).toHaveLength(2);
+    expect(cheerio('.apple ~ .pear', fruits).attr('class')).toBe('pear');
   });
 
   it('should handle wildcards on attributes: cheerio("li[class*=r]")', () => {
@@ -241,20 +235,18 @@ describe('cheerio', () => {
   });
 
   it('cheerio.html(null) should return a "" string', () => {
-    expect(cheerio.html(null as any)).toBe('');
+    expect(cheerio.html(null as never)).toBe('');
   });
 
   it('should set html(number) as a string', () => {
     const $elem = cheerio('<div>');
-    // @ts-expect-error Passing a number
-    $elem.html(123);
+    $elem.html(123 as never);
     expect(typeof $elem.text()).toBe('string');
   });
 
   it('should set text(number) as a string', () => {
     const $elem = cheerio('<div>');
-    // @ts-expect-error Passing a number
-    $elem.text(123);
+    $elem.text(123 as never);
     expect(typeof $elem.text()).toBe('string');
   });
 
@@ -424,9 +416,9 @@ describe('cheerio', () => {
 
     it('cloneDom : should be able clone single Elements', () => {
       const main = cheerio('<p>Cheerio</p>') as Cheerio<Element>;
-      let result: Element[] = [];
+      const result: Element[] = [];
       utils.domEach<Element>(main, (el) => {
-        result = [...result, ...utils.cloneDom(el)];
+        result.push(...utils.cloneDom(el));
       });
       expect(result).toHaveLength(1);
       expect(result[0]).not.toBe(main[0]);
@@ -452,29 +444,26 @@ describe('cheerio', () => {
   describe('parse5 options', () => {
     // Should parse noscript tags only with false option value
     test('{scriptingEnabled: ???}', () => {
-      const options: CheerioOptions = {};
-      let result: Cheerio<Element>;
+      // [default] `scriptingEnabled: true` - tag contains one text element
+      const withScripts = cheerio.load(noscript)('noscript');
+      expect(withScripts).toHaveLength(1);
+      expect(withScripts[0].children).toHaveLength(1);
+      expect(withScripts[0].children[0].type).toBe('text');
 
-      // [default] scriptingEnabled: true - tag contains one text element
-      result = cheerio.load(noscript)('noscript');
-      expect(result).toHaveLength(1);
-      expect(result[0].children).toHaveLength(1);
-      expect(result[0].children[0].type).toBe('text');
+      // `scriptingEnabled: false` - content of noscript will parsed
+      const noScripts = cheerio.load(noscript, { scriptingEnabled: false })(
+        'noscript'
+      );
+      expect(noScripts).toHaveLength(1);
+      expect(noScripts[0].children).toHaveLength(2);
+      expect(noScripts[0].children[0].type).toBe('comment');
+      expect(noScripts[0].children[1].type).toBe('tag');
+      expect(noScripts[0].children[1]).toHaveProperty('name', 'a');
 
-      // ScriptingEnabled: false - content of noscript will parsed
-      options.scriptingEnabled = false;
-      result = cheerio.load(noscript, options)('noscript');
-      expect(result).toHaveLength(1);
-      expect(result[0].children).toHaveLength(2);
-      expect(result[0].children[0].type).toBe('comment');
-      expect(result[0].children[1].type).toBe('tag');
-      expect(result[0].children[1]).toHaveProperty('name', 'a');
-
-      // ScriptingEnabled: ??? - should acts as true
-      const values = [undefined, null, 0, ''];
-      for (const val of values) {
-        options.scriptingEnabled = val as any;
-        result = cheerio.load(noscript, options)('noscript');
+      // `scriptingEnabled: ???` - should acts as true
+      for (const val of [undefined, null, 0, '']) {
+        const options = { scriptingEnabled: val as never };
+        const result = cheerio.load(noscript, options)('noscript');
         expect(result).toHaveLength(1);
         expect(result[0].children).toHaveLength(1);
         expect(result[0].children[0].type).toBe('text');
@@ -483,21 +472,17 @@ describe('cheerio', () => {
 
     // Should contain location data only with truthful option value
     test('{sourceCodeLocationInfo: ???}', () => {
-      const options: CheerioOptions = {};
-
       // Location data should not be present
-      let values = [undefined, null, 0, false, ''];
-      for (let i = 0; i < values.length; i++) {
-        options.sourceCodeLocationInfo = values[i] as any;
+      for (const val of [undefined, null, 0, false, '']) {
+        const options = { sourceCodeLocationInfo: val as never };
         const result = cheerio.load(noscript, options)('noscript');
         expect(result).toHaveLength(1);
         expect(result[0]).not.toHaveProperty('sourceCodeLocation');
       }
 
       // Location data should be present
-      values = [true, 1, 'test'];
-      for (let i = 0; i < values.length; i++) {
-        options.sourceCodeLocationInfo = values[i] as any;
+      for (const val of [true, 1, 'test']) {
+        const options = { sourceCodeLocationInfo: val as never };
         const result = cheerio.load(noscript, options)('noscript');
         expect(result).toHaveLength(1);
         expect(result[0]).toHaveProperty('sourceCodeLocation');

--- a/src/static.spec.ts
+++ b/src/static.spec.ts
@@ -41,8 +41,8 @@ describe('cheerio', () => {
 
     it('() : does not crash with `null` as `this` value', () => {
       const { html } = cheerio;
-      expect(html.call(null as any)).toBe('');
-      expect(html.call(null as any, '#nothing')).toBe('');
+      expect(html.call(null as never)).toBe('');
+      expect(html.call(null as never, '#nothing')).toBe('');
     });
   });
 
@@ -91,7 +91,7 @@ describe('cheerio', () => {
 
     it('() : does not crash with `null` as `this` value', () => {
       const { text } = cheerio;
-      expect(text.call(null as any)).toBe('');
+      expect(text.call(null as never)).toBe('');
     });
   });
 
@@ -199,46 +199,35 @@ describe('cheerio', () => {
 
   describe('.merge', () => {
     const $ = cheerio.load('');
-    let arr1: ArrayLike<number>;
-    let arr2: ArrayLike<number>;
-
-    beforeEach(() => {
-      arr1 = [1, 2, 3];
-      arr2 = [4, 5, 6];
-    });
 
     it('should be a function', () => {
       expect(typeof $.merge).toBe('function');
     });
 
-    it('(arraylike, arraylike) : should return an array', () => {
+    it('(arraylike, arraylike) : should modify the first array, but not the second', () => {
+      const arr1 = [1, 2, 3];
+      const arr2 = [4, 5, 6];
+
       const ret = $.merge(arr1, arr2);
       expect(typeof ret).toBe('object');
       expect(Array.isArray(ret)).toBe(true);
-    });
-
-    it('(arraylike, arraylike) : should modify the first array', () => {
-      $.merge(arr1, arr2);
+      expect(ret).toBe(arr1);
       expect(arr1).toHaveLength(6);
-    });
-
-    it('(arraylike, arraylike) : should not modify the second array', () => {
-      $.merge(arr1, arr2);
       expect(arr2).toHaveLength(3);
     });
 
     it('(arraylike, arraylike) : should handle objects that arent arrays, but are arraylike', () => {
       const arr1: ArrayLike<string> = {
         length: 3,
-        [0]: 'a',
-        [1]: 'b',
-        [2]: 'c',
+        0: 'a',
+        1: 'b',
+        2: 'c',
       };
       const arr2 = {
         length: 3,
-        [0]: 'd',
-        [1]: 'e',
-        [2]: 'f',
+        0: 'd',
+        1: 'e',
+        2: 'f',
       };
 
       $.merge(arr1, arr2);
@@ -250,21 +239,19 @@ describe('cheerio', () => {
     });
 
     it('(?, ?) : should gracefully reject invalid inputs', () => {
-      expect($.merge([4], 3 as any)).toBeFalsy();
-      expect($.merge({} as any, {} as any)).toBeFalsy();
-      expect($.merge([], {} as any)).toBeFalsy();
-      expect($.merge({} as any, [])).toBeFalsy();
-      const fakeArray1 = { length: 3, [0]: 'a', [1]: 'b', [3]: 'd' };
+      expect($.merge([4], 3 as never)).toBeFalsy();
+      expect($.merge({} as never, {} as never)).toBeFalsy();
+      expect($.merge([], {} as never)).toBeFalsy();
+      expect($.merge({} as never, [])).toBeFalsy();
+      const fakeArray1 = { length: 3, 0: 'a', 1: 'b', 3: 'd' };
       expect($.merge(fakeArray1, [])).toBeFalsy();
       expect($.merge([], fakeArray1)).toBeFalsy();
-      const fakeArray2 = { length: '7' };
-      expect($.merge(fakeArray2 as any, [])).toBeFalsy();
-      const fakeArray3 = { length: -1 };
-      expect($.merge(fakeArray3, [])).toBeFalsy();
+      expect($.merge({ length: '7' } as never, [])).toBeFalsy();
+      expect($.merge({ length: -1 }, [])).toBeFalsy();
     });
 
     it('(?, ?) : should no-op on invalid inputs', () => {
-      const fakeArray1 = { length: 3, [0]: 'a', [1]: 'b', [3]: 'd' };
+      const fakeArray1 = { length: 3, 0: 'a', 1: 'b', 3: 'd' };
       $.merge(fakeArray1, []);
       expect(fakeArray1).toHaveLength(3);
       expect(fakeArray1[0]).toBe('a');


### PR DESCRIPTION
For tests, this PR:

- Gets rid of many re-assigned variables,
- Replaces most `any` uses with `never` (which makes it clearer that we are testing an edge-case that shouldn't be allowed by TS)
- Simplifies imports to be from fewer files.