### PR TITLE
Update repository URL metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/cheeriojs/cheerio.git"
+    "url": "git+https://github.com/cheeriojs/cheerio.git"
   },
   "funding": "https://github.com/cheeriojs/cheerio?sponsor=1",
   "license": "MIT",


### PR DESCRIPTION
Summary:
- update the package repository URL from the legacy `git://` protocol to `git+https://`
- keep the existing bugs URL, homepage, and license metadata unchanged

Validation:
- fetched `package.json` from the default branch and parsed it as JSON
- asserted `repository.url` is `git+https://github.com/cheeriojs/cheerio.git`
- asserted `bugs.url` remains `https://github.com/cheeriojs/cheerio/issues`
- asserted `homepage` remains `https://cheerio.js.org/`