### PR TITLE
docs: use code block for install, mention yarn and bun

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,7 +34,13 @@ $.html();
 
 ## Installation
 
-`npm install cheerio`
+Install Cheerio using a package manager like npm, yarn, or bun.
+
+```bash
+npm install cheerio
+# or
+bun add cheerio
+```
 
 ## Features
 


### PR DESCRIPTION
Changed the readme to use a code block instead of an inline code tag. Also mentioned yarn and bun as installation methods.