### PR TITLE
refactor(batteries): Bump `htmlparser2`, use custom stream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.1.0",
         "encoding-sniffer": "^0.0.2",
-        "htmlparser2": "^8.0.2",
+        "htmlparser2": "^9.0.0",
         "parse5": "^7.1.2",
         "parse5-htmlparser2-tree-adapter": "^7.0.0",
         "parse5-parser-stream": "^7.1.2",
@@ -2772,9 +2772,9 @@
       }
     },
     "node_modules/entities": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "engines": {
         "node": ">=0.12"
       },
@@ -3665,9 +3665,9 @@
       "dev": true
     },
     "node_modules/htmlparser2": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.0.0.tgz",
+      "integrity": "sha512-uxbSI98wmFT/G4P2zXx4OVx04qWUmyFPrD2/CNepa2Zo3GPNaCaaxElDgwUrwYWkK1nr9fft0Ya8dws8coDLLQ==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -3678,8 +3678,8 @@
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -9693,9 +9693,9 @@
       }
     },
     "entities": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -10335,14 +10335,14 @@
       "dev": true
     },
     "htmlparser2": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.0.0.tgz",
+      "integrity": "sha512-uxbSI98wmFT/G4P2zXx4OVx04qWUmyFPrD2/CNepa2Zo3GPNaCaaxElDgwUrwYWkK1nr9fft0Ya8dws8coDLLQ==",
       "requires": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
       }
     },
     "http-proxy-agent": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "domhandler": "^5.0.3",
     "domutils": "^3.1.0",
     "encoding-sniffer": "^0.0.2",
-    "htmlparser2": "^8.0.2",
+    "htmlparser2": "^9.0.0",
     "parse5": "^7.1.2",
     "parse5-htmlparser2-tree-adapter": "^7.0.0",
     "parse5-parser-stream": "^7.1.2",

--- a/src/batteries.ts
+++ b/src/batteries.ts
@@ -12,9 +12,7 @@ import { load } from './index.js';
 import { flattenOptions, type InternalOptions } from './options.js';
 import { adapter as htmlparser2Adapter } from 'parse5-htmlparser2-tree-adapter';
 
-// eslint-disable-next-line n/file-extension-in-import
-import { WritableStream as Htmlparser2Stream } from 'htmlparser2/lib/WritableStream';
-import DomHandler from 'domhandler';
+import * as htmlparser2 from 'htmlparser2';
 import { ParserStream as Parse5Stream } from 'parse5-parser-stream';
 import {
   decodeBuffer,
@@ -23,7 +21,7 @@ import {
 } from 'encoding-sniffer';
 import * as undici from 'undici';
 import MIMEType from 'whatwg-mimetype';
-import { type Writable, finished } from 'node:stream';
+import { Writable, finished } from 'node:stream';
 
 /**
  * Sniffs the encoding of a buffer, then creates a querying function bound to a
@@ -38,6 +36,7 @@ import { type Writable, finished } from 'node:stream';
  * const buffer = fs.readFileSync('index.html');
  * const $ = cheerio.fromBuffer(buffer);
  * ```
+ *
  * @param buffer - The buffer to sniff the encoding of.
  * @param options - The options to pass to Cheerio.
  * @returns The loaded document.
@@ -60,12 +59,26 @@ function _stringStream(
   cb: (err: Error | null | undefined, $: CheerioAPI) => void
 ): Writable {
   if (options?._useHtmlParser2) {
-    const handler: DomHandler = new DomHandler(
-      (err) => cb(err, load(handler.root)),
+    const parser = htmlparser2.createDocumentStream(
+      (err, document) => cb(err, load(document)),
       options
     );
 
-    return new Htmlparser2Stream(handler, options);
+    return new Writable({
+      decodeStrings: false,
+      write(chunk, _encoding, callback) {
+        if (typeof chunk !== 'string') {
+          throw new TypeError('Expected a string');
+        }
+
+        parser.write(chunk);
+        callback();
+      },
+      final(callback) {
+        parser.end();
+        callback();
+      },
+    });
   }
 
   options ??= {};
@@ -108,6 +121,7 @@ function _stringStream(
  *   writeStream
  * );
  * ```
+ *
  * @param options - The options to pass to Cheerio.
  * @param cb - The callback to call when the stream is finished.
  * @returns The writable stream.
@@ -184,6 +198,7 @@ const defaultRequestOptions: UndiciStreamOptions = {
  *
  * const $ = await cheerio.fromURL('https://example.com');
  * ```
+ *
  * @param url - The URL to load the document from.
  * @param options - The options to pass to Cheerio.
  * @returns The loaded document.


### PR DESCRIPTION
`htmlparser2`'s `WritableStream` comes with a `TextDecoder` instance that is not needed for cheerio's use-case. It is easy enough to use a custom stream here to avoid potential complications.