### PR TITLE
Support react-native resolution in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
         "types": "./dist/browser/index.d.ts",
         "default": "./dist/browser/index.js"
       },
+      "react-native": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -47,6 +51,10 @@
         "types": "./dist/browser/slim.d.ts",
         "default": "./dist/browser/slim.js"
       },
+      "react-native": {
+        "types": "./dist/browser/slim.d.ts",
+        "default": "./dist/browser/slim.js"
+      },
       "import": {
         "types": "./dist/esm/slim.d.ts",
         "default": "./dist/esm/slim.js"
@@ -58,6 +66,10 @@
     },
     "./utils": {
       "browser": {
+        "types": "./dist/browser/utils.d.ts",
+        "default": "./dist/browser/utils.js"
+      },
+      "react-native": {
         "types": "./dist/browser/utils.d.ts",
         "default": "./dist/browser/utils.js"
       },


### PR DESCRIPTION
React Native's bundler (metro) will try to find a "react-native" field during resolution.

If unfound, it will fallback to "import" or "require", which includes incompatible dependencies, causing issues like #4005, #4012.

This PR fixes #4005, fixes #4012.