### PR TITLE
Issue #581 - coerce attribute names to lower case

### DIFF
--- a/src/__fixtures__/fixtures.ts
+++ b/src/__fixtures__/fixtures.ts
@@ -2,7 +2,7 @@ export const fruits = [
   '<ul id="fruits">',
   '<li class="apple">Apple</li>',
   '<li class="orange">Orange</li>',
-  '<li class="pear">Pear</li>',
+  '<li class="pear" FOO="true">Pear</li>',
   '</ul>',
 ].join('');
 

--- a/src/__tests__/deprecated.spec.ts
+++ b/src/__tests__/deprecated.spec.ts
@@ -172,7 +172,7 @@ describe('deprecated APIs', () => {
 
       it('(selector) : should return the outerHTML of the selected element', () => {
         const $ = cheerio.load(fixtures.fruits);
-        expect($.html('.pear')).toBe('<li class="pear">Pear</li>');
+        expect($.html('.pear')).toBe('<li class="pear" foo="true">Pear</li>');
       });
     });
 

--- a/src/api/attributes.spec.ts
+++ b/src/api/attributes.spec.ts
@@ -42,6 +42,12 @@ describe('$(...)', () => {
       expect(attr).toBe('autofocus');
     });
 
+    it('(valid key) should get uppercase attribute with lowercase name', () => {
+      const $pear = $('.pear');
+      expect($pear.attr('FOO')).toBe('true');
+      expect($pear.attr('foo')).toBe('true');
+    });
+
     it('(key, value) : should set one attr', () => {
       const $pear = $('.pear').attr('id', 'pear');
       expect($('#pear')).toHaveLength(1);
@@ -63,6 +69,12 @@ describe('$(...)', () => {
       const $src = $().attr('key', 'value');
       expect($src.length).toBe(0);
       expect($src[0]).toBeUndefined();
+    });
+
+    it('(key, value) should save uppercase attribute name as lowercase', () => {
+      const $pear = $('.pear').attr('BAR', '100');
+      expect($pear.attr('BAR')).toBe('100');
+      expect($pear.attr('bar')).toBe('100');
     });
 
     it('(map) : object map should set multiple attributes', () => {
@@ -168,19 +180,24 @@ describe('$(...)', () => {
     });
 
     it('(chaining) setting value and calling attr returns result', () => {
+      const pearAttr = $('.pear').attr('fizz', 'buzz').attr('fizz');
+      expect(pearAttr).toBe('buzz');
+    });
+
+    it('(chaining) overwriting value and calling attr returns result', () => {
       const pearAttr = $('.pear').attr('foo', 'bar').attr('foo');
       expect(pearAttr).toBe('bar');
     });
 
     it('(chaining) setting attr to null returns a $', () => {
-      const $pear = $('.pear').attr('foo', null);
+      const $pear = $('.pear').attr('bar', null);
       expect($pear).toBeInstanceOf($);
     });
 
     it('(chaining) setting attr to undefined returns a $', () => {
-      const $pear = $('.pear').attr('foo', undefined);
+      const $pear = $('.pear').attr('bar', undefined);
       expect($('.pear')).toHaveLength(1);
-      expect($('.pear').attr('foo')).toBeUndefined();
+      expect($('.pear').attr('bar')).toBeUndefined();
       expect($pear).toBeInstanceOf($);
     });
 

--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -57,15 +57,17 @@ function getAttr(
   }
 
   // Coerce attribute names to lowercase to match load() and setAttr() behavior
-  name = name.toLowerCase();
+  const lowerCasedName = name.toLowerCase();
 
-  if (hasOwn.call(elem.attribs, name)) {
+  if (hasOwn.call(elem.attribs, lowerCasedName)) {
     // Get the (decoded) attribute
-    return !xmlMode && rboolean.test(name) ? name : elem.attribs[name];
+    return !xmlMode && rboolean.test(lowerCasedName)
+      ? lowerCasedName
+      : elem.attribs[lowerCasedName];
   }
 
   // Mimic the DOM and return text content as value for `option's`
-  if (elem.name === 'option' && name === 'value') {
+  if (elem.name === 'option' && lowerCasedName === 'value') {
     return text(elem.children);
   }
 
@@ -73,7 +75,7 @@ function getAttr(
   if (
     elem.name === 'input' &&
     (elem.attribs['type'] === 'radio' || elem.attribs['type'] === 'checkbox') &&
-    name === 'value'
+    lowerCasedName === 'value'
   ) {
     return 'on';
   }
@@ -92,12 +94,12 @@ function getAttr(
  */
 function setAttr(el: Element, name: string, value: string | null) {
   // Coerce attr names to lowercase to match load() behavior
-  name = name.toLowerCase();
+  const lowerCasedName = name.toLowerCase();
 
   if (value === null) {
-    removeAttribute(el, name);
+    removeAttribute(el, lowerCasedName);
   } else {
-    el.attribs[name] = `${value}`;
+    el.attribs[lowerCasedName] = `${value}`;
   }
 }
 

--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -56,6 +56,9 @@ function getAttr(
     return elem.attribs;
   }
 
+  // Coerce attribute names to lowercase to match load() and setAttr() behavior
+  name = name.toLowerCase();
+
   if (hasOwn.call(elem.attribs, name)) {
     // Get the (decoded) attribute
     return !xmlMode && rboolean.test(name) ? name : elem.attribs[name];
@@ -88,6 +91,9 @@ function getAttr(
  * @param value - The attribute's value.
  */
 function setAttr(el: Element, name: string, value: string | null) {
+  // Coerce attr names to lowercase to match load() behavior
+  name = name.toLowerCase();
+
   if (value === null) {
     removeAttribute(el, name);
   } else {

--- a/src/api/manipulation.spec.ts
+++ b/src/api/manipulation.spec.ts
@@ -1729,7 +1729,7 @@ describe('$(...)', () => {
         [
           '<li class="apple">Apple</li>',
           '<li class="orange">Orange</li>',
-          '<li class="pear">Pear</li>',
+          '<li class="pear" foo="true">Pear</li>',
         ].join('')
       );
     });
@@ -1777,7 +1777,7 @@ describe('$(...)', () => {
     it('(elem) : should move the passed element (#940)', () => {
       $('.apple').html($('.orange'));
       expect($fruits.html()).toBe(
-        '<li class="apple"><li class="orange">Orange</li></li><li class="pear">Pear</li>'
+        '<li class="apple"><li class="orange">Orange</li></li><li class="pear" foo="true">Pear</li>'
       );
     });
 
@@ -1809,12 +1809,14 @@ describe('$(...)', () => {
 
   describe('.toString', () => {
     it('() : should get the outerHTML for an element', () => {
-      expect($fruits.toString()).toBe(fruits);
+      expect($fruits.toString()).toBe(
+        '<ul id="fruits"><li class="apple">Apple</li><li class="orange">Orange</li><li class="pear" foo="true">Pear</li></ul>'
+      );
     });
 
     it('() : should return an html string for a set of elements', () => {
       expect($fruits.find('li').toString()).toBe(
-        '<li class="apple">Apple</li><li class="orange">Orange</li><li class="pear">Pear</li>'
+        '<li class="apple">Apple</li><li class="orange">Orange</li><li class="pear" foo="true">Pear</li>'
       );
     });
 


### PR DESCRIPTION
Fix for issue #581.  Attribute names will now always be coerced to lower case when attempting to get or set attributes to keep the behavior in line with how cheerio.load() handles attribute names.