### PR TITLE
fix(attributes): .attr('value') on <option> without value attribute returns undefined

### DIFF
--- a/src/api/attributes.spec.ts
+++ b/src/api/attributes.spec.ts
@@ -194,6 +194,13 @@ describe('$(...)', () => {
       expect($xml.attr('checked')).toBe('checked');
       expect($xml.attr('disabled')).toBe('yes');
     });
+    it('(key) : should return undefined for option without value attribute', () => {
+      const $ = load(inputs);
+      // An <option> without a `value` attribute should return undefined,
+      // not the option's text content (per HTML spec / jQuery behaviour).
+      const val = $('select#one-valueless option').eq(0).attr('value');
+      expect(val).toBeUndefined();
+    });
   });
 
   describe('.prop', () => {

--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -66,11 +66,6 @@ function getAttr(
     return !xmlMode && rboolean.test(name) ? name : elem.attribs[name];
   }
 
-  // Mimic the DOM and return text content as value for `option's`
-  if (elem.name === 'option' && name === 'value') {
-    return text(elem.children);
-  }
-
   // Mimic DOM with default value for radios/checkboxes
   if (
     elem.name === 'input' &&
@@ -817,13 +812,17 @@ export function val<T extends AnyNode>(
 
       return this.attr('multiple')
         ? option.toArray().map((el) => text(el.children))
-        : option.attr('value');
+        : (option.val() as string | undefined);
     }
     case 'button':
-    case 'input':
-    case 'option': {
+    case 'input': {
       return querying
         ? this.attr('value')
+        : this.attr('value', value as string);
+    }
+    case 'option': {
+      return querying
+        ? (this.attr('value') ?? text(element.children))
         : this.attr('value', value as string);
     }
   }


### PR DESCRIPTION
Fixes #3237

## Bug

When an `<option>` element does not have an explicit `value` attribute, calling `.attr("value")` incorrectly returns the element's **text content** instead of `undefined`.

```js
const $ = cheerio.load(`<select><option>Red</option></select>`);
$("option").attr("value"); // was: "Red"  ← wrong
                            // now: undefined ✓
```

Per the [HTML spec](https://html.spec.whatwg.org/multipage/form-elements.html#concept-option-value) and [jQuery's documented behaviour](https://api.jquery.com/attr/), `.attr(name)` returns `undefined` when the attribute is absent. The text-content fallback belongs in `.val()`, not in the lower-level `getAttr()` helper.

This was introduced as part of #671 (which fixed `.val()`) but inadvertently also changed `.attr()`.

## Changes

- **`src/api/attributes.ts`** — remove the option text-content fallback from `getAttr()`.  Split the `case 'button': case 'input': case 'option':` block in `val()` so the text-content fallback (`this.attr("value") ?? text(element.children)`) applies only to `'option'`.  Use `option.val()` instead of `option.attr("value")` in the single-select branch so the fallback flows through `val()` as intended.
- **`src/api/attributes.spec.ts`** — add a regression test.

## Verification

```
npx vitest run src/api/attributes.spec.ts
# Tests  128 passed (128)  ← 127 pre-existing + 1 new

npx vitest run
# Tests  791 passed (791)
```

> AI-assisted contribution (GitHub Copilot / Claude used for code generation)
