### PR TITLE
fix(website): use Buffer for the crawler API credentials

### DIFF
--- a/website/scripts/sync-algolia-crawler.mjs
+++ b/website/scripts/sync-algolia-crawler.mjs
@@ -75,8 +75,13 @@ async function sync() {
     );
   }
 
-  const credentials = new TextEncoder().encode(`${userId}:${apiKey}`);
-  const authorization = `Basic ${credentials.toBase64()}`;
+  /*
+   * `Uint8Array#toBase64()` is not in Node 24, which is what `lts/*` resolves
+   * to on the runner — it threw "toBase64 is not a function" there. Buffer
+   * works on every version this repo runs on.
+   */
+  // eslint-disable-next-line unicorn/prefer-uint8array-base64
+  const authorization = `Basic ${Buffer.from(`${userId}:${apiKey}`).toString('base64')}`;
 
   async function send(path, method, payload) {
     const response = await fetch(`${endpoint}${path}`, {


### PR DESCRIPTION
The `sync-crawler` job added in #5388 failed on its first real run:

```
credentials.toBase64 is not a function
```

`node-version: lts/*` resolves to **Node 24.18.0** on the runner, and
`Uint8Array#toBase64()` is not available there — it landed later than we
assumed when switching away from `Buffer`. Local verification passed because
this machine runs Node 26, so the method exists.

Reverts that line to `Buffer.from(...).toString('base64')`, which works on
every Node version this repo runs on, with the lint rule disabled and the
reason recorded.

**Verified** by deleting `Uint8Array.prototype.toBase64` to reproduce the Node 24
runtime, then running the real script: it builds the auth header and reaches the
API, failing only on a deliberately invalid credential (`403 Forbidden`) rather
than a `TypeError`.

No user-facing impact — search is unaffected. The index still serves correct
results, and the crawler configuration currently stored in the dashboard already
matches this repo. Only the automated push was broken.

---

🤖 created by Claude Opus 5
