### PR TITLE
fix(website): lowercase API doc links for case-sensitive hosting

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -5,6 +5,7 @@ import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'astro/config';
 import remarkDirective from 'remark-directive';
 import { rehypeExternalLinks } from './src/plugins/rehype-external-links.ts';
+import { rehypeFixTypedocLinks } from './src/plugins/rehype-fix-typedoc-links.ts';
 import { remarkAdmonitions } from './src/plugins/remark-admonitions.ts';
 import { remarkFixTypedocLinks } from './src/plugins/remark-fix-typedoc-links.ts';
 import { remarkLiveCode } from './src/plugins/remark-live-code.ts';
@@ -30,6 +31,6 @@ export default defineConfig({
       remarkFixTypedocLinks,
       remarkLiveCode,
     ],
-    rehypePlugins: [rehypeExternalLinks],
+    rehypePlugins: [rehypeFixTypedocLinks, rehypeExternalLinks],
   },
 });

--- a/website/src/plugins/normalize-api-doc-link.ts
+++ b/website/src/plugins/normalize-api-doc-link.ts
@@ -1,0 +1,12 @@
+const markdownExtensionRe = /\.md$/;
+
+/** Normalize internal API doc URLs for case-sensitive static hosting. */
+export function normalizeApiDocLink(url: string): string | null {
+  if (!url.startsWith('/docs/api/')) {
+    return null;
+  }
+
+  const [path, hash] = url.split('#');
+  const normalizedPath = path.replace(markdownExtensionRe, '').toLowerCase();
+  return hash ? `${normalizedPath}#${hash}` : normalizedPath;
+}

--- a/website/src/plugins/rehype-fix-typedoc-links.ts
+++ b/website/src/plugins/rehype-fix-typedoc-links.ts
@@ -1,0 +1,28 @@
+import type { Element, Root } from 'hast';
+import { visit } from 'unist-util-visit';
+import { normalizeApiDocLink } from './normalize-api-doc-link.ts';
+
+function visitTypedocLink(node: Element): void {
+  if (node.tagName !== 'a' || typeof node.properties?.href !== 'string') {
+    return;
+  }
+
+  const normalized = normalizeApiDocLink(node.properties.href);
+  if (normalized) {
+    node.properties.href = normalized;
+  }
+}
+
+function transformer(tree: Root): void {
+  visit(tree, 'element', visitTypedocLink);
+}
+
+/**
+ * Rehype plugin to fix typedoc-generated links in rendered HTML (including GFM
+ * tables). Removes .md extension and lowercases paths in internal API doc links.
+ *
+ * @returns A transformer function.
+ */
+export function rehypeFixTypedocLinks() {
+  return transformer;
+}

--- a/website/src/plugins/remark-fix-typedoc-links.ts
+++ b/website/src/plugins/remark-fix-typedoc-links.ts
@@ -1,12 +1,13 @@
 import type { Link, Root } from 'mdast';
 import { visit } from 'unist-util-visit';
-
-const markdownExtensionRe = /\.md$/;
+import { normalizeApiDocLink } from './normalize-api-doc-link.ts';
 
 function visitTypedocLink(node: Link): void {
-  if (typeof node.url === 'string' && node.url.startsWith('/docs/api/')) {
-    // Remove .md extension from API doc links
-    node.url = node.url.replace(markdownExtensionRe, '');
+  if (typeof node.url === 'string') {
+    const normalized = normalizeApiDocLink(node.url);
+    if (normalized) {
+      node.url = normalized;
+    }
   }
 }
 
@@ -15,8 +16,8 @@ function transformer(tree: Root): void {
 }
 
 /**
- * Remark plugin to fix typedoc-generated links. Removes .md extension from
- * internal API doc links.
+ * Remark plugin to fix typedoc-generated links. Removes .md extension and
+ * lowercases paths in internal API doc links.
  *
  * @returns A transformer function.
  */


### PR DESCRIPTION
## Issue
TypeDoc-generated API docs link to mixed-case paths such as `/docs/api/interfaces/CheerioAPI`, but Astro serves lowercase routes at `/docs/api/interfaces/cheerioapi/`. On case-sensitive static hosting, those internal links returns with 404.

```md
[`CheerioRequestOptions`](/docs/api/interfaces/CheerioRequestOptions.md)
```

## Repro

Open https://cheerio.js.org/docs/api/functions/fromurl and click `CheerioRequestOptions` in the parameters table — the link goes to `/docs/api/interfaces/CheerioRequestOptions` and returns **404**.

```bash
curl -sI https://cheerio.js.org/docs/api/interfaces/CheerioRequestOptions | head -1
# HTTP/2 404

curl -sI https://cheerio.js.org/docs/api/interfaces/cheerioapi | head -1
# HTTP/2 301
```

The same links often work locally on macOS because the filesystem is case-insensitive, which hides the bug during `astro preview`.

## Root cause

TypeDoc preserves TypeScript symbol casing in generated markdown links. Astro's content collection lowercases slugs when building static routes. The existing remark plugin only stripped `.md` extensions and did not lowercase paths. It also runs before GFM table parsing, so links inside TypeDoc parameter tables were left unchanged.

## Fix

Extract a shared normalizer and apply it in both remark and rehype stages. Lowercase `/docs/api/` paths and strip `.md` extensions while preserving hash fragments.

```ts
export function normalizeApiDocLink(url: string): string | null {
  if (!url.startsWith('/docs/api/')) {
    return null;
  }

  const [path, hash] = url.split('#');
  const normalizedPath = path.replace(/\.md$/, '').toLowerCase();
  return hash ? `${normalizedPath}#${hash}` : normalizedPath;
}
```

The remark plugin fixes guide pages and standard markdown links. The rehype plugin fixes links rendered from TypeDoc GFM tables.

Fixes #5303

## Tests

- `cd website && npm run build`
- `grep -roh 'href="/docs/api/[^"]*[A-Z]' dist --include='*.html' | wc -l` → `0`
- Verified `/docs/api/functions/fromurl` links resolve (e.g. `CheerioRequestOptions`, `CheerioAPI`)
- Verified guide page links on `/docs/basics/traversing` resolve (e.g. `/docs/api/classes/cheerio#find`)