### PR TITLE
fix: improve error messages with helpful suggestions

### DIFF
--- a/src/load.ts
+++ b/src/load.ts
@@ -133,7 +133,13 @@ export function getLoad(
     isDocument = true,
   ): CheerioAPI {
     if ((content as string | null) == null) {
-      throw new Error('cheerio.load() expects a string');
+      const actualType = content === null ? 'null' : typeof content;
+      throw new Error(
+        `cheerio.load() expects a string, Buffer, or DOM node as content. ` +
+        `Received: ${actualType}. ` +
+        `Hint: If you're passing a variable, make sure it's not undefined or null. ` +
+        `Example: cheerio.load('<html>...</html>')`
+      );
     }
 
     const internalOpts = flattenOptions(options);
@@ -216,7 +222,12 @@ export function getLoad(
       }
 
       if (typeof selector !== 'string') {
-        throw new TypeError('Unexpected type of selector');
+        throw new TypeError(
+          `Unexpected selector type: ${typeof selector}. ` +
+          `Cheerio accepts strings (CSS selectors or HTML), DOM nodes, arrays of DOM nodes, or Cheerio objects. ` +
+          `Received type: ${typeof selector}. ` +
+          `Example: $('div.class'), $('<html>'), or $(domNode)`
+        );
       }
 
       // We know that our selector is a string now.


### PR DESCRIPTION
## Summary

This PR improves error messages in cheerio to help developers debug faster by providing actionable context.

## Changes

### `cheerio.load()` error
- Shows the actual type received (null, undefined, etc.) instead of a generic message
- Lists valid input types (string, Buffer, DOM node)
- Includes a usage example and debugging hint

### Selector type error
- Explains what types are accepted, with examples

## Example Improved Error Messages

Before:
```
Error: cheerio.load() expects a string
```

After:
```
Error: cheerio.load() expects a string, Buffer, or DOM node as content. Received: undefined. Hint: If you're passing a variable, make sure it's not undefined or null. Example: cheerio.load('<html>...</html>')
```