### PR TITLE
feat: lowercased lookup with attr/data

### DIFF
--- a/src/api/attributes.spec.ts
+++ b/src/api/attributes.spec.ts
@@ -42,6 +42,16 @@ describe('$(...)', () => {
       expect(attr).toBe('autofocus');
     });
 
+    it('(valid key) : valid lowercased attr should get value', () => {
+      const cls = $('.apple').attr('Class');
+      expect(cls).toBe('apple');
+    });
+
+    it('(valid key) : valid lowercased attr should get lowercased name when boolean', () => {
+      const attr = $('<input name=email autofocus>').attr('autoFocus');
+      expect(attr).toBe('autofocus');
+    });
+
     it('(key, value) : should set one attr', () => {
       const $pear = $('.pear').attr('id', 'pear');
       expect($('#pear')).toHaveLength(1);
@@ -484,6 +494,12 @@ describe('$(...)', () => {
 
       expect(highlight).toBe('Lindor');
       expect(origin).toBe('swiss');
+    });
+
+    it('(valid key) : valid lowercased data attribute should get value', () => {
+      const highlight = $('.linth').data('highLight');
+
+      expect(highlight).toBe('Lindor');
     });
 
     it('(key) : should translate camel-cased key values to hyphen-separated versions', () => {

--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -61,6 +61,15 @@ function getAttr(
     return !xmlMode && rboolean.test(name) ? name : elem.attribs[name];
   }
 
+  // Try again for lowercase
+  const lowerName = name.toLowerCase();
+  if (hasOwn.call(elem.attribs, lowerName)) {
+    // Get the (decoded) attribute
+    return !xmlMode && rboolean.test(lowerName)
+      ? lowerName
+      : elem.attribs[lowerName];
+  }
+
   // Mimic the DOM and return text content as value for `option's`
   if (elem.name === 'option' && name === 'value') {
     return text(elem.children);
@@ -580,8 +589,15 @@ function readData(el: DataElement, name: string): unknown {
     return data[name];
   }
 
+  // E.g. .data('helloWorld') will lookup cssCased name: attribs['data-hello-world']
   if (hasOwn.call(el.attribs, domName)) {
     return (data[name] = parseDataValue(el.attribs[domName]));
+  }
+
+  /** Try again for lowercase. E.g. .data('aBc') will lookup attribs['data-abc']. */
+  const lowerName = dataAttrPrefix + name.toLowerCase();
+  if (hasOwn.call(el.attribs, lowerName)) {
+    return (data[lowerName] = parseDataValue(el.attribs[lowerName]));
   }
 
   return undefined;


### PR DESCRIPTION
Fix for #581

If you accidentally use a lowercased lookup with .attr() or .data(), we will attempt to retry the lookup with a lowercased name.