### PR TITLE
refactor: Remove type re-exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,17 +21,7 @@ export type { Cheerio } from './cheerio.js';
  * @category Cheerio
  */
 export * from './types.js';
-export type {
-  CheerioOptions,
-  HTMLParser2Options,
-  Parse5Options,
-} from './options.js';
-/**
- * Re-exporting all of the node types.
- *
- * @category DOM Node
- */
-export type { Node, AnyNode, ParentNode, Element, Document } from 'domhandler';
+export type { CheerioOptions, HTMLParser2Options } from './options.js';
 export type { CheerioAPI } from './load.js';
 export { contains, merge } from './static.js';
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -13,17 +13,14 @@ export interface HTMLParser2Options
   extends DomHandlerOptions,
     HTMLParser2ParserOptions {}
 
-/** Options for parse5, the default parser for HTML. */
-export interface Parse5Options // eslint-disable-line @typescript-eslint/no-empty-interface
-  extends Parse5ParserOptions<Htmlparser2TreeAdapterMap> {}
-
 /**
  * Options accepted by Cheerio.
  *
  * Please note that parser-specific options are _only recognized_ if the
  * relevant parser is used.
  */
-export interface CheerioOptions extends Parse5Options {
+export interface CheerioOptions
+  extends Parse5ParserOptions<Htmlparser2TreeAdapterMap> {
   /**
    * Recommended way of configuring htmlparser2 when wanting to parse XML.
    *

--- a/src/slim.ts
+++ b/src/slim.ts
@@ -14,11 +14,6 @@ export type {
   CheerioAPI,
   CheerioOptions,
   HTMLParser2Options,
-  Node,
-  AnyNode,
-  ParentNode,
-  Element,
-  Document,
 } from './index.js';
 
 /**

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -228,7 +228,6 @@ const config = {
     ],
     [
       'docusaurus-plugin-typedoc',
-
       {
         // TypeDoc options
         entryPoints: ['../src/batteries.ts'],
@@ -259,6 +258,7 @@ const config = {
         sidebar: {
           // Always display the API entry last
           position: Number.MAX_SAFE_INTEGER,
+          pretty: true,
         },
         outputFileStrategy: 'members',
       },


### PR DESCRIPTION
This made the docs difficult to read, as all types ended up in the docs.

BREAKING CHANGE; if you previously imported node types from Cheerio, you will now have to import them directly from `domhandler`.