### PR TITLE
fix: correct fromURL link casing in loading docs

### DIFF
--- a/website/src/content/docs/basics/loading.md
+++ b/website/src/content/docs/basics/loading.md
@@ -149,7 +149,7 @@ const $ = await cheerio.fromURL('https://example.com');
 ```
 
 Learn more about the `fromURL` method in the
-[API documentation](/docs/api/functions/fromURL).
+[API documentation](/docs/api/functions/fromurl).
 
 ## Conclusion
 


### PR DESCRIPTION
## Description

Broken hyperlink on the loading docs page.

**Current URL:** `/docs/api/functions/fromURL`
**Should be:** `/docs/api/functions/fromurl`

## Related Issue

Fixes #5237