### PR TITLE
fix(attributes): preserve non-standard boolean attribute values like hidden=until-found

### DIFF
--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -63,7 +63,18 @@ function getAttr(
 
   if (Object.hasOwn(elem.attribs, name)) {
     // Get the (decoded) attribute
-    return !xmlMode && rboolean.test(name) ? name : elem.attribs[name];
+    // For boolean attributes, return the attribute name if the value is empty
+    // or equals the attribute name (standard boolean normalization).
+    // If the attribute has a non-standard value (e.g., hidden="until-found"),
+    // return the actual value.
+    if (!xmlMode && rboolean.test(name)) {
+      const value = elem.attribs[name];
+      if (value === '' || value === name) {
+        return name;
+      }
+      return value;
+    }
+    return elem.attribs[name];
   }
 
   // Mimic the DOM and return text content as value for `option's`


### PR DESCRIPTION
## Problem

When using `hidden="until-found"` (an HTML Living Standard feature), Cheerio normalizes the attribute value back to just `hidden`:

```ts
const $ = cheerio.load('<div id="test" hidden="until-found"></div>');
$('#test').attr('hidden'); // Returns "hidden", but should return "until-found"
```

This affects any boolean HTML attribute that receives a non-standard value.

## Root cause

In `src/api/attributes.ts`, the attribute getter checks if the attribute name matches a boolean attribute regex, and if so, always returns the attribute name instead of the actual value:

```ts
return !xmlMode && rboolean.test(name) ? name : elem.attribs[name];
```

## Changes

Modified the getter to check the actual attribute value. If the value is empty or matches the attribute name, the boolean normalization is preserved. If the attribute has a non-standard value (e.g., `"until-found"` for `hidden`), the actual value is returned.

## Closes

Closes #5073
