### PR TITLE
fix(attributes): make attr() name lookup case-insensitive for HTML

### DIFF
--- a/src/api/attributes.spec.ts
+++ b/src/api/attributes.spec.ts
@@ -44,6 +44,15 @@ describe('$(...)', () => {
       expect(attr).toBe('autofocus');
     });
 
+    it('(key) : should be case-insensitive for HTML', () => {
+      const cls = $('.apple').attr('CLASS');
+      expect(cls).toBe('apple');
+      const cls2 = $('.apple').attr('Class');
+      expect(cls2).toBe('apple');
+      const id = $('ul').attr('ID');
+      expect(id).toBe('fruits');
+    });
+
     it('(key, value) : should set one attr', () => {
       const $pear = $('.pear').attr('id', 'pear');
       expect($('#pear')).toHaveLength(1);

--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -61,6 +61,13 @@ function getAttr(
     return elem.attribs;
   }
 
+  // HTML attribute names are case-insensitive. Browsers normalize them to
+  // lowercase, so we should do the same when looking up.
+  // https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
+  if (!xmlMode) {
+    name = name.toLowerCase();
+  }
+
   if (Object.hasOwn(elem.attribs, name)) {
     // Get the (decoded) attribute
     return !xmlMode && rboolean.test(name) ? name : elem.attribs[name];


### PR DESCRIPTION
## Summary

HTML attribute names are case-insensitive per the [HTML spec](https://html.spec.whatwg.org/multipage/syntax.html#attributes-2). Browsers normalize attribute names to lowercase, so cheerio's `attr()` getter should do the same when not in XML mode.

Previously, `$el.attr('CLASS')` would return `undefined` when the attribute was stored as `\class'` by the parser. Now it correctly normalizes the lookup name to lowercase in HTML mode.

**Before:**
```js
$('<div class="apple"></div>').attr('CLASS');  // undefined
$('<div class="apple"></div>').attr('Class');  // undefined
```

**After:**
```js
$('<div class="apple"></div>').attr('CLASS');  // "apple"
$('<div class="apple"></div>').attr('Class');  // "apple"
```

## Changes
- **`src/api/attributes.ts`**: Added `name = name.toLowerCase()` normalization in the `getAttr()` function when not in XML mode
- **`src/api/attributes.spec.ts`**: Added test cases verifying case-insensitive attribute lookup for `CLASS`, `Class`, and `ID`

## Notes
- XML mode is preserved — attribute names remain case-sensitive when `xmlMode: true`
- Setting attributes (`setAttr`) is not affected since the parser already normalizes attribute names to lowercase in HTML mode
- Boolean attribute detection (`rboolean` regex) already uses case-insensitive matching (`/i` flag), so this change is consistent

Closes #581