### PR TITLE
fix(attributes): make removeAttr case-insensitive for HTML documents

### DIFF
--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -838,6 +838,9 @@ export function val<T extends AnyNode>(
  * @param name - Name of the attribute to remove.
  */
 function removeAttribute(elem: Element, name: string) {
+  // HTML attribute names are case-insensitive; htmlparser2 stores them in lowercase.
+  name = name.toLowerCase();
+
   if (!(elem.attribs && Object.hasOwn(elem.attribs, name))) return;
 
   delete elem.attribs[name];


### PR DESCRIPTION
Fixes #5257

Why
`.removeAttr()` does not lowercase the attribute name before removing it from `elem.attribs`. Since htmlparser2 stores all attribute names in lowercase (per HTML spec), calling `.removeAttr("CLASS")` fails to remove a `class` attribute stored as `"class"`.

Changes
Added `name = name.toLowerCase()` at the top of the `removeAttribute()` function.

Updated component: `src/api/attributes.ts`

Testing
`.removeAttr("CLASS")` now correctly removes the `class` attribute. Existing case-sensitive calls continue to work.

Surface area
- Attributes API
- Bug fix