### PR TITLE
fix(types): Fix module/moduleResolution options for TypeScript 5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "module": "lib/esm/index.js",
+  "type": "commonjs",
   "exports": {
     ".": {
       "require": "./lib/index.js",
@@ -113,8 +114,10 @@
     "update-sponsors": "ts-node --esm -TO '{\"module\":\"node16\",\"target\":\"es2019\"}' scripts/fetch-sponsors.mts",
     "bench": "npm run benchmark",
     "build": "npm run build:cjs && npm run build:esm",
+    "make-esm": "sed -i '' 's/\"type\": \"commonjs\"/\"type\": \"module\"/g' package.json",
+    "make-cjs": "sed -i '' 's/\"type\": \"module\"/\"type\": \"commonjs\"/g' package.json",
     "build:cjs": "tsc --sourceRoot https://raw.githubusercontent.com/cheeriojs/cheerio/$(git rev-parse HEAD)/src/",
-    "build:esm": "npm run build:cjs -- --module esnext --target es2019 --outDir lib/esm && echo '{\"type\":\"module\"}' > lib/esm/package.json",
+    "build:esm": "npm run make-esm && npm run build:cjs -- --target es2019 --outDir lib/esm && echo '{\"type\":\"module\"}' > lib/esm/package.json; npm run make-cjs",
     "prepublishOnly": "npm run build",
     "prepare": "husky install"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,9 @@
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "lib",
+    // esModuleInterop is implied by `--module node16`,
+    // but ts-jest doesn't recognize that and needs it listed.
+    "esModuleInterop": true,
 
     /* Strict Type-Checking Options */
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     /* Basic Options */
     "target": "es5",
-    "module": "commonjs",
+    "module": "node16",
     "lib": ["ES2015.Core"],
     "declaration": true,
     "declarationMap": true,
@@ -20,12 +20,7 @@
     "noImplicitReturns": true,
     "noPropertyAccessFromIndexSignature": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true,
-
-    /* Module Resolution Options */
-    "esModuleInterop": true,
-    "moduleResolution": "node16",
-    "resolveJsonModule": true
+    "noUnusedParameters": true
   },
   "include": ["src"],
   "exclude": [


### PR DESCRIPTION
👋 Hey, I work on the TypeScript team, and in 5.2 we’re planning to [break your tsconfig](https://github.com/microsoft/TypeScript/pull/54567), so I’m opening a PR to preemptively fix it. Specifically, we’re going to enforce that `module` and `moduleResolution` have to be set to the same value when either is `node16` or `nodenext`.

You’re currently using `moduleResolution: node16` in combination with both `module: commonjs` and `module: esnext` in order to achieve dual module format emit with tsc. tsc isn’t really designed to work with those combinations, as explained in the afore-linked PR. Those limitations are why you were susceptible to issues like #2759 and need the eslint rule that enforces file extensions on import paths. Really, TypeScript should be doing that validation for you. (By the way, it looks like #2759 was never released, as the current release still has [type resolution errors](https://arethetypeswrong.github.io/?p=cheerio%401.0.0-rc.12).)

This PR makes a slight modification to your build scripts to ensure that tsc sees an accurate value for package.json `"type"` when compiling, which (with the right tsconfig settings) affects its type checking, module resolution, and emit to all be in sync. You might also be interested in tracking https://github.com/microsoft/TypeScript/issues/54593 which, if we ever resolve, aims to make this kind of thing easier.

Feel free to use this PR, edit it, or close it and do something different. Just wanted to give you a heads up and hopefully get you started down the right track.