### PR TITLE
build(deps-dev): adopt @feedic/eslint-config 0.5

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -66,6 +66,93 @@ export default defineConfig(
       'unicorn/no-useless-undefined': 0,
       'unicorn/prefer-array-find': 0,
       'unicorn/prevent-abbreviations': 0,
+
+      /*
+       * Rules that do not fit how cheerio is built. These are off for good,
+       * not pending work.
+       */
+
+      /*
+       * Cheerio's API is `this`-bound: every method in `src/api` is called
+       * with the Cheerio instance as `this` and mixed onto the prototype by
+       * `Object.assign`. 257 reports, none actionable.
+       */
+      'unicorn/no-this-outside-of-class': 0,
+      /*
+       * Fires on cheerio's own traversal methods (`.parent()`, `.closest()`,
+       * `.children()`), suggesting DOM APIs that do not exist here.
+       */
+      'unicorn/better-dom-traversing': 0,
+      /*
+       * `_root`, `_make`, `_parse` and `_render` are documented API, so they
+       * cannot become `#private`.
+       */
+      'unicorn/prefer-private-class-fields': 0,
+      /*
+       * The prototype assignment in `src/cheerio.ts` is how the API is
+       * composed; it is the module's purpose, not an accident.
+       */
+      'unicorn/no-top-level-side-effects': 0,
+      /*
+       * Reports dynamic keys that callers supply themselves (`extract()`
+       * schema keys, `css()` property names) and land on local result
+       * objects. There is no static key to switch to.
+       */
+      'unicorn/no-unsafe-property-key': 0,
+      /*
+       * `name in el` mirrors jQuery's `.prop()`, which also reflects
+       * inherited members; `i in item` is the sparse-array check in
+       * `isArrayLike`. Both are deliberate.
+       */
+      'unicorn/no-computed-property-existence-check': 0,
+      /*
+       * Both read `Cheerio.prototype.toArray()` as `Iterator#toArray()`. It
+       * returns a plain array, so the suggested rewrites call `.flatMap()` on
+       * a Cheerio instance and `.toArray()` on an array — neither exists.
+       */
+      'unicorn/prefer-iterator-to-array-at-end': 0,
+      'unicorn/no-useless-iterator-to-array': 0,
+      /*
+       * The reported `${value}` wrappers coerce arguments at the API
+       * boundary, where the types say `string` but JavaScript callers pass
+       * numbers: `attr('width', 100)` has to store `"100"`, and `text(42)`
+       * has to render `42`. Verified against all four sites.
+       */
+      'unicorn/no-useless-template-literals': 0,
+      /*
+       * Directly contradicts Biome's `useNumberNamespace`, which this repo
+       * turns on and which rewrites `Infinity` back to
+       * `Number.POSITIVE_INFINITY`. `eslint-config-biome` does not yet know
+       * about this rule, so disable it here to stop the two formatters from
+       * undoing each other.
+       */
+      'unicorn/prefer-global-number-constants': 0,
+
+      /*
+       * TODO: rules that only need renames. Each is mechanical but touches
+       * hundreds of lines, so they are better done on their own.
+       */
+
+      /*
+       * TODO(rename): 548 reports — `i` -> `index`, `str` -> `string_`,
+       * `ret` -> `returnValue`, `el` -> `element`, `arr` -> `array`.
+       */
+      'unicorn/name-replacements': 0,
+      /*
+       * TODO(rename): 25 reports — booleans wanting an `is`/`has`/`should`
+       * prefix, e.g. `cheerioOnly`, `removeAll`.
+       */
+      'unicorn/consistent-boolean-name': 0,
+      /*
+       * TODO(rename): 2 reports — the locals `setClass` and `removeAll` in
+       * `src/api/attributes.ts` read as verbs but hold a string and a boolean.
+       */
+      'unicorn/no-non-function-verb-prefix': 0,
+      /*
+       * TODO(rename): 3 reports — `__fixtures__` and `__tests__` follow the
+       * test-runner convention rather than kebab-case.
+       */
+      'unicorn/filename-case': 0,
     },
   },
 
@@ -98,6 +185,24 @@ export default defineConfig(
       // Assuming "recommended" is the flat config equivalent for "legacy-recommended"
       ...eslintPluginVitest.configs.recommended.rules,
       'n/no-unpublished-import': 0, // Allow importing devDependencies
+      /*
+       * The `http://` URLs here are fixture data for `attr()`/`css()` and XML
+       * namespace URIs, which are identifiers rather than links to follow.
+       */
+      'unicorn/prefer-https': 0,
+      /*
+       * Reports cheerio's own `.find()` and `.map()`, which tests call for a
+       * thrown error or for the callback's side effects.
+       */
+      'unicorn/no-unused-array-method-return': 0,
+    },
+  },
+
+  // This file is not published, so it is not bound by the `engines` range.
+  {
+    files: ['eslint.config.js'],
+    rules: {
+      'n/no-unsupported-features/node-builtins': 0,
     },
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.12",
         "@eslint/compat": "^2.0.5",
-        "@feedic/eslint-config": "^0.3.1",
+        "@feedic/eslint-config": "^0.5.0",
         "@imgix/js-core": "^3.8.0",
         "@octokit/graphql": "^9.0.3",
         "@types/jsdom": "^28.0.1",
@@ -32,7 +32,7 @@
         "@types/whatwg-mimetype": "^5.0.0",
         "@vitest/coverage-v8": "^4.1.4",
         "@vitest/eslint-plugin": "^1.6.16",
-        "eslint": "^10.2.0",
+        "eslint": "^10.8.0",
         "eslint-config-biome": "^2.1.3",
         "globals": "^17.5.0",
         "husky": "^9.1.7",
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@altano/repository-tools": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@altano/repository-tools/-/repository-tools-2.0.1.tgz",
-      "integrity": "sha512-YE/52CkFtb+YtHPgbWPai7oo5N9AKnMuP5LM+i2AG7G1H2jdYBCO1iDnkDE3dZ3C1MIgckaF+d5PNRulgt0bdw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@altano/repository-tools/-/repository-tools-2.0.3.tgz",
+      "integrity": "sha512-cSR/ZYDF6Wp9OeAJMyLYYN1GenAAhV17W+w38ELP+3c5Ltsy9jkkCymi33nz/qnXyef3n6Fbr1h2yt3dvUN5sQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -111,9 +111,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -511,20 +511,34 @@
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.84.0.tgz",
-      "integrity": "sha512-0xew1CxOam0gV5OMjh2KjFQZsKL2bByX1+q4j3E73MpYIdyUxcZb/xQct9ccUb+ve5KGUYbCUxyPnYB7RbuP+w==",
+      "version": "0.91.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.91.0.tgz",
+      "integrity": "sha512-vgqlMGNNhZxwDYbUNIHj3Hskb4R28iqdXx90ufHyt/NeuTQkeqjTDslAs9I0/GCAfbxP5BpH5WsL1R1fht5Lxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "^1.0.8",
-        "@typescript-eslint/types": "^8.54.0",
-        "comment-parser": "1.4.5",
+        "@types/estree": "^1.0.9",
+        "@typescript-eslint/types": "^8.65.0",
+        "comment-parser": "1.4.7",
         "esquery": "^1.7.0",
-        "jsdoc-type-pratt-parser": "~7.1.1"
+        "jsdoc-type-pratt-parser": "~8.0.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment/node_modules/@typescript-eslint/types": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@es-joy/resolve.exports": {
@@ -1045,9 +1059,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1102,9 +1116,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
-      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1134,30 +1148,24 @@
       }
     },
     "node_modules/@feedic/eslint-config": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@feedic/eslint-config/-/eslint-config-0.3.1.tgz",
-      "integrity": "sha512-CBDfjWp629dQs4IaZVsQdeMVN2lPyKSVaitxnr/Vb5wz7lXwGX0h9h4Rn9nQ4O5OdgK4KIxftlD+4AnDdZfNpw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@feedic/eslint-config/-/eslint-config-0.5.0.tgz",
+      "integrity": "sha512-j3rj0vDAGJ/FpgYKiHgrknWx2vEzdIvTcE6/jCWsYmCI8YV6Mpkn9gzpmkBsomQ4XgiDXD6nQeaz0m83I9oGog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint/js": "^10.0.1",
-        "eslint-plugin-jsdoc": "^62.8.0",
-        "eslint-plugin-n": "^17.24.0",
-        "eslint-plugin-package-json": "^0.90.1",
-        "eslint-plugin-unicorn": "^63.0.0",
-        "globals": "^17.4.0"
+        "eslint-plugin-jsdoc": "^63.0.7",
+        "eslint-plugin-n": "^18.1.0",
+        "eslint-plugin-package-json": "^1.5.0",
+        "eslint-plugin-unicorn": "^68.0.0",
+        "globals": "^17.7.0"
       },
       "engines": {
         "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "eslint": "^10.0.0",
-        "typescript-eslint": "^8.56.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript-eslint": {
-          "optional": true
-        }
+        "eslint": "^10.3.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1689,9 +1697,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2430,9 +2438,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.6.tgz",
+      "integrity": "sha512-69D/imtToCsIcAl8WBS2YaRwA4jO/j0HhU+hELqMEu9f54MoUtI6+XH5mrKU8rEFNEk/Ui1I2MK4/JkWacclGw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2466,22 +2474,22 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "dev": true,
       "funding": [
         {
@@ -2499,11 +2507,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2513,9 +2521,9 @@
       }
     },
     "node_modules/builtin-modules": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.0.0.tgz",
-      "integrity": "sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.3.0.tgz",
+      "integrity": "sha512-hMQUl2bUFG339QygPM97E+mc8OY1IAchORZxm4a/frcYwKzozMzRVDBwHW0NjOqGElLm2O37AVQE8ikxlZHrMQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2526,9 +2534,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001777",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz",
-      "integrity": "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true,
       "funding": [
         {
@@ -2660,29 +2668,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/clean-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
-      "integrity": "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/clean-regexp/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -2734,9 +2719,9 @@
       }
     },
     "node_modules/comment-parser": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.5.tgz",
-      "integrity": "sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.7.tgz",
+      "integrity": "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2751,9 +2736,9 @@
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
-      "version": "3.48.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.48.0.tgz",
-      "integrity": "sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+      "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3086,9 +3071,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.307",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
-      "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
+      "version": "1.5.398",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.398.tgz",
+      "integrity": "sha512-AsvhAxopJGh6museTDMIjn6JpDYOfgu4RLlygomt87MUwBUqTfd/1EiPtx10/LZE8xpTvkP2E9Gafq7lkLtodQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -3113,14 +3098,14 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
-      "integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
+      "version": "5.24.4",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.4.tgz",
+      "integrity": "sha512-GVoi+ICHocoOIU7qVVM48wOJziRsqrsyqlI0Ce0LdowRn6v3bcH2zUa9kp85ncx0nwIb9/HOCOLS3fdThDG/XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -3224,18 +3209,21 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
-      "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.4",
-        "@eslint/config-helpers": "^0.5.4",
-        "@eslint/core": "^1.2.0",
-        "@eslint/plugin-kit": "^0.7.0",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.7.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -3257,7 +3245,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -3303,9 +3291,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-fix-utils": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-fix-utils/-/eslint-fix-utils-0.4.2.tgz",
-      "integrity": "sha512-n7ZTcwwkP5scedlhvWMcqxED+O1NzXcj5Rxn/0kJQMP88k02vRcBfQ1qsk/JHb6Aw8bajFoetFCCBiNIcNCsvA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-fix-utils/-/eslint-fix-utils-0.4.3.tgz",
+      "integrity": "sha512-EKzNhsNavV5DdkHVltHBM9TqfsonCmiUhOm1Ra97zo03M9IAx3wtM1eC27eWGMj/D3LrALmHHNe1QlQH1P7Nxw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3317,6 +3305,28 @@
       },
       "peerDependenciesMeta": {
         "@types/estree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-json-compat-utils": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-json-compat-utils/-/eslint-json-compat-utils-0.2.3.tgz",
+      "integrity": "sha512-RbBmDFyu7FqnjE8F0ZxPNzx5UaptdeS9Uu50r7A+D7s/+FCX+ybiyViYEgFUaFIFqSWJgZRTpL5d8Kanxxl2lQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esquery": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "jsonc-eslint-parser": "^2.4.0 || ^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@eslint/json": {
           "optional": true
         }
       }
@@ -3344,38 +3354,38 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "62.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.8.0.tgz",
-      "integrity": "sha512-hu3r9/6JBmPG6wTcqtYzgZAnjEG2eqRUATfkFscokESg1VDxZM21ZaMire0KjeMwfj+SXvgB4Rvh5LBuesj92w==",
+      "version": "63.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.3.2.tgz",
+      "integrity": "sha512-5B3oO23iqbNJC/ru7uqIY80wmY66De1Q0+5kXQGHuLrGze/rL0Zw/YktMcqgYQ+kdHmgvY1q5TpRgl3yZMLmhQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.84.0",
+        "@es-joy/jsdoccomment": "~0.91.0",
         "@es-joy/resolve.exports": "1.2.0",
         "are-docs-informative": "^0.0.2",
-        "comment-parser": "1.4.5",
+        "comment-parser": "1.4.7",
         "debug": "^4.4.3",
         "escape-string-regexp": "^4.0.0",
-        "espree": "^11.1.0",
+        "espree": "^11.2.0",
         "esquery": "^1.7.0",
         "html-entities": "^2.6.0",
-        "object-deep-merge": "^2.0.0",
+        "object-deep-merge": "^2.0.1",
         "parse-imports-exports": "^0.2.4",
-        "semver": "^7.7.4",
-        "spdx-expression-parse": "^4.0.0",
+        "semver": "^7.8.5",
+        "spdx-expression-parse": "^5.0.0",
         "to-valid-identifier": "^1.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^22.13.0 || >=24"
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-n": {
-      "version": "17.24.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.24.0.tgz",
-      "integrity": "sha512-/gC7/KAYmfNnPNOb3eu8vw+TdVnV0zhdQwexsw6FLXbhzroVj20vRn2qL8lDWDGnAQ2J8DhdfvXxX9EoxvERvw==",
+      "version": "18.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-18.2.2.tgz",
+      "integrity": "sha512-gOO0lIqwEjZ750kv9/SptCWArUoAZXJoBr0vYWTO2dCBxctHUXlBIigiC8xuxxr/NKqgIT6Ehz1xRcilj8a5cA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3386,17 +3396,26 @@
         "globals": "^15.11.0",
         "globrex": "^0.1.2",
         "ignore": "^5.3.2",
-        "semver": "^7.6.3",
-        "ts-declaration-location": "^1.0.6"
+        "semver": "^7.6.3"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       },
       "peerDependencies": {
-        "eslint": ">=8.23.0"
+        "eslint": ">=8.57.1",
+        "ts-declaration-location": "^1.0.6",
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ts-declaration-location": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-n/node_modules/globals": {
@@ -3413,76 +3432,70 @@
       }
     },
     "node_modules/eslint-plugin-package-json": {
-      "version": "0.90.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-package-json/-/eslint-plugin-package-json-0.90.1.tgz",
-      "integrity": "sha512-6GU2nyjGZ+iSLIo1Qxm6O2HcPKshpjIS3B5ZeBTt8spGad5IQ45+hQUDrULYP0vD6SFT8veJfQ/Ha49/g4Cr5w==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-package-json/-/eslint-plugin-package-json-1.6.2.tgz",
+      "integrity": "sha512-Zp0CdqXKQqB9luUYa/TOwnGq3VlLotx1UDflZOzEt3D5A5kxu3Lj1VFJ087jKudEhc+K3kF20XV/aKZAlDuslw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@altano/repository-tools": "^2.0.1",
+        "@types/estree": "^1.0.0",
         "change-case": "^5.4.4",
         "detect-indent": "^7.0.2",
         "detect-newline": "^4.0.1",
-        "eslint-fix-utils": "~0.4.1",
-        "package-json-validator": "^1.2.1",
+        "eslint-fix-utils": "~0.4.3",
+        "eslint-json-compat-utils": "^0.2.3",
+        "jsonc-eslint-parser": "^3.1.0",
+        "package-json-validator": "^1.5.0",
         "semver": "^7.7.3",
         "sort-object-keys": "^2.0.0",
-        "sort-package-json": "^3.4.0",
-        "validate-npm-package-name": "^7.0.0"
+        "sort-package-json": "^4.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": "^22.22.2 || >=24.15.0"
       },
       "peerDependencies": {
-        "eslint": ">=8.0.0",
-        "jsonc-eslint-parser": ">=2.0.0"
+        "@eslint/json": ">=1.0.0",
+        "eslint": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@eslint/json": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-unicorn": {
-      "version": "63.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-63.0.0.tgz",
-      "integrity": "sha512-Iqecl9118uQEXYh7adylgEmGfkn5es3/mlQTLLkd4pXkIk9CTGrAbeUux+YljSa2ohXCBmQQ0+Ej1kZaFgcfkA==",
+      "version": "68.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-68.0.0.tgz",
+      "integrity": "sha512-mHYWvX948Q4H3bGc39bsNMxD/leOuNI+Iws9NVsoSz5VA7EGP86wnz7mZ/SPSvRhefT8L4hd8DHfDuGC+lIoCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@eslint-community/eslint-utils": "^4.9.0",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "browserslist": "^4.28.2",
         "change-case": "^5.4.4",
-        "ci-info": "^4.3.1",
-        "clean-regexp": "^1.0.0",
-        "core-js-compat": "^3.46.0",
+        "ci-info": "^4.4.0",
+        "core-js-compat": "^3.49.0",
+        "detect-indent": "^7.0.2",
         "find-up-simple": "^1.0.1",
-        "globals": "^16.4.0",
+        "globals": "^17.6.0",
         "indent-string": "^5.0.0",
         "is-builtin-module": "^5.0.0",
         "jsesc": "^3.1.0",
         "pluralize": "^8.0.0",
-        "regexp-tree": "^0.1.27",
-        "regjsparser": "^0.13.0",
-        "semver": "^7.7.3",
+        "regjsparser": "^0.13.1",
+        "semver": "^7.8.4",
         "strip-indent": "^4.1.1"
       },
       "engines": {
-        "node": "^20.10.0 || >=21.0.0"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
       },
       "peerDependencies": {
-        "eslint": ">=9.38.0"
-      }
-    },
-    "node_modules/eslint-plugin-unicorn/node_modules/globals": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
-      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "eslint": ">=10.4"
       }
     },
     "node_modules/eslint-scope": {
@@ -3835,9 +3848,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
-      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
+      "version": "17.8.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
+      "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3869,6 +3882,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -4164,9 +4190,9 @@
       "license": "MIT"
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.1.1.tgz",
-      "integrity": "sha512-/2uqY7x6bsrpi3i9LVU6J89352C0rpMk0as8trXxCtvd4kPk1ke/Eyif6wqfSLvoNJqcDG9Vk4UsXgygzCt2xA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-8.0.0.tgz",
+      "integrity": "sha512-uQu/fXVqVaMg6gM8/E5G5+eygVcZ1NV0Z51CvqhNa2bDWxvHMl484ETr6vph4oPyC+KUcbP/w2W2pewfCiR9aQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4297,7 +4323,6 @@
       "integrity": "sha512-75EA7EWZExL/j+MDKQrRbdzcRI2HOkRlmUw8fZJc1ioqFEOvBsq7Rt+A6yCxOt9w/TYNpkt52gC6nm/g5tFIng==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.5.0",
         "eslint-visitor-keys": "^5.0.0",
@@ -4316,7 +4341,6 @@
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },
@@ -5296,13 +5320,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -5371,11 +5395,30 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/npm-package-arg": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
+      "integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "hosted-git-info": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-name": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -5390,9 +5433,9 @@
       }
     },
     "node_modules/object-deep-merge": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.0.tgz",
-      "integrity": "sha512-3DC3UMpeffLTHiuXSy/UG4NOIYTLlY9u3V82+djSCLYClWobZiS4ivYzpIUWrRY/nfsJ8cWsKyG3QfyLePmhvg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.1.tgz",
+      "integrity": "sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5481,12 +5524,13 @@
       "license": "BlueOak-1.0.0"
     },
     "node_modules/package-json-validator": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/package-json-validator/-/package-json-validator-1.3.1.tgz",
-      "integrity": "sha512-RfUMqyBoLa1qcPsKNAksnVDRuzDvLi//RqfMbf52RNMKsm+cWR/3Cfe6hvrTS/ATtEwvtm/57dPggXsau6++uA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/package-json-validator/-/package-json-validator-1.5.2.tgz",
+      "integrity": "sha512-eHXskJQU4aCiSfjhRfTVtCJ+22/EzLHgYgZv5Gj3teb3NJrnTMzq5BnKAWKvR+PLpknCO1PmOCImDuO+dX4Vaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "npm-package-arg": "^13.0.2",
         "semver": "^7.7.2",
         "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "^7.0.0"
@@ -5722,6 +5766,16 @@
         "prettier": "^3.0.0"
       }
     },
+    "node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5746,16 +5800,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/regexp-tree": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
-      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "regexp-tree": "bin/regexp-tree"
-      }
-    },
     "node_modules/reghex": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/reghex/-/reghex-3.0.2.tgz",
@@ -5764,9 +5808,9 @@
       "license": "MIT"
     },
     "node_modules/regjsparser": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz",
-      "integrity": "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.2.tgz",
+      "integrity": "sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -5924,9 +5968,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -6004,9 +6048,9 @@
       "license": "MIT"
     },
     "node_modules/sort-package-json": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-3.6.1.tgz",
-      "integrity": "sha512-Chgejw1+10p2D0U2tB7au1lHtz6TkFnxmvZktyBCRyV0GgmF6nl1IxXxAsPtJVsUyg/fo+BfCMAVVFUVRkAHrQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-4.0.0.tgz",
+      "integrity": "sha512-6aYOlYI9AWioZ+rzu+4zKLmoFqJP0/fHDxrd7X04yqEibikY+5YVF0EYlyGn4v6X2PJY7yAUWV7oeP+i5rOm/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6022,7 +6066,7 @@
         "sort-package-json": "cli.js"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/source-map-js": {
@@ -6065,9 +6109,9 @@
       "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
-      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-5.0.0.tgz",
+      "integrity": "sha512-vngmw3Rgn+o2arXNbnZaj5UtOEBuWBfvaI+Wc8GFfykIhA5/vdK9/Sp/XkLv63dykz2rxKDvKEHupF5P0FORcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6195,9 +6239,9 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6347,29 +6391,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
-      }
-    },
-    "node_modules/ts-declaration-location": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/ts-declaration-location/-/ts-declaration-location-1.0.7.tgz",
-      "integrity": "sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "ko-fi",
-          "url": "https://ko-fi.com/rebeccastevens"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/ts-declaration-location"
-        }
-      ],
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "picomatch": "^4.0.2"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.0.0"
       }
     },
     "node_modules/tshy": {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.12",
     "@eslint/compat": "^2.0.5",
-    "@feedic/eslint-config": "^0.3.1",
+    "@feedic/eslint-config": "^0.5.0",
     "@imgix/js-core": "^3.8.0",
     "@octokit/graphql": "^9.0.3",
     "@types/jsdom": "^28.0.1",
@@ -133,7 +133,7 @@
     "@types/whatwg-mimetype": "^5.0.0",
     "@vitest/coverage-v8": "^4.1.4",
     "@vitest/eslint-plugin": "^1.6.16",
-    "eslint": "^10.2.0",
+    "eslint": "^10.8.0",
     "eslint-config-biome": "^2.1.3",
     "globals": "^17.5.0",
     "husky": "^9.1.7",

--- a/scripts/fetch-sponsors.mts
+++ b/scripts/fetch-sponsors.mts
@@ -275,11 +275,13 @@ console.log('Received sponsors:', sponsors);
 // Remove sponsors that are already in the pre-populated headliners
 for (let i = 0; i < sponsors.length; i++) {
   if (
-    tierSponsors.headliner.some((sponsor) => sponsor.url === sponsors[i].url)
+    tierSponsors.headliner.every((sponsor) => sponsor.url !== sponsors[i].url)
   ) {
-    sponsors.splice(i, 1);
-    i--;
+    continue;
   }
+
+  sponsors.splice(i, 1);
+  i--;
 }
 
 sponsors.sort((a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt));

--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -20,6 +20,10 @@ const rboolean =
 // Matches strings that look like JSON objects or arrays
 const rbrace = /^{[\s\S]*}$|^\[[\s\S]*]$/;
 
+// Tags whose `href`/`src` is resolved against `baseURI`
+const hrefTags = new Set(['a', 'link']);
+const srcTags = new Set(['img', 'iframe', 'audio', 'video', 'source']);
+
 /**
  * Gets a node's attribute. For boolean attributes, it will return the value's
  * name should it be set.
@@ -207,8 +211,7 @@ export function attr<T extends AnyNode>(
       if (!isTag(el)) return;
 
       if (typeof name === 'object') {
-        for (const objName of Object.keys(name)) {
-          const objValue = name[objName];
+        for (const [objName, objValue] of Object.entries(name)) {
           setAttr(el, objName, objValue);
         }
       } else {
@@ -451,13 +454,7 @@ export function prop<T extends AnyNode>(
 
         if (
           typeof URL !== 'undefined' &&
-          ((name === 'href' && (el.tagName === 'a' || el.tagName === 'link')) ||
-            (name === 'src' &&
-              (el.tagName === 'img' ||
-                el.tagName === 'iframe' ||
-                el.tagName === 'audio' ||
-                el.tagName === 'video' ||
-                el.tagName === 'source'))) &&
+          (name === 'href' ? hrefTags : srcTags).has(el.tagName) &&
           prop !== undefined &&
           this.options.baseURI
         ) {
@@ -512,8 +509,7 @@ export function prop<T extends AnyNode>(
       if (!isTag(el)) return;
 
       if (typeof name === 'object') {
-        for (const key of Object.keys(name)) {
-          const val = name[key];
+        for (const [key, val] of Object.entries(name)) {
           setProp(el, key, val, this.options.xmlMode);
         }
       } else {
@@ -568,7 +564,7 @@ function setData(
 function readAllData(el: DataElement): unknown {
   const data = (el.data ??= {});
 
-  for (const domName of Object.keys(el.attribs)) {
+  for (const [domName, domValue] of Object.entries(el.attribs)) {
     if (!domName.startsWith(dataAttrPrefix)) {
       continue;
     }
@@ -576,7 +572,7 @@ function readAllData(el: DataElement): unknown {
     const jsName = camelCase(domName.slice(dataAttrPrefix.length));
 
     if (!Object.hasOwn(data, jsName)) {
-      data[jsName] = parseDataValue(el.attribs[domName]);
+      data[jsName] = parseDataValue(domValue);
     }
   }
 
@@ -799,7 +795,6 @@ export function val<T extends AnyNode>(
       return this.text(value as string);
     }
     case 'select': {
-      const option = this.find('option:selected');
       if (!querying) {
         if (this.attr('multiple') == null && typeof value === 'object') {
           return this;
@@ -814,6 +809,8 @@ export function val<T extends AnyNode>(
 
         return this;
       }
+
+      const option = this.find('option:selected');
 
       return this.attr('multiple')
         ? option.toArray().map((el) => text(el.children))
@@ -964,10 +961,12 @@ export function addClass<T extends AnyNode, R extends ArrayLike<T>>(
   // Support functions
   if (typeof value === 'function') {
     return domEach(this, (el, i) => {
-      if (isTag(el)) {
-        const className = el.attribs['class'] || '';
-        addClass.call([el], value.call(el, i, className));
+      if (!isTag(el)) {
+        return;
       }
+
+      const className = el.attribs['class'] || '';
+      addClass.call([el], value.call(el, i, className));
     });
   }
 

--- a/src/api/forms.spec.ts
+++ b/src/api/forms.spec.ts
@@ -22,7 +22,7 @@ describe('$(...)', () => {
     it('() : should get nested form controls', () => {
       expect($('form#nested').serializeArray()).toHaveLength(2);
       const data = $('form#nested').serializeArray();
-      data.sort((a, b) => (a.value > b.value ? 1 : -1));
+      data.sort((a, b) => a.value.localeCompare(b.value));
       expect(data).toStrictEqual([
         {
           name: 'fruit',
@@ -69,7 +69,7 @@ describe('$(...)', () => {
     it('() : should get multiple selected options', () => {
       expect($('form#multiple').serializeArray()).toHaveLength(2);
       const data = $('form#multiple').serializeArray();
-      data.sort((a, b) => (a.value > b.value ? 1 : -1));
+      data.sort((a, b) => a.value.localeCompare(b.value));
       expect(data).toStrictEqual([
         {
           name: 'fruit',
@@ -84,7 +84,7 @@ describe('$(...)', () => {
 
     it('() : should get individually selected elements', () => {
       const data = $('form#nested input').serializeArray();
-      data.sort((a, b) => (a.value > b.value ? 1 : -1));
+      data.sort((a, b) => a.value.localeCompare(b.value));
       expect(data).toStrictEqual([
         {
           name: 'fruit',

--- a/src/api/traversing.ts
+++ b/src/api/traversing.ts
@@ -985,6 +985,11 @@ export function last<T>(this: Cheerio<T>): Cheerio<T> {
  * @see {@link https://api.jquery.com/eq/}
  */
 export function eq<T>(this: Cheerio<T>, i: number): Cheerio<T> {
+  /*
+   * Not redundant: JavaScript callers pass string indices, and `eq('-1')`
+   * would otherwise reach `this.length + i` as string concatenation.
+   */
+  // eslint-disable-next-line unicorn/no-useless-coercion
   i = +i;
 
   // Use the first identity optimization if possible

--- a/src/cheerio.ts
+++ b/src/cheerio.ts
@@ -46,6 +46,8 @@ export abstract class Cheerio<T> implements ArrayLike<T> {
    * @private
    */
   _root: Cheerio<Document> | null;
+  /** The selection this one was derived from, as set by `end()`. */
+  prevObject: Cheerio<any> | undefined;
 
   /**
    * Instance of cheerio. Methods are specified in the modules. Usage of this
@@ -72,7 +74,6 @@ export abstract class Cheerio<T> implements ArrayLike<T> {
     }
   }
 
-  prevObject: Cheerio<any> | undefined;
   /**
    * Make a cheerio object.
    *

--- a/src/static.ts
+++ b/src/static.ts
@@ -269,7 +269,7 @@ export function merge<T>(
     return;
   }
   let newLength = arr1.length;
-  const len = +arr2.length;
+  const len = arr2.length;
 
   for (let i = 0; i < len; i++) {
     arr1[newLength++] = arr2[i];
@@ -295,6 +295,11 @@ function isArrayLike(item: unknown): item is ArrayLike<unknown> {
     item === null ||
     !('length' in item) ||
     typeof item.length !== 'number' ||
+    /*
+     * Not an array's `.length`: `item` is an arbitrary object being validated,
+     * so this property really can be negative.
+     */
+    // eslint-disable-next-line unicorn/no-impossible-length-comparison
     item.length < 0
   ) {
     return false;

--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -12,13 +12,16 @@ const docs = defineCollection({
   }),
 });
 
+const string = z.string();
+const stringOrStrings = z.union([string, z.array(string)]);
+
 const blog = defineCollection({
   loader: glob({ pattern: '**/[^_]*.{md,mdx}', base: './src/content/blog' }),
   schema: z.object({
-    title: z.string(),
-    slug: z.string().optional(),
-    authors: z.union([z.string(), z.array(z.string())]).optional(),
-    tags: z.array(z.string()).optional(),
+    title: string,
+    slug: string.optional(),
+    authors: stringOrStrings.optional(),
+    tags: z.array(string).optional(),
     date: z.date().optional(),
   }),
 });

--- a/website/src/pages/blog/rss.xml.ts
+++ b/website/src/pages/blog/rss.xml.ts
@@ -18,15 +18,15 @@ function getPostDate(filePath: string): Date {
 export async function GET(context: APIContext) {
   const posts = await getCollection('blog');
 
+  if (!context.site) {
+    throw new Error('Site URL is required for RSS feed generation');
+  }
+
   // Sort posts by date (newest first)
   const sortedPosts = posts.toSorted(
     (a, b) =>
       getPostDate(b.filePath).getTime() - getPostDate(a.filePath).getTime(),
   );
-
-  if (!context.site) {
-    throw new Error('Site URL is required for RSS feed generation');
-  }
 
   return rss({
     title: 'Cheerio Blog',
@@ -42,7 +42,7 @@ export async function GET(context: APIContext) {
         title: post.data.title,
         pubDate: getPostDate(post.filePath),
         link: `/blog/${post.id}/`,
-        ...(content ? { content } : {}),
+        ...(content && { content }),
       };
     }),
   });

--- a/website/src/plugins/rehype-external-links.ts
+++ b/website/src/plugins/rehype-external-links.ts
@@ -3,16 +3,20 @@ import { visit } from 'unist-util-visit';
 
 function visitExternalLink(node: Element): void {
   if (
-    node.tagName === 'a' &&
-    node.properties?.href &&
-    typeof node.properties.href === 'string'
+    !(
+      node.tagName === 'a' &&
+      node.properties?.href &&
+      typeof node.properties.href === 'string'
+    )
   ) {
-    const { href } = node.properties;
-    // Check if it's an external link (starts with http:// or https://)
-    if (href.startsWith('http://') || href.startsWith('https://')) {
-      node.properties.target = '_blank';
-      node.properties.rel = 'noopener noreferrer';
-    }
+    return;
+  }
+
+  const { href } = node.properties;
+  // Check if it's an external link (starts with http:// or https://)
+  if (href.startsWith('http://') || href.startsWith('https://')) {
+    node.properties.target = '_blank';
+    node.properties.rel = 'noopener noreferrer';
   }
 }
 

--- a/website/src/plugins/remark-live-code.ts
+++ b/website/src/plugins/remark-live-code.ts
@@ -20,35 +20,37 @@ function visitLiveCode(
   parent: Parent | undefined,
 ): void {
   // Check if the code block has 'live' in its meta
-  if (node.meta?.includes('live') && index !== undefined && parent) {
-    // Transform the code node into an MDX JSX element
-    const code = node.value;
-
-    /*
-     * Create an mdxJsxFlowElement node for the LiveCode component
-     * with client:visible for lazy hydration
-     */
-    const jsxNode: MdxJsxFlowElement = {
-      type: 'mdxJsxFlowElement',
-      name: 'LiveCode',
-      attributes: [
-        {
-          type: 'mdxJsxAttribute',
-          name: 'code',
-          value: code,
-        },
-        {
-          type: 'mdxJsxAttribute',
-          name: 'client:visible',
-          value: null,
-        },
-      ],
-      children: [],
-    };
-
-    // Replace the code node with the JSX node
-    parent.children.splice(index, 1, jsxNode as unknown as Code);
+  if (!(node.meta?.includes('live') && index !== undefined && parent)) {
+    return;
   }
+
+  // Transform the code node into an MDX JSX element
+  const code = node.value;
+
+  /*
+   * Create an mdxJsxFlowElement node for the LiveCode component
+   * with client:visible for lazy hydration
+   */
+  const jsxNode: MdxJsxFlowElement = {
+    type: 'mdxJsxFlowElement',
+    name: 'LiveCode',
+    attributes: [
+      {
+        type: 'mdxJsxAttribute',
+        name: 'code',
+        value: code,
+      },
+      {
+        type: 'mdxJsxAttribute',
+        name: 'client:visible',
+        value: null,
+      },
+    ],
+    children: [],
+  };
+
+  // Replace the code node with the JSX node
+  parent.children[index] = jsxNode as unknown as Code;
 }
 
 function transformer(tree: Root): void {


### PR DESCRIPTION
Adopts `@feedic/eslint-config` 0.5, which enables a large set of new `unicorn` rules. On this codebase they report **984 problems**. This PR triages all of them: 26 are fixed, the rest are turned off with a recorded reason.

Requires `eslint >= 10.3.0`, so eslint moves to `^10.8.0` as well.

## What got fixed

**`src`**
- `attr()`, `prop()` and `readAllData()` iterate `Object.entries()` instead of `Object.keys()` plus a lookup.
- `prop()` matches `href`/`src` tag names against two module-level `Set`s rather than a chain of seven equality checks.
- `val()` builds the `option:selected` selection after the setter branch returns, instead of on every call.
- `addClass()` uses an early return.
- `Cheerio.prevObject` is declared with the other fields rather than after the constructor, and picks up a doc comment.
- `merge()` drops `+arr2.length` — `isArrayLike()` has already established that `length` is a number.

**`website` / `scripts`** — early returns in the rehype and remark plugins, a direct index assignment in place of a one-element `splice()`, the RSS `context.site` guard hoisted above the sort, and the blog schema's nested `z` calls lifted into named values.

**Tests** — `forms.spec.ts` sorts with `localeCompare` instead of a comparator that never returned `0`.

## Rules turned off for good

These describe a codebase cheerio isn't:

| Rule | Reports | Why |
| --- | --- | --- |
| `no-this-outside-of-class` | 257 | The API is `this`-bound and mixed onto the prototype by `Object.assign`. |
| `better-dom-traversing` | 72 | Matches cheerio's own `.parent()`/`.children()` and suggests real-DOM APIs that don't exist here. |
| `prefer-iterator-to-array-at-end`, `no-useless-iterator-to-array` | 6 | Read `Cheerio.prototype.toArray()` as `Iterator#toArray()`. The rewrites would call `.flatMap()` on a Cheerio instance and `.toArray()` on an array. |
| `prefer-https` (specs) | 26 | The URLs are `attr()`/`css()` fixture data and XML namespace URIs — identifiers, not links. |
| `no-useless-template-literals` | 4 | See below. |
| `prefer-private-class-fields` | 4 | `_root`, `_make`, `_parse`, `_render` are documented API. |
| `no-unsafe-property-key` | 4 | Caller-supplied `extract()` schema keys and `css()` property names landing on local result objects. |
| `no-computed-property-existence-check` | 3 | `name in el` mirrors jQuery's `.prop()`; `i in item` is the sparse-array check in `isArrayLike`. |
| `prefer-global-number-constants` | 2 | See below. |
| `no-unused-array-method-return` (specs) | 2 | Reports cheerio's own `.find()`/`.map()`, called for a thrown error or for side effects. |
| `no-top-level-side-effects` | 1 | The prototype assignment is the point of `src/cheerio.ts`. |
| `n/no-unsupported-features/node-builtins` | 2 | Scoped off for `eslint.config.js`, which is not published and so is not bound by the `engines` range. |

Two of those are worth calling out.

**`no-useless-template-literals`** wanted to strip the `${value}` wrappers at the API boundary. The types say `string`, but JavaScript callers pass numbers, and all four sites coerce deliberately — verified: `attr('width', 100)` has to store `"100"`, and `text(42)` has to render `42`.

**`prefer-global-number-constants`** directly contradicts Biome's `useNumberNamespace`, which this repo enables. Left on, the two rewrite each other's output on every `npm run format`. `eslint-config-biome` doesn't know about the rule yet.

## Rules turned off with a TODO

Pure renames — mechanical, but each touches enough lines to deserve its own PR:

- `name-replacements` (548) — `i` → `index`, `str` → `string_`, `ret` → `returnValue`, `el` → `element`, `arr` → `array`
- `consistent-boolean-name` (25) — booleans wanting an `is`/`has`/`should` prefix
- `filename-case` (3) — `__fixtures__` and `__tests__` follow the test-runner convention
- `no-non-function-verb-prefix` (2) — the locals `setClass` and `removeAll` in `src/api/attributes.ts`

## Two false positives suppressed inline

Both were verified rather than assumed:

- **`eq()` keeps `i = +i`.** Autofix removed it as redundant. Without it, `eq('-1')` from JavaScript reaches `this.length + i` as *string concatenation* (`3 + '-1'` → `'3-1'`) and returns an empty selection instead of the last element. Spelling it `Number(i)` reads better but is reported just the same, so the line is unchanged apart from the comment.
- **`isArrayLike()` keeps `item.length < 0`.** The rule assumes an array's `length`; `item` here is an arbitrary object under validation, so the property genuinely can be negative.

## Verification

Clean `npm ci`, then build, lint, typecheck and the full suite: 793 tests pass, 0 lint errors, no type errors. Website builds unchanged.

---

Created by Claude Opus 5
