### PR TITLE
Fix https://github.com/advisories/GHSA-p6mc-m468-83gw 

### DIFF
--- a/lib/api/css.js
+++ b/lib/api/css.js
@@ -1,6 +1,13 @@
 var domEach = require('../utils').domEach,
     _ = {
-      pick: require('lodash.pick'),
+      pick: function(object, keys) {
+        return keys.reduce(function (obj, key) {
+          if (object && object.hasOwnProperty(key)) {
+            obj[key] = object[key];
+          }
+          return obj;
+        }, {});
+      }
     };
 
 var toString = Object.prototype.toString;

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "lodash.foreach": "^4.3.0",
     "lodash.map": "^4.4.0",
     "lodash.merge": "^4.4.0",
-    "lodash.pick": "^4.2.1",
     "lodash.reduce": "^4.4.0",
     "lodash.reject": "^4.4.0",
     "lodash.some": "^4.4.0"


### PR DESCRIPTION
This updates the 0.22.0 code such that it no longer relies on lodash.pick, which currently triggers security audit warnings due to https://github.com/advisories/GHSA-p6mc-m468-83gw

While 0.22.0 is by no means a recent release, it is the last 0.x release, with several still current libraries (e.g. official gatsby plugins) still implicitly relying on it. Releasing a 0.22.1 patch version will allow folks to address this GHSA as a progressive override/upgrade.

Note that this isn't really a PR against `main`, it's a PR on top of the `0.22.0` tag branch, but that's not a type of PR that github understands.