### PR TITLE
fix(traversing): reset the *Until index for each starting element

### DIFF
--- a/src/api/traversing.spec.ts
+++ b/src/api/traversing.spec.ts
@@ -385,6 +385,13 @@ describe('$(...)', () => {
       const elems = $drinks.eq(0).nextUntil($until);
       expect(elems).toHaveLength(2);
     });
+
+    it('(function) : should reset the index for each starting element', () => {
+      const elems = $('.apple, .carrot', food).nextUntil((i) => i === 1);
+      expect(elems).toHaveLength(2);
+      expect(elems[0].attribs).toHaveProperty('class', 'orange');
+      expect(elems[1].attribs).toHaveProperty('class', 'sweetcorn');
+    });
   });
 
   describe('.prev', () => {
@@ -566,6 +573,13 @@ describe('$(...)', () => {
       const $until = $([$drinks[0], $drinks[1]]);
       const elems = $drinks.eq(4).prevUntil($until);
       expect(elems).toHaveLength(2);
+    });
+
+    it('(function) : should reset the index for each starting element', () => {
+      const elems = $('.pear, .sweetcorn', food).prevUntil((i) => i === 1);
+      expect(elems).toHaveLength(2);
+      expect(elems[0].attribs).toHaveProperty('class', 'orange');
+      expect(elems[1].attribs).toHaveProperty('class', 'carrot');
     });
   });
 
@@ -758,6 +772,13 @@ describe('$(...)', () => {
       const result = $('.carrot').parentsUntil(body);
       expect(result).toHaveLength(2);
       expect(result.eq(0).is('ul#vegetables')).toBe(true);
+    });
+
+    it('(function) : should reset the index for each starting element', () => {
+      const result = $('.apple, .carrot').parentsUntil((i) => i === 1);
+      expect(result).toHaveLength(2);
+      expect(result[0].attribs).toHaveProperty('id', 'vegetables');
+      expect(result[1].attribs).toHaveProperty('id', 'fruits');
     });
   });
 

--- a/src/api/traversing.ts
+++ b/src/api/traversing.ts
@@ -182,9 +182,10 @@ function _matchUntil(
       const matched: Element[] = [];
 
       domEach(elems, (elem) => {
-        for (let next; (next = nextElem(elem)); elem = next) {
-          // FIXME: `matched` might contain duplicates here and the index is too large.
-          if (matches?.(next, matched.length)) break;
+        let i = 0;
+        for (let next; (next = nextElem(elem)); elem = next, i++) {
+          // FIXME: `matched` might still contain duplicates across starting elements.
+          if (matches?.(next, i)) break;
           matched.push(next);
         }
       });


### PR DESCRIPTION
## Summary
`_matchUntil` (the shared implementation behind `nextUntil`/`prevUntil`/`parentsUntil`) passes `matched.length` as the index argument to a function selector — but `matched` accumulates across **every** starting element in the input set, not just the one currently being walked. So once one starting element has contributed `N` matches, the next starting element's own walk starts seeing index `N` instead of `0`, and its own legitimate candidates get wrongly treated as the stop condition and silently dropped.

```js
const $ = cheerio.load('<ul><li id="a">a</li><li id="b">b</li><li id="c">c</li><li id="d">d</li><li id="e">e</li></ul>')
$('#a, #d').nextUntil((i, el) => i === 1).map((i, el) => $(el).attr('id')).get()
// [ 'b' ]        -- actual
// [ 'b', 'e' ]   -- expected
```

`#a`'s walk contributes `b` (stopping at `c`, index 1). By the time `#d`'s walk starts, `matched.length` is already `1`, so `#d`'s very first candidate (`e`) is checked at index `1` and treated as the stop condition — `e` never gets pushed. This is exactly what the maintainer's own `// FIXME: matched might contain duplicates here and the index is too large` comment (added in #1909, 2021) was flagging.

## Changes
- `src/api/traversing.ts`: track the index locally per starting element (reset to `0` inside the `domEach` callback) instead of reading it off the shared `matched` array.
- `src/api/traversing.spec.ts`: one regression test each for `nextUntil`, `prevUntil`, and `parentsUntil` with a function selector and multiple starting elements — confirmed each fails without the fix and passes with it.

Scope note: the FIXME also mentions `matched` potentially containing duplicates — that's a separate, distinct concern (two starting elements' walks converging on the same element) that this PR doesn't touch.

## Testing
- Full suite: 796/796 passing, typecheck clean.
- `eslint`, `biome check` clean.
- Verified each new test fails on the pre-fix code and passes on the fix.