### PR TITLE
fix(website): make docs TOC scrollable when it overflows

### DIFF
--- a/website/src/components/TableOfContents.astro
+++ b/website/src/components/TableOfContents.astro
@@ -15,7 +15,7 @@ const toc = headings.filter((h) => h.depth >= 2 && h.depth <= 3);
 
 {toc.length > 0 && (
   <nav class="hidden xl:block w-56 shrink-0 pl-6 pt-4">
-    <div class="sticky top-20">
+    <div class="sticky top-20 h-[calc(100vh-5rem)] overflow-y-auto">
       <h4 class="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
         On this page
       </h4>


### PR DESCRIPTION
## Summary
- Fixes the sticky "On this page" TOC so long docs pages (for example the Cheerio API class page) can scroll the TOC inside the viewport instead of requiring a full-page scroll.
- Matches the existing sidebar pattern: constrain height with `h-[calc(100vh-5rem)]` and enable `overflow-y-auto` on the sticky container.

Closes #5302

## Test plan
- [ ] Open a long docs page such as https://cheerio.js.org/docs/api/classes/cheerio/ (or local `website` build equivalent)
- [ ] At xl breakpoint, confirm the TOC is sticky below the navbar
- [ ] Confirm overflowing TOC entries are reachable via TOC scrollbar without scrolling the whole page
- [ ] Confirm short-page TOCs still look unchanged