### PR TITLE
fix: case-insensitive removeAttr for HTML documents

### DIFF
--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -94,7 +94,7 @@ function getAttr(
  */
 function setAttr(el: Element, name: string, value: string | null) {
   if (value === null) {
-    removeAttribute(el, name);
+    removeAttribute(el, name, false);
   } else {
     el.attribs[name] = `${value}`;
   }
@@ -837,8 +837,18 @@ export function val<T extends AnyNode>(
  * @param elem - Node to remove attribute from.
  * @param name - Name of the attribute to remove.
  */
-function removeAttribute(elem: Element, name: string) {
-  if (!(elem.attribs && Object.hasOwn(elem.attribs, name))) return;
+function removeAttribute(
+  elem: Element,
+  name: string,
+  xmlMode?: boolean,
+) {
+  if (!(elem.attribs)) return;
+
+  if (!xmlMode) {
+    name = name.toLowerCase();
+  }
+
+  if (!Object.hasOwn(elem.attribs, name)) return;
 
   delete elem.attribs[name];
 }
@@ -881,7 +891,7 @@ export function removeAttr<T extends AnyNode>(
 
   for (const attrName of attrNames) {
     domEach(this, (elem) => {
-      if (isTag(elem)) removeAttribute(elem, attrName);
+      if (isTag(elem)) removeAttribute(elem, attrName, this.options.xmlMode);
     });
   }
 


### PR DESCRIPTION
## Description

Makes `.removeAttr()` lowercase the attribute name before removing it in non-XML mode, matching browser and jQuery behavior.

Since htmlparser2 stores all attribute names in lowercase (per HTML spec), calling `.removeAttr("CLASS")` will now correctly remove the `class` attribute.

## Changes

- `removeAttribute()` now accepts an optional `xmlMode` parameter
- When `xmlMode` is false/undefined, the attribute name is lowercased before lookup
- Updated `removeAttr()` to pass `this.options.xmlMode` to `removeAttribute()`
- Updated `setAttr()` to pass `xmlMode=false` to `removeAttribute()` when setting null values

## Related Issue

Fixes #5257