### PR TITLE
Add a field `browser` to `package.json` root

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   },
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",
+  "browser": "./dist/browser/index.js",
   "types": "./dist/commonjs/index.d.ts",
   "files": [
     "dist",


### PR DESCRIPTION
Fixes https://github.com/cheeriojs/cheerio/issues/4032

Some bundlers (e.g. react-native) requires the field `browser` at `package.json` root to find the correct resolution entry points. (Reference: https://metrobundler.dev/docs/configuration/#resolvermainfields)

This PR adds the correct entry point for browsers to `package.json`.