### PR TITLE
Fix potential github action smells

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -6,6 +6,8 @@ on:
   # Runs on pushes targeting the main branch
   push:
     branches: [main]
+    paths:
+      - webiste/**
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -45,14 +47,17 @@ jobs:
       - name: Build
         run: npm run build
       - name: Install website dependencies
-        run: cd website && npm ci
+        working-directory: website
+        run: npm ci
       - name: Sync Crowdin
-        run: cd website && npm run crowdin:sync
+        working-directory: website
+        run: npm run crowdin:sync
         continue-on-error: true
         env:
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
       - name: Build docs
-        run: cd website && npm run build
+        working-directory: website
+        run: npm run build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
@@ -65,6 +70,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    if: ${{github.repository == 'cheeriojs/cheerio'}}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
Hey! 🙂
I've made the following changes to your workflow: 

- Avoid running CI related actions when no source code has changed
  - Running workflows which build or test certain parts of the code base without these parts being changed is useless, as nothing new will be checked or created.
- Steps should only perform a single command
  - When one step does multiple things at once, it becomes unclear what exactly has failed during the execution of the step.
- Avoid deploying jobs on forks
  - Deploying from a fork is usually not wanted because in that case unreviewed code by external authors will be published/deployed to main. Furthermore, forks usually don't have the correct rights to publish/deploy and will fail the workflow anyway.

I've fixed these smells in (part of) your workflows, and I'm interested in your feedback on the following changes.

(These changes are part of a research Study at TU Delft looking at GitHub Action Smells. [Find out more](https://ceddy4395.github.io/research/gha-smells.html))