### PR TITLE
test(fromURL): cover `baseURI` when no redirect happens

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -221,4 +221,18 @@ describe('fromURL', () => {
     );
     expect($('a').prop('href')).toBe(`http://localhost:${port}/final/link`);
   });
+
+  it('should set `baseURI` to the requested URL when there is no redirect', async () => {
+    const port = await createTestServer(
+      'text/html',
+      '<a id="relative" href="link">relative</a><a id="rooted" href="/link">rooted</a>',
+    );
+
+    const $ = await cheerio.fromURL(`http://localhost:${port}/dir/page`);
+
+    expect($('#relative').prop('href')).toBe(
+      `http://localhost:${port}/dir/link`,
+    );
+    expect($('#rooted').prop('href')).toBe(`http://localhost:${port}/link`);
+  });
 });


### PR DESCRIPTION
Refs #5368. Test-only change.

`fromURL` always composes undici's redirect interceptor, so `res.context.history` exists but is **empty** when the response was not redirected. The released 1.2.0 reads the final URL as `history[history.length - 1]`, which is `undefined` in that case, so `baseURI` is never set and `prop('href')` returns the raw attribute — exactly what #5368 reports.

`main` is not affected, because the expression became `history?.at(-1) ?? urlObject` during an unrelated refactor (46bfdf3). That means the fix was incidental and nothing pins it down: the existing `should follow redirects` test only exercises the path where `history` has an entry.

This adds a test for the no-redirect path, covering a document-relative and a root-relative href. Verified both ways:

- against `main`: passes
- against the 1.2.0 expression (`history ? history[history.length - 1] : urlObject`): fails with `expected 'link' to be 'http://localhost:PORT/dir/link'`

`vitest run src/index.spec.ts` -> 14 passing, no type errors; `biome check` and `eslint` clean on the touched file.