### PR TITLE
fix: broken link fromURL → fromurl in loading.md

### DIFF
--- a/website/src/content/docs/basics/loading.md
+++ b/website/src/content/docs/basics/loading.md
@@ -149,7 +149,7 @@ const $ = await cheerio.fromURL('https://example.com');
 ```
 
 Learn more about the `fromURL` method in the
-[API documentation](/docs/api/functions/fromURL).
+[API documentation](/docs/api/functions/fromurl).
 
 ## Conclusion
 


### PR DESCRIPTION
Fixes #5237

Broken hyperlink at https://cheerio.js.org/docs/basics/loading/
The link `/docs/api/functions/fromURL` should be `/docs/api/functions/fromurl` (lowercase) as cheerio's Astro site routes are lowercase.