### PR TITLE
perf(traversing): keep closest() dedup and map() accumulation linear

### DIFF
--- a/src/api/traversing.spec.ts
+++ b/src/api/traversing.spec.ts
@@ -833,6 +833,43 @@ describe('$(...)', () => {
       const result = textNode.closest('#food') as Cheerio<Element>;
       expect(result[0].attribs).toHaveProperty('id', 'food');
     });
+
+    it('(fn) : should dedupe in linear time (no O(n^2) membership scan)', () => {
+      /*
+       * N distinct matches: pre-fix `set.includes` scans a growing array,
+       * giving sum(0..N-1) = O(N^2) comparisons. The fix upgrades to a Set.
+       */
+      const N = 2000;
+      const $big = load(
+        `<div>${'<div class="t"><span></span></div>'.repeat(N)}</div>`,
+      );
+      const spans = $big('span');
+      expect(spans).toHaveLength(N);
+
+      const origIncludes = Array.prototype.includes;
+      let includesWork = 0;
+      Array.prototype.includes = function (this: unknown[], ...args) {
+        includesWork += this.length;
+        return origIncludes.apply(this, args as [unknown]);
+      };
+      let result: Cheerio<AnyNode>;
+      try {
+        /*
+         * A predicate selector avoids css-select internals, so the only
+         * Array#includes in play is the dedup scan under test.
+         */
+        result = spans.closest((_i, el) => el.name === 'div');
+      } finally {
+        Array.prototype.includes = origIncludes;
+      }
+
+      expect(result).toHaveLength(N);
+      /*
+       * Fixed: 5050, the scans that happen before the Set upgrade at 100
+       * entries. Pre-fix: N*(N-1)/2, about 2M for N=2000.
+       */
+      expect(includesWork).toBeLessThan(N * 10);
+    });
   });
 
   describe('.each', () => {
@@ -934,6 +971,34 @@ describe('$(...)', () => {
         null,
         undefined,
       ]);
+    });
+
+    it('(fn) : should accumulate in linear time (no O(n^2) concat copies)', () => {
+      /*
+       * Pre-fix `elems = elems.concat(val)` copies the whole accumulator each
+       * iteration, giving sum(0..N-1) = O(N^2) work. The fix uses `push`.
+       */
+      const N = 4000;
+      const $big = load('<div></div>'.repeat(N));
+      const sel = $big('div');
+      expect(sel).toHaveLength(N);
+
+      const origConcat = Array.prototype.concat;
+      let concatWork = 0;
+      Array.prototype.concat = function (this: unknown[], ...args) {
+        concatWork += this.length;
+        return origConcat.apply(this, args) as unknown[];
+      };
+      let mapped: Cheerio<Element>;
+      try {
+        mapped = sel.map((_i, el) => el);
+      } finally {
+        Array.prototype.concat = origConcat;
+      }
+
+      expect(mapped).toHaveLength(N);
+      // Fixed: 0, as `push` replaces `concat`. Pre-fix: about 8M for N=4000.
+      expect(concatWork).toBeLessThan(N * 10);
     });
   });
 

--- a/src/api/traversing.ts
+++ b/src/api/traversing.ts
@@ -353,6 +353,15 @@ export function closest<T extends AnyNode>(
       ? (elem: Element) => select.is(elem, selector, selectOpts)
       : getFilterFn(selector);
 
+  /*
+   * Dedup: a linear scan is cheapest for the small result sets `closest`
+   * usually produces. Once the set grows past `dedupThreshold` we switch to a
+   * Set, so a pathological input with many distinct matches stays O(n) instead
+   * of O(n^2). `set` always preserves document order.
+   */
+  const dedupThreshold = 100;
+  let seen: Set<AnyNode> | undefined;
+
   domEach(this, (elem: AnyNode | null) => {
     if (elem && !isDocument(elem) && !isTag(elem)) {
       elem = elem.parent;
@@ -360,8 +369,13 @@ export function closest<T extends AnyNode>(
     while (elem && isTag(elem)) {
       if (selectFn(elem, 0)) {
         // Do not add duplicate elements to the set
-        if (!set.includes(elem)) {
+        if (seen ? !seen.has(elem) : !set.includes(elem)) {
           set.push(elem);
+          if (seen) {
+            seen.add(elem);
+          } else if (set.length > dedupThreshold) {
+            seen = new Set(set);
+          }
         }
         break;
       }
@@ -670,13 +684,20 @@ export function map<T, M>(
   this: Cheerio<T>,
   fn: (this: T, i: number, el: T) => M[] | M | null | undefined,
 ): Cheerio<M> {
-  let elems: M[] = [];
+  const elems: M[] = [];
   for (let i = 0; i < this.length; i++) {
     const el = this[i];
     const val = fn.call(el, i, el);
     if (val != null) {
-      // eslint-disable-next-line unicorn/prefer-spread
-      elems = elems.concat(val);
+      /*
+       * Accumulate in place; `concat` would copy the whole array each
+       * iteration, making this O(n^2) in the size of the collection.
+       */
+      if (Array.isArray(val)) {
+        for (let j = 0; j < val.length; j++) elems.push(val[j]);
+      } else {
+        elems.push(val);
+      }
     }
   }
   return this._make(elems);


### PR DESCRIPTION
Two quadratic accumulation paths, found while auditing for asymmetric cost.

### `closest()`

The duplicate guard was `set.includes(elem)`, a scan of a growing array. When each element in the collection resolves to a *distinct* ancestor the result set grows to `n` and the running scan cost is `n(n-1)/2`.

Keeping a plain `Set` from the start regresses the common case: the allocation and per-node hashing are paid on every call regardless of result size, measured at +4–7% on ordinary collections (function selectors and shallow matches expose it; it only disappears when css-select matching dominates the call). So this keeps the array scan for the small result sets `closest` normally yields and upgrades to a `Set` once the set passes 100 entries. `set` still carries document order, so ordering and dedup semantics are unchanged.

| N distinct matches | before | after |
|---|---|---|
| 16k | 31.8 ms | 4.7 ms |
| 32k | 126.5 ms | 7.5 ms |
| 64k | 467.2 ms | 13.6 ms |

Ordinary 50-element call: 4770 ns → 4780 ns (+0.2%, noise).

### `map()`

The accumulator was rebuilt every iteration with `elems = elems.concat(val)`, copying the whole array each time. Push instead, spreading array return values with a loop to preserve `concat`'s one-level flatten — including its treatment of `null`/`undefined` members, which the existing tests cover.

| N | before | after |
|---|---|---|
| 5k | 41.3 ms | 0.14 ms |
| 20k | 686.1 ms | 0.44 ms |
| 40k | 2971.1 ms | 0.94 ms |

Ordinary 50-element map is ~12x faster, since `push` is strictly cheaper than `concat`.

The one behavioural difference from `concat` is that it also spreads non-array objects carrying `Symbol.isConcatSpreadable`, which `Array.isArray` does not. The callback's return type is `M[] | M | null | undefined`, so that isn't a value the public API can produce.

### Tests

Both regression tests assert operation counts rather than timings. Against the current source they fail with `expected 1999000 to be less than 20000` and `expected 7998000 to be less than 40000`. Full suite green, no type errors.

Neither is a security issue: both need the application to run these APIs over a very large collection, not merely to parse markup.

Written by Claude Fable 5.