### PR TITLE
Improve documentation, esp. selections of size >1

### DIFF
--- a/src/api/manipulation.ts
+++ b/src/api/manipulation.ts
@@ -885,7 +885,7 @@ export function replaceWith<T extends AnyNode>(
 }
 
 /**
- * Empties an element, removing all its children.
+ * Empties an element, removing all its children (but not text or comments).
  *
  * @category Manipulation
  * @example

--- a/src/api/traversing.ts
+++ b/src/api/traversing.ts
@@ -363,7 +363,7 @@ export function closest<T extends AnyNode>(
 }
 
 /**
- * Gets the next sibling of the first selected element, optionally filtered by a
+ * Gets the next sibling of each selected element, optionally filtered by a
  * selector.
  *
  * @category Traversing
@@ -380,7 +380,7 @@ export function closest<T extends AnyNode>(
 export const next = _singleMatcher((elem) => nextElementSibling(elem));
 
 /**
- * Gets all the following siblings of the first selected element, optionally
+ * Gets all the following siblings of the each selected element, optionally
  * filtered by a selector.
  *
  * @category Traversing
@@ -427,7 +427,7 @@ export const nextUntil = _matchUntil(
 );
 
 /**
- * Gets the previous sibling of the first selected element optionally filtered
+ * Gets the previous sibling of each selected element optionally filtered
  * by a selector.
  *
  * @category Traversing
@@ -444,7 +444,7 @@ export const nextUntil = _matchUntil(
 export const prev = _singleMatcher((elem) => prevElementSibling(elem));
 
 /**
- * Gets all the preceding siblings of the first selected element, optionally
+ * Gets all the preceding siblings of each selected element, optionally
  * filtered by a selector.
  *
  * @category Traversing

--- a/website/docs/basics/manipulation.md
+++ b/website/docs/basics/manipulation.md
@@ -20,11 +20,13 @@ manipulate elements within a document using Cheerio.
 
 ## Modifying Element Attributes and Properties
 
-To modify the attributes and properties of an element, you can use the
+To modify the attributes and properties of a single element, you can use the
 [`attr()`](/docs/api/classes/Cheerio#attr) and
 [`prop()`](/docs/api/classes/Cheerio#prop) methods, respectively. Both methods
 take a key and a value as arguments, and allow you to get and set the attribute
-or property.
+or property. When setting, they apply to all elements in the selection;
+when getting, they return a single value corresponding to the
+first element in the selection.
 
 ```js
 // Set the 'src' attribute of an image element
@@ -43,7 +45,7 @@ const isDisabled = $('button').prop('disabled');
 `prop()` is not limited to simple values like strings and booleans. You can also
 use it to get complex properties like the `style` object, or to resolve `href`
 or `src` URLs of supported elements. You can also use it to get the `tagName`,
-`innerHTML`, `outerHTML`, `textContent`, and `innerText` properties of an
+`innerHTML`, `outerHTML`, `textContent`, and `innerText` properties of a single
 element.
 
 ```js
@@ -67,7 +69,7 @@ To add or remove classes from an element, you can use the
 [`removeClass()`](/docs/api/classes/Cheerio#removeclass), and
 [`toggleClass()`](/docs/api/classes/Cheerio#toggleclass) methods. All three
 methods take a class name or a space-separated list of class names as an
-argument.
+argument. They modify all elements in the selection.
 
 ```js
 // Add a class to an element
@@ -88,9 +90,11 @@ $('div').toggleClass('active');
 
 ## Modifying the Text Content of an Element
 
-To modify the text content of an element, you can use the
-[`text()`](/docs/api/classes/Cheerio#text) method. It takes a string as an
-argument and sets the text content of the element to the given string.
+To query or modify the text content of an element, you can use the
+[`text()`](/docs/api/classes/Cheerio#text) method. Given a string as an
+argument, it sets the text content of every element in the selection to the
+given string. Without arguments, it returns the text content of every element
+(including its descendants) in the selection, concatenated together.
 
 ```js
 // Set the text content of an element
@@ -102,7 +106,7 @@ const text = $('p').text();
 
 :::tip Note
 
-`text()` returns the `textContent` of the passed elements. The result will
+`text()` returns the `textContent` of all passed elements. The result will
 include the contents of `<script>` and `<style>` elements. To avoid this, use
 `.prop('innerText')` instead.
 
@@ -110,9 +114,11 @@ include the contents of `<script>` and `<style>` elements. To avoid this, use
 
 ## Modifying the HTML Content of an Element
 
-To modify the HTML content of an element, you can use the
-[`html()`](/docs/api/classes/Cheerio#html) method. It takes an HTML string as an
-argument and sets the inner HTML of the element to the given string.
+To query or modify the HTML content of an element, you can use the
+[`html()`](/docs/api/classes/Cheerio#html) method. Given an HTML string as an
+argument, it sets the inner HTML of every element in the selection to the given
+string. Without arguments, it returns the inner HTML of the *first* element in
+the selection.
 
 ```js
 // Set the inner HTML of an element
@@ -129,6 +135,7 @@ To insert new elements into a document, you can use the
 [`prepend()`](/docs/api/classes/Cheerio#prepend),
 [`before()`](/docs/api/classes/Cheerio#before), and
 [`after()`](/docs/api/classes/Cheerio#after) methods.
+These modify every element in the selection.
 
 ```js
 // Append an element to the end of a parent element
@@ -207,12 +214,12 @@ parent element, while keeping the element and its children.
 $('p').unwrap();
 ```
 
-## Replacing elements
+## Replacing Elements
 
 To replace an element with another element, you can use the
 [`replaceWith()`](/docs/api/classes/Cheerio#replacewith) method. It takes a
-string or a Cheerio object as an argument and replaces the element with the
-given element.
+string or a Cheerio object as an argument and replaces each element in the
+selection with the given element.
 
 ```js
 // Replace an element with another element
@@ -227,12 +234,23 @@ instead.
 ## Removing Elements
 
 To remove an element from a document, you can use the
-[`remove()`](/docs/api/classes/Cheerio#remove) method. It removes the element
-and all its children from the document.
+[`remove()`](/docs/api/classes/Cheerio#remove) method. It removes each element
+in the selection, and all of their children, from the document.
 
 ```js
 // Remove an element from the document
 $('li').remove();
+```
+
+Alternatively, you can remove the children of an element from the document,
+without removing the element itself, using the
+[`empty()`](/docs/api/classes/Cheerio#empty) method. It removes the children
+(but not text nodes or comments) of each element in the selection from the
+document.
+
+```js
+// Remove an element's children from the document
+$('li').empty();
 ```
 
 ## Conclusion

--- a/website/docs/basics/selecting.md
+++ b/website/docs/basics/selecting.md
@@ -92,6 +92,11 @@ const $p = $('div > p');
 Please have a look at the documentation of Cheerio's underlying CSS selector
 library, `css-select`, for
 [a list of all supported selectors](https://github.com/fb55/css-select/blob/master/README.md#supported-selectors).
+For example, to select `<p>` elements containing the word "hello":
+
+```js
+const $p = $('p:contains("hello")');
+```
 
 Cheerio also supports several jQuery-specific extensions that allow you to
 select elements based on their position in the document. For example, to select

--- a/website/docs/basics/traversing.md
+++ b/website/docs/basics/traversing.md
@@ -19,7 +19,7 @@ Cheerio.
 
 :::tip
 
-This guide is intened to give you an overview of the various methods available
+This guide is intended to give you an overview of the various methods available
 in Cheerio for traversing and filtering elements. For a more detailed reference
 of these methods, see the [API documentation](/docs/api/classes/Cheerio).
 
@@ -102,7 +102,7 @@ elements that are ancestors of the current selection.
 
 The [`parent` method](/docs/api/classes/Cheerio#parent) allows you to select the
 parent element of a selection. It returns a new selection containing the parent
-element of the current selection.
+element of each element in the current selection.
 
 Here's an example of using `parent` to select the parent `<ul>` element of a
 `<li>` element:
@@ -181,11 +181,12 @@ selecting elements that are siblings of the current selection.
 
 The [`next` method](/docs/api/classes/Cheerio#next) allows you to select the
 next sibling element of a selection. It returns a new selection containing the
-next sibling element.
+next sibling element (if there is one). If the given selection contains
+multiple elements, `next` includes the next sibling for each one.
 
 The [`prev` method](/docs/api/classes/Cheerio#prev) is similar to `next`, but
 allows you to select the previous sibling element. It returns a new selection
-containing the previous sibling element.
+containing the previous sibling element for each element in the given selection.
 
 Here's an example of using `next` and `prev` to select sibling elements of a
 `<li>` element:
@@ -208,15 +209,16 @@ render(`Next: ${nextItem.text()} | Prev: ${prevItem.text()}`);
 
 The [`nextAll` method](/docs/api/classes/Cheerio#nextall) allows you to select
 all siblings after the current element. It returns a new selection containing
-all sibling elements after the current element.
+all sibling elements after each element in the current selection.
 
 The [`prevAll` method](/docs/api/classes/Cheerio#prevall) is similar to nextAll,
 but allows you to select all siblings before the current element. It returns a
-new selection containing all sibling elements before the current element.
+new selection containing all sibling elements before each element in the current
+selection.
 
 The [`siblings` method](/docs/api/classes/Cheerio#siblings) allows you to select
 all siblings of a selection. It returns a new selection containing all sibling
-elements of the current element.
+elements of each element in the current selection.
 
 Here's an example of using `nextAll`, `prevAll`, and `siblings` to select
 sibling elements of a `<li>` element:


### PR DESCRIPTION
When I read the website documentation, especially the tutorial, I was confused about which methods applied to every element in a selection, and which only considered the first element. Notably, `.prop` and `.attr` and `.html` used as getters only apply to the first element, but they apply to all elements when used as setters (and `.text` applies to all elements even as a getter). Most other methods (e.g. `.next`) apply to all elements in the selection. I added some relevant text in a bunch of places to clarify what happens with selection sizes >1, which I think is a natural thing to wonder. I also fixed a couple of places where the documentation didn't match the code.