### PR TITLE
fix(static): let $.html() keep the instance parser mode

### DIFF
--- a/src/static.spec.ts
+++ b/src/static.spec.ts
@@ -40,6 +40,17 @@ describe('cheerio', () => {
       expect(cheerio.html($collection)).toBe(expected);
     });
 
+    it('(<opts>) : keeps using the instance parser when serializing', () => {
+      // An htmlparser2-backed instance, rendered as HTML rather than XML.
+      const $ = cheerio.load('<style>a < b && c > d</style><p>x<br>y</p>', {
+        xmlMode: true,
+      });
+
+      expect($.html(undefined as never, { xmlMode: false })).toBe(
+        '<style>a < b && c > d</style><p>x<br>y</p>',
+      );
+    });
+
     it('() : does not crash with `null` as `this` value', () => {
       const { html } = cheerio;
       expect(html.call(null as never)).toBe('');

--- a/src/static.spec.ts
+++ b/src/static.spec.ts
@@ -46,7 +46,7 @@ describe('cheerio', () => {
         xmlMode: true,
       });
 
-      expect($.html(undefined as never, { xmlMode: false })).toBe(
+      expect($.html(undefined, { xmlMode: false })).toBe(
         '<style>a < b && c > d</style><p>x<br>y</p>',
       );
     });

--- a/src/static.ts
+++ b/src/static.ts
@@ -86,10 +86,7 @@ export function html(
    * Sometimes `$.html()` is used without preloading html,
    * so fallback non-existing options to the default ones.
    */
-  const opts = {
-    ...this?._options,
-    ...flattenOptions(options),
-  };
+  const opts = flattenOptions(options, this?._options);
 
   return render(this, toRender, opts);
 }


### PR DESCRIPTION
`html()` built its options as `{ ...this._options, ...flattenOptions(options) }`. `flattenOptions(undefined)` returns the module-level defaults, which carry `_useHtmlParser2: false`, so the spread overwrote the instance's parser flag and an htmlparser2-backed instance serialized through parse5. Raw text was entity-escaped and void elements gained closing tags:

```js
const $ = cheerio.load('<style>a < b && c > d</style><p>x<br>y</p>', { xmlMode: true });
$.html(undefined, { xmlMode: false });
// before: <style>a &lt; b &amp;&amp; c &gt; d</style><p>x<br>y</br></p>
// after:  <style>a < b && c > d</style><p>x<br>y</p>
```

The fix passes the instance options as the base instead, which is what `flattenOptions` takes its second argument for. `flattenOptions(undefined, undefined)` still returns the defaults, so the `html.call(null)` path is unchanged.

Found while investigating GHSA-4q36-8g63-3r78. It also explains the reporter's observation there: the difference they attributed to a `dom-serializer` "detached parent" was this option-flattening bug selecting the wrong serializer.

The new test fails on the current `static.ts` and passes with the fix. Full suite green, no type errors.

Not a security issue: output corruption, no boundary crossed.

Written by Claude Fable.