### PR TITLE
docs: correct loadBuffer() name in example

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ import { load } from './load-parse.js';
  * import * as cheerio from 'cheerio';
  *
  * const buffer = fs.readFileSync('index.html');
- * const $ = cheerio.fromBuffer(buffer);
+ * const $ = cheerio.loadBuffer(buffer);
  * ```
  *
  * @param buffer - The buffer to sniff the encoding of.


### PR DESCRIPTION
The example [in the docs](https://cheerio.js.org/docs/api/functions/loadBuffer) uses `cheerio.fromBuffer` instead of `cheerio.loadBuffer`, which confused me for a second when copy-pasting.