### PR TITLE
fix(types): fix ExtractedValue type

### DIFF
--- a/src/api/extract.spec.ts
+++ b/src/api/extract.spec.ts
@@ -152,6 +152,28 @@ describe('$.extract', () => {
     ).toStrictEqual({ red: 'red=Four' });
   });
 
+  it('should correctly type check custom extraction functions returning non-string values', () => {
+    const $ = load(fixtures.eleven);
+    const $root = $.root();
+
+    expectTypeOf(
+      $root.extract({
+        red: {
+          selector: '.red',
+          value: (el) => $(el).text().length,
+        },
+      }),
+    ).toEqualTypeOf<{ red: number | undefined }>();
+    expect(
+      $root.extract({
+        red: {
+          selector: '.red',
+          value: (el) => $(el).text().length,
+        },
+      }),
+    ).toStrictEqual({ red: 4 });
+  });
+
   it('should extract multiple values using custom extraction functions', () => {
     const $ = load(fixtures.eleven);
     const $root = $.root();
@@ -211,6 +233,44 @@ describe('$.extract', () => {
       section: {
         red: 'Five',
         sel: 'Seven',
+      },
+    });
+  });
+
+  it('should correctly type check nested objects returning non-string values', () => {
+    const $ = load(fixtures.eleven);
+    const $root = $.root();
+
+    expectTypeOf(
+      $root.extract({
+        section: {
+          selector: 'ul:nth(1)',
+          value: {
+            red: {
+              selector: '.red',
+              value: (el) => $(el).text().length,
+            },
+          },
+        },
+      }),
+    ).toEqualTypeOf<{
+      section: { red: number | undefined } | undefined;
+    }>();
+    expect(
+      $root.extract({
+        section: {
+          selector: 'ul:nth(1)',
+          value: {
+            red: {
+              selector: '.red',
+              value: (el) => $(el).text().length,
+            },
+          },
+        },
+      }),
+    ).toStrictEqual({
+      section: {
+        red: 4,
       },
     });
   });

--- a/src/api/extract.ts
+++ b/src/api/extract.ts
@@ -18,22 +18,24 @@ type ExtractValue = string | ExtractDescriptor | [string | ExtractDescriptor];
 
 export type ExtractMap = Record<string, ExtractValue>;
 
-type ExtractedValue<V extends ExtractValue, M extends ExtractMap> = V extends [
+type ExtractedValue<V extends ExtractValue> = V extends [
   string | ExtractDescriptor,
 ]
-  ? NonNullable<ExtractedValue<V[0], M>>[]
+  ? NonNullable<ExtractedValue<V[0]>>[]
   : V extends string
     ? string | undefined
     : V extends ExtractDescriptor
-      ? V['value'] extends ExtractMap
-        ? ExtractedMap<V['value']> | undefined
-        : V['value'] extends ExtractDescriptorFn
-          ? ReturnType<V['value']> | undefined
-          : ReturnType<typeof prop> | undefined
+      ? V['value'] extends infer U
+        ? U extends ExtractMap
+          ? ExtractedMap<U> | undefined
+          : U extends ExtractDescriptorFn
+            ? ReturnType<U> | undefined
+            : ReturnType<typeof prop> | undefined
+        : never
       : never;
 
 export type ExtractedMap<M extends ExtractMap> = {
-  [key in keyof M]: ExtractedValue<M[key], M>;
+  [key in keyof M]: ExtractedValue<M[key]>;
 };
 
 function getExtractDescr(


### PR DESCRIPTION
Noticed this while working with `extract`

TypeScript does not automatically distribute conditionals unless the generic type itself represents a union. So, in `ExtractedValue`, `V['value']` is not distributed unless inferred as a separate generic type.

EDIT: Adding [issue link](https://github.com/cheeriojs/cheerio/issues/4335#issue-2769048688)

```
// Testing distributed conditional over an indexed access type
interface Obj {
  value: string | number;
}

type TestIndexedObj<V extends { value: unknown }> = V['value'] extends number ? 'extends number' : 'does not extend number';
type TestIndexedObjResult = TestIndexedObj<Obj> // "does not extend number"

// Testing distributed conditional over a union
type ObjValue = Obj['value'];

type TestUnion<V> = V extends number ? 'extends number' : 'does not extend number';
type TestUnionResult = TestUnion<ObjValue> // "does not extend number" | "extends number"

// Testing distributed conditional over an inferred generic from an indexed access type
type TestInferredIndexedObj<V extends { value: unknown }> = V['value'] extends infer U ? (U extends number ? 'extends number' : 'does not extend number') : never;
type TestInferredIndexedObjResult = TestInferredIndexedObj<Obj> // "does not extend number" | "extends number"
```