### PR TITLE
fix: make removeAttr case-insensitive for HTML, preserve hidden=until-found

### DIFF
--- a/src/api/attributes.spec.ts
+++ b/src/api/attributes.spec.ts
@@ -44,6 +44,11 @@ describe('$(...)', () => {
       expect(attr).toBe('autofocus');
     });
 
+    it('(valid key) : should preserve hidden="until-found"', () => {
+      const $el = cheerio('<div hidden="until-found">');
+      expect($el.attr('hidden')).toBe('until-found');
+    });
+
     it('(key, value) : should set one attr', () => {
       const $pear = $('.pear').attr('id', 'pear');
       expect($('#pear')).toHaveLength(1);
@@ -796,6 +801,12 @@ describe('$(...)', () => {
       $body.removeAttr('class');
 
       expect($text('body').html()).toBe(mixedText);
+    });
+
+    it('(key) : should be case-insensitive for HTML', () => {
+      const $apple = $('.apple');
+      $apple.removeAttr('CLASS');
+      expect($apple.attr('class')).toBeUndefined();
     });
   });
 

--- a/src/api/attributes.spec.ts
+++ b/src/api/attributes.spec.ts
@@ -819,6 +819,7 @@ describe('$(...)', () => {
         xmlMode: true,
       });
       $xml('foo').removeAttr('BAR');
+      expect($xml('foo').attr('BAR')).toBeUndefined();
       expect($xml('foo').attr('bar')).toBe('qux');
     });
   });

--- a/src/api/attributes.spec.ts
+++ b/src/api/attributes.spec.ts
@@ -49,6 +49,11 @@ describe('$(...)', () => {
       expect($el.attr('hidden')).toBe('until-found');
     });
 
+    it('(valid key) : should preserve hidden="Until-Found" mixed case', () => {
+      const $el = cheerio('<div hidden="Until-Found">');
+      expect($el.attr('hidden')).toBe('Until-Found');
+    });
+
     it('(key, value) : should set one attr', () => {
       const $pear = $('.pear').attr('id', 'pear');
       expect($('#pear')).toHaveLength(1);
@@ -807,6 +812,14 @@ describe('$(...)', () => {
       const $apple = $('.apple');
       $apple.removeAttr('CLASS');
       expect($apple.attr('class')).toBeUndefined();
+    });
+
+    it('(key) : should be case-sensitive for XML', () => {
+      const $xml = cheerio.load('<foo BAR="baz" bar="qux" />', {
+        xmlMode: true,
+      });
+      $xml('foo').removeAttr('BAR');
+      expect($xml('foo').attr('bar')).toBe('qux');
     });
   });
 

--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -69,7 +69,7 @@ function getAttr(
     // accepts the special value `until-found` per HTML spec.
     return !xmlMode &&
       rboolean.test(name) &&
-      value.toLowerCase() !== 'until-found'
+      !(name === 'hidden' && value.toLowerCase() === 'until-found')
       ? name
       : value;
   }

--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -63,7 +63,13 @@ function getAttr(
 
   if (Object.hasOwn(elem.attribs, name)) {
     // Get the (decoded) attribute
-    return !xmlMode && rboolean.test(name) ? name : elem.attribs[name];
+    const value = elem.attribs[name];
+
+    // Boolean attributes normally return the attribute name, but `hidden`
+    // accepts the special value `until-found` per HTML spec.
+    return !xmlMode && rboolean.test(name) && value !== 'until-found'
+      ? name
+      : value;
   }
 
   // Mimic the DOM and return text content as value for `option's`
@@ -838,9 +844,14 @@ export function val<T extends AnyNode>(
  * @param name - Name of the attribute to remove.
  */
 function removeAttribute(elem: Element, name: string) {
-  if (!(elem.attribs && Object.hasOwn(elem.attribs, name))) return;
+  if (!elem.attribs) return;
 
-  delete elem.attribs[name];
+  // Attribute names are lowercased by htmlparser2 for HTML documents.
+  const lowerName = name.toLowerCase();
+
+  if (!Object.hasOwn(elem.attribs, lowerName)) return;
+
+  delete elem.attribs[lowerName];
 }
 
 /**

--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -67,7 +67,9 @@ function getAttr(
 
     // Boolean attributes normally return the attribute name, but `hidden`
     // accepts the special value `until-found` per HTML spec.
-    return !xmlMode && rboolean.test(name) && value !== 'until-found'
+    return !xmlMode &&
+      rboolean.test(name) &&
+      value.toLowerCase() !== 'until-found'
       ? name
       : value;
   }
@@ -843,11 +845,11 @@ export function val<T extends AnyNode>(
  * @param elem - Node to remove attribute from.
  * @param name - Name of the attribute to remove.
  */
-function removeAttribute(elem: Element, name: string) {
+function removeAttribute(elem: Element, name: string, xmlMode?: boolean) {
   if (!elem.attribs) return;
 
   // Attribute names are lowercased by htmlparser2 for HTML documents.
-  const lowerName = name.toLowerCase();
+  const lowerName = xmlMode ? name : name.toLowerCase();
 
   if (!Object.hasOwn(elem.attribs, lowerName)) return;
 
@@ -889,10 +891,11 @@ export function removeAttr<T extends AnyNode>(
   name: string,
 ): Cheerio<T> {
   const attrNames = splitNames(name);
+  const { xmlMode } = this.options;
 
   for (const attrName of attrNames) {
     domEach(this, (elem) => {
-      if (isTag(elem)) removeAttribute(elem, attrName);
+      if (isTag(elem)) removeAttribute(elem, attrName, xmlMode);
     });
   }
 


### PR DESCRIPTION
## Description

Makes HTML attribute removal case-insensitive for consistency with the HTML spec, and preserves the special `hidden="until-found"` value when reading attributes.

### Changes

- **`.removeAttr()` case-insensitive in HTML mode**: Lowercases attribute names before removal in HTML documents, matching how htmlparser2 stores attribute names. XML mode preserves case-sensitive removal.
- **Hidden attribute value preservation**: `.attr('hidden')` now returns `"until-found"` when set, instead of normalizing to `true`. This aligns with the [HTML Living Standard](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/hidden#description).

### Tests

- Added test for hidden attribute value (lowercase and mixed-case)
- Added tests for case-insensitive HTML removeAttr
- Added test confirming XML removeAttr remains case-sensitive

Closes #5257
Closes #5073
