### PR TITLE
feat(website): add a sponsors page

### DIFF
--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -14,7 +14,10 @@ const footerLinks = {
     },
     { label: 'GitHub', href: 'https://github.com/cheeriojs/cheerio' },
   ],
-  More: [{ label: 'Blog', href: '/blog/' }],
+  More: [
+    { label: 'Blog', href: '/blog/' },
+    { label: 'Sponsors', href: '/sponsors/' },
+  ],
 };
 
 const currentYear = new Date().getFullYear();

--- a/website/src/components/Sponsors.astro
+++ b/website/src/components/Sponsors.astro
@@ -24,8 +24,11 @@ const headliners = (sponsorsData.headliner as Sponsor[]).map((sponsor) => ({
 
     <div class="animate-fade-up animation-delay-200 flex flex-wrap items-center justify-center gap-6">
       {
-        headliners.map((sponsor) => (
-          <a
+        headliners.map((sponsor) => {
+          // Sponsors without a usable URL get a card, but not a link.
+          const Card = sponsor.href ? 'a' : 'div';
+          return (
+          <Card
             href={sponsor.href}
             target={sponsor.href ? '_blank' : undefined}
             rel={sponsor.href ? SPONSOR_REL : undefined}
@@ -51,8 +54,9 @@ const headliners = (sponsorsData.headliner as Sponsor[]).map((sponsor) => ({
             <span class="font-medium text-slate-700 transition-colors group-hover:text-slate-900 dark:text-slate-300 dark:group-hover:text-white">
               {sponsor.name}
             </span>
-          </a>
-        ))
+          </Card>
+          );
+        })
       }
     </div>
 

--- a/website/src/components/Sponsors.astro
+++ b/website/src/components/Sponsors.astro
@@ -1,15 +1,13 @@
 ---
 import { Image } from 'astro:assets';
 import { Heart } from '@lucide/astro';
+import { SPONSOR_REL, type Sponsor, sponsorHref } from '@/lib/sponsors';
 import sponsorsData from '../../sponsors.json';
 
-interface Sponsor {
-  name: string;
-  image: string;
-  url: string;
-}
-
-const headliners = sponsorsData.headliner as Sponsor[];
+const headliners = (sponsorsData.headliner as Sponsor[]).map((sponsor) => ({
+  ...sponsor,
+  href: sponsorHref(sponsor.url),
+}));
 ---
 
 <section class="relative overflow-hidden bg-slate-50 py-20 dark:bg-slate-800/50">
@@ -28,9 +26,9 @@ const headliners = sponsorsData.headliner as Sponsor[];
       {
         headliners.map((sponsor) => (
           <a
-            href={sponsor.url}
-            target="_blank"
-            rel="noopener noreferrer"
+            href={sponsor.href}
+            target={sponsor.href ? '_blank' : undefined}
+            rel={sponsor.href ? SPONSOR_REL : undefined}
             class="group flex items-center gap-3 rounded-xl border border-slate-200 bg-white px-6 py-4 transition-all duration-300 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5 dark:border-slate-700 dark:bg-slate-800 dark:hover:border-primary/40"
           >
             {sponsor.image.endsWith('.svg') ? (

--- a/website/src/components/Sponsors.astro
+++ b/website/src/components/Sponsors.astro
@@ -58,7 +58,7 @@ const headliners = sponsorsData.headliner as Sponsor[];
       }
     </div>
 
-    <div class="animate-fade-up animation-delay-400 mt-10 text-center">
+    <div class="animate-fade-up animation-delay-400 mt-10 flex flex-col items-center justify-center gap-4 text-center sm:flex-row">
       <a
         href="https://github.com/sponsors/cheeriojs"
         target="_blank"
@@ -67,6 +67,12 @@ const headliners = sponsorsData.headliner as Sponsor[];
       >
         <Heart class="h-5 w-5" fill="currentColor" stroke-width={0} />
         Become a sponsor
+      </a>
+      <a
+        href="/sponsors/"
+        class="text-sm font-medium text-slate-600 transition-colors hover:text-primary dark:text-slate-400"
+      >
+        See all sponsors
       </a>
     </div>
   </div>

--- a/website/src/lib/sponsors.ts
+++ b/website/src/lib/sponsors.ts
@@ -1,0 +1,33 @@
+export interface Sponsor {
+  name: string;
+  image: string;
+  /** Sponsors that never set a website on their profile have no URL. */
+  url: string | null;
+}
+
+/**
+ * Marks sponsor links as paid, per Google's guidance on link schemes.
+ * GitHub already applies `nofollow` to README links; the website has to say so
+ * itself.
+ */
+export const SPONSOR_REL = 'sponsored noopener noreferrer';
+
+/**
+ * Sponsor URLs come from Open Collective and GitHub profiles, so they are
+ * third-party data rather than something we control. Only turn a sponsor into
+ * a link when the URL is one we know is safe to render.
+ *
+ * @param url - The sponsor's profile URL, if they set one.
+ * @returns The URL to link to, or `undefined` to render no link at all.
+ */
+export function sponsorHref(url: string | null): string | undefined {
+  if (!url) return;
+
+  try {
+    const { protocol } = new URL(url);
+    return protocol === 'https:' || protocol === 'http:' ? url : undefined;
+  } catch {
+    // Not a parsable URL, so there is nothing safe to link to.
+    return;
+  }
+}

--- a/website/src/pages/sponsors.astro
+++ b/website/src/pages/sponsors.astro
@@ -56,8 +56,11 @@ const tiers = (
               {tier.title}
             </h2>
             <div class="flex flex-wrap items-center justify-center gap-6">
-              {tier.sponsors.map((sponsor) => (
-                <a
+              {tier.sponsors.map((sponsor) => {
+                // Sponsors without a usable URL get a card, but not a link.
+                const Card = sponsor.href ? 'a' : 'div';
+                return (
+                <Card
                   href={sponsor.href}
                   target={sponsor.href ? '_blank' : undefined}
                   rel={sponsor.href ? SPONSOR_REL : undefined}
@@ -72,8 +75,9 @@ const tiers = (
                   <span class="font-medium text-slate-700 transition-colors group-hover:text-slate-900 dark:text-slate-300 dark:group-hover:text-white">
                     {sponsor.name}
                   </span>
-                </a>
-              ))}
+                </Card>
+                );
+              })}
             </div>
           </div>
         ))

--- a/website/src/pages/sponsors.astro
+++ b/website/src/pages/sponsors.astro
@@ -1,14 +1,8 @@
 ---
 import { Heart } from '@lucide/astro';
 import BaseLayout from '@/layouts/BaseLayout.astro';
+import { SPONSOR_REL, type Sponsor, sponsorHref } from '@/lib/sponsors';
 import sponsorsData from '../../sponsors.json';
-
-interface Sponsor {
-  name: string;
-  image: string;
-  /** Sponsors that never set a website on their profile have no URL. */
-  url: string | null;
-}
 
 /*
  * Logos come from whatever URL a sponsor has on their profile, so they are
@@ -18,9 +12,6 @@ interface Sponsor {
  * Sizes constrain the height and let the width follow, so that wordmarks stay
  * legible instead of being squeezed into a square alongside the round avatars.
  */
-/** `sponsored` marks these as paid links, per Google's guidance on link schemes. */
-const SPONSOR_REL = 'sponsored noopener noreferrer';
-
 const tiers = (
   [
     { key: 'headliner', title: 'Headlining Sponsors', size: 'h-14 max-w-48' },
@@ -29,7 +20,13 @@ const tiers = (
     { key: 'backer', title: 'Backers', size: 'h-9 max-w-36' },
   ] as const
 )
-  .map((tier) => ({ ...tier, sponsors: sponsorsData[tier.key] as Sponsor[] }))
+  .map((tier) => ({
+    ...tier,
+    sponsors: (sponsorsData[tier.key] as Sponsor[]).map((sponsor) => ({
+      ...sponsor,
+      href: sponsorHref(sponsor.url),
+    })),
+  }))
   .filter((tier) => tier.sponsors.length > 0);
 ---
 
@@ -61,9 +58,9 @@ const tiers = (
             <div class="flex flex-wrap items-center justify-center gap-6">
               {tier.sponsors.map((sponsor) => (
                 <a
-                  href={sponsor.url ?? undefined}
-                  target={sponsor.url ? '_blank' : undefined}
-                  rel={sponsor.url ? SPONSOR_REL : undefined}
+                  href={sponsor.href}
+                  target={sponsor.href ? '_blank' : undefined}
+                  rel={sponsor.href ? SPONSOR_REL : undefined}
                   class="group flex items-center gap-3 rounded-xl border border-slate-200 bg-white px-6 py-4 transition-all duration-300 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5 dark:border-slate-700 dark:bg-slate-800 dark:hover:border-primary/40"
                 >
                   <img

--- a/website/src/pages/sponsors.astro
+++ b/website/src/pages/sponsors.astro
@@ -1,0 +1,115 @@
+---
+import { Heart } from '@lucide/astro';
+import BaseLayout from '@/layouts/BaseLayout.astro';
+import sponsorsData from '../../sponsors.json';
+
+interface Sponsor {
+  name: string;
+  image: string;
+  /** Sponsors that never set a website on their profile have no URL. */
+  url: string | null;
+}
+
+/*
+ * Logos come from whatever URL a sponsor has on their profile, so they are
+ * rendered as plain images rather than through `astro:assets` — that would
+ * mean adding every new sponsor's domain to `image.remotePatterns`.
+ *
+ * Sizes constrain the height and let the width follow, so that wordmarks stay
+ * legible instead of being squeezed into a square alongside the round avatars.
+ */
+/** `sponsored` marks these as paid links, per Google's guidance on link schemes. */
+const SPONSOR_REL = 'sponsored noopener noreferrer';
+
+const tiers = (
+  [
+    { key: 'headliner', title: 'Headlining Sponsors', size: 'h-14 max-w-48' },
+    { key: 'sponsor', title: 'Sponsors', size: 'h-11 max-w-40' },
+    { key: 'professional', title: 'Professional', size: 'h-9 max-w-36' },
+    { key: 'backer', title: 'Backers', size: 'h-9 max-w-36' },
+  ] as const
+)
+  .map((tier) => ({ ...tier, sponsors: sponsorsData[tier.key] as Sponsor[] }))
+  .filter((tier) => tier.sponsors.length > 0);
+---
+
+<BaseLayout
+  title="Sponsors"
+  description="The companies and individuals who fund Cheerio's development."
+>
+  <section class="relative overflow-hidden bg-slate-50 py-20 dark:bg-slate-800/50">
+    <div class="absolute inset-0 bg-[radial-gradient(ellipse_at_center,rgba(232,140,31,0.05),transparent_70%)]"></div>
+
+    <div class="relative mx-auto max-w-5xl px-6">
+      <div class="animate-fade-up text-center">
+        <p class="mb-3 text-sm font-semibold uppercase tracking-widest text-primary">Thank you</p>
+        <h1 class="font-display text-4xl text-slate-900 dark:text-white">
+          Cheerio's Sponsors
+        </h1>
+        <p class="mx-auto mt-6 max-w-2xl text-lg leading-relaxed text-slate-600 dark:text-slate-400">
+          Cheerio is free and open source. These companies and individuals fund its
+          development and support, and let maintainers spend more time on the project.
+        </p>
+      </div>
+
+      {
+        tiers.map((tier, index) => (
+          <div class:list={['animate-fade-up mt-16', index > 0 && 'animation-delay-100']}>
+            <h2 class="mb-8 text-center text-xs font-semibold uppercase tracking-widest text-slate-500 dark:text-slate-400">
+              {tier.title}
+            </h2>
+            <div class="flex flex-wrap items-center justify-center gap-6">
+              {tier.sponsors.map((sponsor) => (
+                <a
+                  href={sponsor.url ?? undefined}
+                  target={sponsor.url ? '_blank' : undefined}
+                  rel={sponsor.url ? SPONSOR_REL : undefined}
+                  class="group flex items-center gap-3 rounded-xl border border-slate-200 bg-white px-6 py-4 transition-all duration-300 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5 dark:border-slate-700 dark:bg-slate-800 dark:hover:border-primary/40"
+                >
+                  <img
+                    src={sponsor.image}
+                    alt={`${sponsor.name} logo`}
+                    class:list={['w-auto rounded-lg object-contain', tier.size]}
+                    loading="lazy"
+                  />
+                  <span class="font-medium text-slate-700 transition-colors group-hover:text-slate-900 dark:text-slate-300 dark:group-hover:text-white">
+                    {sponsor.name}
+                  </span>
+                </a>
+              ))}
+            </div>
+          </div>
+        ))
+      }
+
+      <div class="animate-fade-up animation-delay-400 mt-20 text-center">
+        <h2 class="font-display text-2xl text-slate-900 dark:text-white">
+          Does your company use Cheerio?
+        </h2>
+        <p class="mx-auto mt-4 max-w-xl text-slate-600 dark:text-slate-400">
+          Sponsorships are what keep Cheerio maintained. Every tier gets your logo here
+          and in our README, with a link back to your site.
+        </p>
+        <div class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <a
+            href="https://github.com/sponsors/cheeriojs"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-2 rounded-full border border-primary/30 bg-primary/5 px-6 py-2.5 text-sm font-medium text-primary transition-all duration-300 hover:border-primary/50 hover:bg-primary/10 dark:text-primary-light"
+          >
+            <Heart class="h-5 w-5" fill="currentColor" stroke-width={0} />
+            GitHub Sponsors
+          </a>
+          <a
+            href="https://opencollective.com/cheerio"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-2 rounded-full border border-slate-300 px-6 py-2.5 text-sm font-medium text-slate-700 transition-all duration-300 hover:border-slate-400 dark:border-slate-600 dark:text-slate-300 dark:hover:border-slate-500"
+          >
+            Open Collective
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</BaseLayout>


### PR DESCRIPTION
## What

Adds a `/sponsors` page listing every sponsor tier, linked from the landing page ("See all sponsors") and the footer.

## Why

The $100 **Sponsors** tier on Open Collective promises:

> Become a sponsor and get your logo on our README on Github, **as well as a subpage of our website**, with a link to your site.

That subpage never existed. `Sponsors.astro` is only used by `index.astro` and renders `sponsorsData.headliner` exclusively, so nothing on the site listed sponsor-tier contributors at all. RapidProxy asked about their missing placement, which is what surfaced it — but it affects every $100 sponsor.

The landing page stays headliners-only, which is what the $250 **Headline Sponsor** tier pays for.

## Screenshots

| Light | Dark |
| --- | --- |
| <img src="https://raw.githubusercontent.com/cheeriojs/cheerio/sponsors-page-screenshots/sponsors-light.png" width="100%"> | <img src="https://raw.githubusercontent.com/cheeriojs/cheerio/sponsors-page-screenshots/sponsors-dark.png" width="100%"> |

## Notes

- **Logos are height-constrained, not square.** RapidProxy's logo is a 432×92 wordmark; forcing it into a square box shrank it to near-illegible. The README works around this with an imgix `rect` crop, but the site reads `image` from `sponsors.json` directly, so it needs to handle varying aspect ratios itself.
- **Plain `<img>`, not `astro:assets`.** Logo URLs come from whatever a sponsor sets on their profile, so using `<Image>` would mean adding each new sponsor's domain to `image.remotePatterns` — `www.rapidproxy.io` isn't there today.
- **Links are `rel="sponsored"`**, per Google's guidance on paid links. The README's links are not; worth a follow-up.
- Sponsors with no website on their profile render without a link rather than as `href="null"`.
- Empty tiers are skipped, so the Backers heading doesn't render while that tier is empty.

Verified with `astro check` (0 errors) and `astro build`.

The screenshots live on the `sponsors-page-screenshots` branch, which can be deleted once this merges.

Created by Claude Opus 5.
