### PR TITLE
fix(attributes): match select option by value comparison in val() setter

### DIFF
--- a/src/api/attributes.spec.ts
+++ b/src/api/attributes.spec.ts
@@ -736,6 +736,27 @@ describe('$(...)', () => {
       const element = $('select#one option').eq(0).val('option_changed');
       expect(element.val()).toBe('option_changed');
     });
+    it('(value): on select should select option with a double quote in its value', () => {
+      const $select = load(
+        '<select><option value="a">a</option><option value="a&quot;b">quote</option></select>',
+      )('select');
+      expect(() => $select.val('a"b')).not.toThrow();
+      expect($select.val()).toBe('a"b');
+    });
+    it('(value): on select should select option with a backslash in its value', () => {
+      const $select = load(
+        String.raw`<select><option value="a">a</option><option value="a\b">backslash</option></select>`,
+      )('select');
+      $select.val(String.raw`a\b`);
+      expect($select.val()).toBe(String.raw`a\b`);
+    });
+    it('(value): on select should select a valueless option by its text', () => {
+      const $select = load(
+        '<select><option>first</option><option>second</option></select>',
+      )('select');
+      $select.val('second');
+      expect($select.val()).toBe('second');
+    });
     it('(value): on radio should set value', () => {
       const element = $('input[name="radio"]').val('off');
       expect(element.val()).toBe('off');

--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -805,11 +805,21 @@ export function val<T extends AnyNode>(
           return this;
         }
 
-        this.find('option').removeAttr('selected');
+        const options = this.find('option');
+        options.removeAttr('selected');
 
         const values = typeof value === 'object' ? value : [value];
-        for (const val of values) {
-          this.find(`option[value="${val}"]`).attr('selected', '');
+        for (const el of options) {
+          /*
+           * Resolve an option's value the same way the getter does: the
+           * `value` attribute, falling back to its text content. Compare
+           * directly instead of building a selector, so values containing
+           * characters such as `"` or `\` are matched literally.
+           */
+          const optionValue = el.attribs['value'] ?? text(el.children);
+          if (values.includes(optionValue)) {
+            el.attribs['selected'] = '';
+          }
         }
 
         return this;


### PR DESCRIPTION
The `.val(value)` setter on a `<select>` builds a CSS selector by interpolating the value unescaped:

```ts
this.find(`option[value="${val}"]`).attr("selected", "");
```

## Repro

```js
const $ = cheerio.load(
  `<select><option value="a">a</option><option value="a&quot;b">quote</option></select>`,
);

$("select").val(`a"b`);
// throws: Error: Attribute selector didn't terminate
```

```js
const $ = cheerio.load(
  String.raw`<select><option value="a">a</option><option value="a\b">backslash</option></select>`,
);

$("select").val(String.raw`a\b`);
$("select").val(); //=> "a"  (nothing selected: the backslash is consumed as a CSS escape)
```

## jQuery parity

cheerio's `val()` docstring links to https://api.jquery.com/val/. jQuery's `.val(value)` selects options by comparing the value directly, with no character restrictions, and never throws. The two cases above are a parity deviation.

## Root cause

The value is concatenated straight into an attribute selector, so any value containing `"` breaks the selector grammar, and any value containing `\` is reinterpreted as a CSS escape sequence rather than a literal character.

## Fix

Resolve each option's value the same way the getter does (the `value` attribute, falling back to its text content) and compare it directly to the target value, instead of building a selector. This also lets valueless options be selected by their text content, matching how the getter already reads them.

```ts
const options = this.find("option");
options.removeAttr("selected");

const values = typeof value === "object" ? value : [value];
for (const el of options) {
  const optionValue = el.attribs["value"] ?? text(el.children);
  if (values.includes(optionValue)) {
    el.attribs["selected"] = "";
  }
}
```

## Tests

Added three cases to `src/api/attributes.spec.ts` that fail on `main` and pass with the fix: selecting an option whose value contains `"`, selecting one whose value contains `\`, and selecting a valueless option by its text. Full suite green (793 passing, no type errors).