### PR TITLE
fix: lowercase attribute name lookup in .attr() for HTML mode

### DIFF
--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -61,9 +61,14 @@ function getAttr(
     return elem.attribs;
   }
 
-  if (Object.hasOwn(elem.attribs, name)) {
+  // HTML attribute names are case-insensitive (but XML is case-sensitive)
+  const lookupName = xmlMode ? name : name.toLowerCase();
+
+  if (Object.hasOwn(elem.attribs, lookupName)) {
     // Get the (decoded) attribute
-    return !xmlMode && rboolean.test(name) ? name : elem.attribs[name];
+    return !xmlMode && rboolean.test(lookupName)
+      ? lookupName
+      : elem.attribs[lookupName];
   }
 
   // Mimic the DOM and return text content as value for `option's`


### PR DESCRIPTION
HTML attribute names are case-insensitive per the spec, but .attr('Data-Value') would return undefined when the actual attribute was stored as data-value. Now lowercases the name before checking elem.attribs when not in xmlMode, so .attr('DATA-VALUE') and .attr('data-value') both find the same attribute.

XML mode is unchanged since XML attributes are case-sensitive.

790/790 tests pass.

Fixes #581