### PR TITLE
refactor(traversing): Simplify `_matcher`

### DIFF
--- a/src/api/manipulation.spec.ts
+++ b/src/api/manipulation.spec.ts
@@ -1712,6 +1712,15 @@ describe('$(...)', () => {
 
       expect($text('body').html()).toBe('<a></a>TEXT<b></b>');
     });
+
+    it('() : should skip comment nodes', () => {
+      const $comment = load('<a>1</a><!--Comment-->TEXT<b>2</b>');
+      const $body = $comment($comment('body')[0].children);
+
+      $body.empty();
+
+      expect($comment('body').html()).toBe('<a></a><!--Comment-->TEXT<b></b>');
+    });
   });
 
   describe('.html', () => {

--- a/src/api/traversing.ts
+++ b/src/api/traversing.ts
@@ -144,14 +144,14 @@ function _getMatcher<P>(
 
 /** Matcher that adds multiple elements for each entry in the input. */
 const _matcher = _getMatcher((fn: (elem: AnyNode) => Element[], elems) => {
-  const ret: Element[][] = [];
+  let ret: Element[] = [];
 
   for (let i = 0; i < elems.length; i++) {
     const value = fn(elems[i]);
-    ret.push(value);
+    if (value.length > 0) ret = ret.concat(value);
   }
 
-  return new Array<Element>().concat(...ret);
+  return ret;
 });
 
 /** Matcher that adds at most one element for each entry in the input. */


### PR DESCRIPTION
And add a test for `empty` with comment nodes.