### PR TITLE
fix(website): send the crawler extractor in its object envelope

### DIFF
--- a/website/scripts/sync-algolia-crawler.mjs
+++ b/website/scripts/sync-algolia-crawler.mjs
@@ -24,12 +24,38 @@ const reindex =
 // Fail fast rather than letting an unresponsive endpoint hang the CI job.
 const timeoutMs = 30_000;
 
-// The API takes extractors as source strings rather than as JSON objects.
+/*
+ * The API rejects a bare source string with "recordExtractor must be a valid
+ * object", so functions travel in the envelope the platform stores them in.
+ */
 const body = JSON.stringify(
   config,
-  (_key, value) => (typeof value === 'function' ? value.toString() : value),
+  (_key, value) =>
+    typeof value === 'function'
+      ? { __type: 'function', source: value.toString() }
+      : value,
   2,
 );
+
+/**
+ * Unwrap function envelopes so a config compares equal whether the API echoes
+ * an extractor back wrapped or as a bare source string.
+ *
+ * @param value - The value to normalise.
+ * @returns The value with every function envelope replaced by its source.
+ */
+function unwrapFunctions(value) {
+  if (Array.isArray(value)) return value.map((item) => unwrapFunctions(item));
+  if (value && typeof value === 'object') {
+    if (value.__type === 'function' && typeof value.source === 'string') {
+      return value.source;
+    }
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, unwrapFunctions(item)]),
+    );
+  }
+  return value;
+}
 
 /**
  * Order keys by code unit rather than locale, so the canonical form does not
@@ -116,7 +142,9 @@ async function sync() {
     const stored = await readBack.json();
     const sent = JSON.parse(body);
     const drifted = Object.keys(sent).filter(
-      (key) => stableStringify(stored[key]) !== stableStringify(sent[key]),
+      (key) =>
+        stableStringify(unwrapFunctions(stored[key])) !==
+        stableStringify(unwrapFunctions(sent[key])),
     );
 
     if (drifted.length > 0) {


### PR DESCRIPTION
Second failure of the `sync-crawler` job. Authentication now works (#5392), and
the API rejected the payload itself:

```
PATCH /config failed (400): recordExtractor must be a valid object
```

The extractor was being sent as a bare source string. I had flagged that format
as the one thing I could not verify without the API key — it was wrong. The
platform stores functions as `{ __type: 'function', source }`, which is the shape
its own admin API round-trips, so that is what this sends.

The read-back diff now unwraps function envelopes before comparing, so it cannot
report false drift if the API echoes an extractor back in either representation.
Verified that a wrapped and a bare extractor compare equal, that a genuinely
different extractor still registers as drift, and that key reordering is still
tolerated.

**No user-facing impact.** Search is unaffected: the index serves correct results
and the configuration currently in the dashboard already matches this repo — it
was pushed through the admin API while debugging. Only the automated push is
broken.

---

🤖 created by Claude Opus 5
