### PR TITLE
fix: broken fromURL link in loading docs

### DIFF
--- a/website/src/content/docs/basics/loading.md
+++ b/website/src/content/docs/basics/loading.md
@@ -149,7 +149,7 @@ const $ = await cheerio.fromURL('https://example.com');
 ```
 
 Learn more about the `fromURL` method in the
-[API documentation](/docs/api/functions/fromURL).
+[API documentation](/docs/api/functions/fromurl).
 
 ## Conclusion
 


### PR DESCRIPTION
Fixes broken hyperlink pointed out in #5237. Changed \/docs/api/functions/fromURL\ to \/docs/api/functions/fromurl\ (lowercase).

Closes #5237