### PR TITLE
chore: upgrade parse5 and related dependencies to 8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,9 +122,9 @@
     "domutils": "^3.2.2",
     "encoding-sniffer": "^0.2.1",
     "htmlparser2": "^10.0.0",
-    "parse5": "^7.3.0",
-    "parse5-htmlparser2-tree-adapter": "^7.1.0",
-    "parse5-parser-stream": "^7.1.2",
+    "parse5": "^8.0.0",
+    "parse5-htmlparser2-tree-adapter": "^8.0.0",
+    "parse5-parser-stream": "^8.0.0",
     "undici": "^7.16.0",
     "whatwg-mimetype": "^4.0.0"
   },


### PR DESCRIPTION
https://github.com/ant-design/ant-design/actions/runs/20592685938/job/59143757152?pr=56009

to support jsdom version 27+ , need

updated parse5 and related packages to version 8.0.0. 

@fb55 