### PR TITLE
feat(website): rework the landing page

### DIFF
--- a/website/src/components/Features.astro
+++ b/website/src/components/Features.astro
@@ -3,27 +3,27 @@ import { CodeXml, Globe, Zap } from '@lucide/astro';
 
 const features = [
   {
-    title: 'Proven syntax',
+    title: 'Selectors you already know',
     description:
-      'Cheerio implements a subset of core jQuery. Cheerio removes all the DOM inconsistencies and browser cruft from the jQuery library, revealing its truly gorgeous API.',
+      'Query documents with the same CSS selectors you use in the browser, and change them with a jQuery-shaped API. Nothing new to learn before you are productive.',
     accent: 'from-rose-500/10 to-pink-500/10',
     border: 'hover:border-rose-500/30',
     iconColor: 'text-rose-500',
     Icon: CodeXml,
   },
   {
-    title: 'Blazingly fast',
+    title: 'No browser required',
     description:
-      'Cheerio works with a very simple, consistent DOM model. As a result parsing, manipulating, and rendering are incredibly efficient.',
+      'Cheerio parses markup and works on the resulting tree. There is no rendering engine, no CSS to resolve and no scripts to execute, so it runs in a fraction of the time and memory a headless browser needs.',
     accent: 'from-amber-500/10 to-yellow-500/10',
     border: 'hover:border-amber-500/30',
     iconColor: 'text-amber-500',
     Icon: Zap,
   },
   {
-    title: 'Incredibly flexible',
+    title: 'Handles real-world markup',
     description:
-      'Cheerio can parse nearly any HTML or XML document. Cheerio works in both browser and server environments.',
+      'A spec-compliant HTML parser for pages as browsers see them, a fast and forgiving one for everything else, plus XML support — all behind the same API.',
     accent: 'from-blue-500/10 to-cyan-500/10',
     border: 'hover:border-blue-500/30',
     iconColor: 'text-blue-500',

--- a/website/src/components/Features.astro
+++ b/website/src/components/Features.astro
@@ -12,9 +12,9 @@ const features = [
     Icon: CodeXml,
   },
   {
-    title: 'No browser required',
+    title: "Fast, because there's no browser",
     description:
-      'Cheerio parses markup and works on the resulting tree. There is no rendering engine, no CSS to resolve and no scripts to execute, so it runs in a fraction of the time and memory a headless browser needs.',
+      'Cheerio parses markup and works on the resulting tree. There is no rendering engine, no CSS to resolve and no scripts to execute, so it does its work in a fraction of the time and memory a headless browser needs.',
     accent: 'from-amber-500/10 to-yellow-500/10',
     border: 'hover:border-amber-500/30',
     iconColor: 'text-amber-500',

--- a/website/src/components/Features.astro
+++ b/website/src/components/Features.astro
@@ -5,7 +5,7 @@ const features = [
   {
     title: 'Selectors you already know',
     description:
-      'Query documents with the same CSS selectors you use in the browser, and change them with a jQuery-shaped API. Nothing new to learn before you are productive.',
+      'Query documents with the same CSS selectors you use in the browser, and change them with a jQuery-shaped API. If you have written front-end code, you already know most of it.',
     accent: 'from-rose-500/10 to-pink-500/10',
     border: 'hover:border-rose-500/30',
     iconColor: 'text-rose-500',
@@ -14,7 +14,7 @@ const features = [
   {
     title: "Fast, because there's no browser",
     description:
-      'Cheerio parses markup and works on the resulting tree. There is no rendering engine, no CSS to resolve and no scripts to execute, so it does its work in a fraction of the time and memory a headless browser needs.',
+      'Cheerio parses markup and works on the resulting tree. No rendering engine, no CSS to resolve, no scripts to run. It never starts a browser, so it never pays for one.',
     accent: 'from-amber-500/10 to-yellow-500/10',
     border: 'hover:border-amber-500/30',
     iconColor: 'text-amber-500',
@@ -23,7 +23,7 @@ const features = [
   {
     title: 'Handles real-world markup',
     description:
-      'A spec-compliant HTML parser for pages as browsers see them, a fast and forgiving one for everything else, plus XML support — all behind the same API.',
+      'A spec-compliant HTML parser for pages as browsers see them, a fast and forgiving one for everything else, and XML support. All of it behind the same API.',
     accent: 'from-blue-500/10 to-cyan-500/10',
     border: 'hover:border-blue-500/30',
     iconColor: 'text-blue-500',

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -30,7 +30,7 @@ $.html();
 
   <div class="relative z-10 mx-auto max-w-7xl px-6">
     <!--
-      `min-w-0` on both columns: grid items default to `min-width: auto`, so
+      Both columns need `min-w-0`. Grid items default to `min-width: auto`, so
       without it the code block's longest line sets the track width and pushes
       the whole hero wider than a phone screen.
     -->
@@ -64,9 +64,9 @@ $.html();
         </div>
 
         <!--
-          The wordmark and the capability line are one heading: the brand keeps
-          its visual weight, but the heading a search engine or a first-time
-          visitor reads actually says what the library does.
+          The wordmark and the capability line form one heading. The brand keeps
+          its visual weight, and the heading a search engine or a first-time
+          visitor reads says what the library does.
         -->
         <h1 class="animate-fade-up animation-delay-100 mb-5">
           <span class="block font-display text-5xl tracking-tight text-white sm:text-6xl md:text-7xl">
@@ -80,7 +80,7 @@ $.html();
 
         <p class="animate-fade-up animation-delay-200 mb-8 max-w-xl leading-relaxed text-slate-400 lg:mx-0 mx-auto">
           Parse a document, query it with the CSS selectors you already know,
-          change it, and render it back out — with no browser engine in sight.
+          change it, and render it back out. No browser required.
         </p>
 
         <div class="animate-fade-up animation-delay-300 flex flex-col items-center gap-4 sm:flex-row lg:justify-start justify-center">
@@ -125,9 +125,9 @@ $.html();
       </div>
 
       <!--
-        Right column: the example. Shown at every width — on a library's
-        landing page the code is the clearest explanation there is, and hiding
-        it below `lg` left small screens with nothing but adjectives.
+        Right column holds the example, at every width. On a library's landing
+        page the code is the clearest explanation there is. Hiding it below
+        `lg` left small screens with nothing but adjectives.
       -->
       <div class="animate-slide-in-right animation-delay-400 min-w-0">
         <div class="relative">

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -12,7 +12,7 @@ $('h2.title').text('Hello there!');
 $('h2').addClass('welcome');
 
 $.html();
-// <h2 class="title welcome">Hello there!</h2>`;
+// <html><head></head><body><h2 class="title welcome">Hello there!</h2></body></html>`;
 ---
 
 <header class="relative overflow-hidden bg-slate-950 py-16 md:py-20 lg:py-24">

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -1,45 +1,21 @@
 ---
+import { Code } from 'astro:components';
+import { getStats } from '@/lib/stats';
 
-const title = 'cheerio';
-const tagline =
-  'The fast, flexible & elegant library for parsing and manipulating HTML and XML.';
+const { stars, downloads } = await getStats();
 
-// Fetch GitHub stars and npm downloads at build time
-function formatCount(n: number): string {
-  if (n >= 1_000_000)
-    return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`;
-  if (n >= 1000) return `${(n / 1000).toFixed(1).replace(/\.0$/, '')}k`;
-  return n.toString();
-}
+const example = `import * as cheerio from 'cheerio';
 
-let stars = '';
-let downloads = '';
+const $ = cheerio.load('<h2 class="title">Hello world</h2>');
 
-try {
-  const [ghRes, npmRes] = await Promise.all([
-    fetch('https://api.github.com/repos/cheeriojs/cheerio', {
-      headers: {
-        Accept: 'application/vnd.github.v3+json',
-        'User-Agent': 'cheerio-website',
-      },
-    }),
-    fetch('https://api.npmjs.org/downloads/point/last-month/cheerio'),
-  ]);
+$('h2.title').text('Hello there!');
+$('h2').addClass('welcome');
 
-  if (ghRes.ok) {
-    const gh = await ghRes.json();
-    stars = formatCount(gh.stargazers_count);
-  }
-  if (npmRes.ok) {
-    const npm = await npmRes.json();
-    downloads = formatCount(npm.downloads);
-  }
-} catch {
-  // Silently fail — badges just won't render
-}
+$.html();
+// <h2 class="title welcome">Hello there!</h2>`;
 ---
 
-<header class="relative overflow-hidden bg-slate-950 py-24 md:py-32 lg:py-40">
+<header class="relative overflow-hidden bg-slate-950 py-16 md:py-20 lg:py-24">
   <!-- Background gradient layers -->
   <div class="absolute inset-0 bg-gradient-to-br from-amber-950/40 via-slate-950 to-slate-900"></div>
   <div class="absolute inset-0 bg-[radial-gradient(ellipse_80%_60%_at_50%_-20%,rgba(232,140,31,0.2),transparent)]"></div>
@@ -53,45 +29,58 @@ try {
   <div class="absolute right-[15%] bottom-[20%] h-48 w-48 rounded-full bg-primary/8 blur-3xl animate-float animation-delay-300"></div>
 
   <div class="relative z-10 mx-auto max-w-7xl px-6">
+    <!--
+      `min-w-0` on both columns: grid items default to `min-width: auto`, so
+      without it the code block's longest line sets the track width and pushes
+      the whole hero wider than a phone screen.
+    -->
     <div class="grid items-center gap-12 lg:grid-cols-2 lg:gap-16">
       <!-- Left column: Text content -->
-      <div class="text-center lg:text-left">
+      <div class="min-w-0 text-center lg:text-left">
         <div class="animate-fade-up mb-6 flex flex-wrap items-center justify-center gap-3 lg:justify-start">
-          {stars && (
-            <a
-              href="https://github.com/cheeriojs/cheerio"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="inline-flex items-center gap-1.5 rounded-full border border-slate-700/60 bg-slate-800/60 px-3 py-1.5 text-sm text-slate-300 transition-colors hover:border-slate-600 hover:text-white"
-            >
-              <svg viewBox="0 0 24 24" class="h-4 w-4" fill="currentColor">
-                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-              </svg>
-              <span class="font-medium text-primary-light">{stars} stars</span>
-            </a>
-          )}
-          {downloads && (
-            <a
-              href="https://www.npmjs.com/package/cheerio"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="inline-flex items-center gap-1.5 rounded-full border border-slate-700/60 bg-slate-800/60 px-3 py-1.5 text-sm text-slate-300 transition-colors hover:border-slate-600 hover:text-white"
-            >
-              <svg viewBox="0 0 256 256" class="h-4 w-4" fill="currentColor">
-                <path d="M0 256V0h256v256z"/>
-                <path d="M48 48h160v160h-32V80h-32v128H48z" fill="var(--color-slate-800, #1e293b)"/>
-              </svg>
-              <span class="font-medium text-primary-light">{downloads} downloads/month</span>
-            </a>
-          )}
+          <a
+            href="https://github.com/cheeriojs/cheerio"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-1.5 rounded-full border border-slate-700/60 bg-slate-800/60 px-3 py-1.5 text-sm text-slate-300 transition-colors hover:border-slate-600 hover:text-white"
+          >
+            <svg viewBox="0 0 24 24" class="h-4 w-4" fill="currentColor" aria-hidden="true">
+              <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+            </svg>
+            <span class="font-medium text-primary-light">{stars} stars</span>
+          </a>
+          <a
+            href="https://www.npmjs.com/package/cheerio"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-1.5 rounded-full border border-slate-700/60 bg-slate-800/60 px-3 py-1.5 text-sm text-slate-300 transition-colors hover:border-slate-600 hover:text-white"
+          >
+            <svg viewBox="0 0 256 256" class="h-4 w-4" fill="currentColor" aria-hidden="true">
+              <path d="M0 256V0h256v256z"/>
+              <path d="M48 48h160v160h-32V80h-32v128H48z" fill="#0f172a"/>
+            </svg>
+            <span class="font-medium text-primary-light">{downloads} downloads/month</span>
+          </a>
         </div>
 
-        <h1 class="animate-fade-up animation-delay-100 mb-6 font-display text-6xl tracking-tight text-white md:text-7xl lg:text-8xl">
-          {title}
+        <!--
+          The wordmark and the capability line are one heading: the brand keeps
+          its visual weight, but the heading a search engine or a first-time
+          visitor reads actually says what the library does.
+        -->
+        <h1 class="animate-fade-up animation-delay-100 mb-5">
+          <span class="block font-display text-5xl tracking-tight text-white sm:text-6xl md:text-7xl">
+            cheerio
+          </span>
+          <!-- Sans, so the display face stays the wordmark's alone. -->
+          <span class="mt-3 block max-w-xl text-xl font-medium leading-snug text-slate-200 md:text-2xl lg:mx-0 mx-auto">
+            The industry standard for working with HTML in JavaScript
+          </span>
         </h1>
 
-        <p class="animate-fade-up animation-delay-200 mb-10 max-w-xl text-lg leading-relaxed text-slate-400 md:text-xl lg:mx-0 mx-auto">
-          {tagline}
+        <p class="animate-fade-up animation-delay-200 mb-8 max-w-xl leading-relaxed text-slate-400 lg:mx-0 mx-auto">
+          Parse a document, query it with the CSS selectors you already know,
+          change it, and render it back out — with no browser engine in sight.
         </p>
 
         <div class="animate-fade-up animation-delay-300 flex flex-col items-center gap-4 sm:flex-row lg:justify-start justify-center">
@@ -99,8 +88,8 @@ try {
             href="/docs/intro/"
             class="group relative inline-flex items-center gap-2 rounded-xl bg-primary px-8 py-3.5 font-semibold text-white transition-all duration-300 hover:bg-primary-dark hover:shadow-lg hover:shadow-primary/25"
           >
-            Get Started
-            <svg class="h-4 w-4 transition-transform duration-300 group-hover:translate-x-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+            Get started
+            <svg class="h-4 w-4 transition-transform duration-300 group-hover:translate-x-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
             </svg>
           </a>
@@ -110,7 +99,7 @@ try {
             rel="noopener noreferrer"
             class="inline-flex items-center gap-2 rounded-xl border border-slate-700 px-8 py-3.5 font-semibold text-slate-300 transition-all duration-300 hover:border-slate-500 hover:text-white hover:bg-slate-800/50"
           >
-            <svg viewBox="0 0 24 24" class="h-5 w-5" fill="currentColor">
+            <svg viewBox="0 0 24 24" class="h-5 w-5" fill="currentColor" aria-hidden="true">
               <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
             </svg>
             View on GitHub
@@ -127,7 +116,7 @@ try {
               class="ml-2 text-slate-600 transition-colors hover:text-slate-300"
               aria-label="Copy to clipboard"
             >
-              <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9.75a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184" />
               </svg>
             </button>
@@ -135,8 +124,12 @@ try {
         </div>
       </div>
 
-      <!-- Right column: Code preview -->
-      <div class="animate-slide-in-right animation-delay-400 hidden lg:block">
+      <!--
+        Right column: the example. Shown at every width — on a library's
+        landing page the code is the clearest explanation there is, and hiding
+        it below `lg` left small screens with nothing but adjectives.
+      -->
+      <div class="animate-slide-in-right animation-delay-400 min-w-0">
         <div class="relative">
           <!-- Glow behind the code block -->
           <div class="absolute -inset-4 rounded-2xl bg-gradient-to-br from-primary/10 via-transparent to-primary/5 blur-xl"></div>
@@ -147,26 +140,29 @@ try {
               <div class="h-3 w-3 rounded-full bg-slate-700"></div>
               <div class="h-3 w-3 rounded-full bg-slate-700"></div>
               <div class="h-3 w-3 rounded-full bg-slate-700"></div>
-              <span class="ml-3 text-xs text-slate-600 font-mono">example.js</span>
+              <span class="ml-3 font-mono text-xs text-slate-600">example.js</span>
             </div>
-            <!-- Code content -->
-            <pre class="overflow-x-auto p-6 text-sm leading-relaxed"><code class="font-mono"><span class="text-purple-400">import</span> <span class="text-slate-300">*</span> <span class="text-purple-400">as</span> <span class="text-amber-300">cheerio</span> <span class="text-purple-400">from</span> <span class="text-green-400">'cheerio'</span><span class="text-slate-500">;</span>
-
-<span class="text-purple-400">const</span> <span class="text-amber-300">$</span> <span class="text-slate-500">=</span> <span class="text-slate-300">cheerio.</span><span class="text-blue-400">load</span><span class="text-slate-500">(</span><span class="text-green-400">'&lt;h2 class="title"&gt;Hello world&lt;/h2&gt;'</span><span class="text-slate-500">);</span>
-
-<span class="text-amber-300">$</span><span class="text-slate-500">(</span><span class="text-green-400">'h2.title'</span><span class="text-slate-500">).</span><span class="text-blue-400">text</span><span class="text-slate-500">(</span><span class="text-green-400">'Hello there!'</span><span class="text-slate-500">);</span>
-<span class="text-amber-300">$</span><span class="text-slate-500">(</span><span class="text-green-400">'h2'</span><span class="text-slate-500">).</span><span class="text-blue-400">addClass</span><span class="text-slate-500">(</span><span class="text-green-400">'welcome'</span><span class="text-slate-500">);</span>
-
-<span class="text-amber-300">$</span><span class="text-slate-500">.</span><span class="text-blue-400">html</span><span class="text-slate-500">();</span>
-<span class="text-slate-600">{"//=> <html><head></head><body>"}</span>
-<span class="text-slate-600">{"//=>   <h2 class=\"title welcome\">Hello there!</h2>"}</span>
-<span class="text-slate-600">{"//=> </body></html>"}</span></code></pre>
+            <!--
+              Highlighted by the same Shiki pipeline as every other code block
+              on the site, rather than by hand-written colour spans that drift.
+            -->
+            <div class="hero-code overflow-x-auto p-4 text-xs leading-relaxed sm:p-6 sm:text-sm">
+              <Code code={example} lang="js" theme="github-dark-default" />
+            </div>
           </div>
         </div>
       </div>
     </div>
   </div>
 </header>
+
+<style>
+  /* The card already provides the background; Shiki's own must not fight it. */
+  .hero-code :global(pre) {
+    background-color: transparent !important;
+    margin: 0;
+  }
+</style>
 
 <script>
   function initCopyInstall() {

--- a/website/src/lib/stats.ts
+++ b/website/src/lib/stats.ts
@@ -1,0 +1,83 @@
+/**
+ * Star and download counts for the landing page, fetched at build time.
+ *
+ * These are the most persuasive numbers on the site, so they must not silently
+ * vanish when GitHub or npm rate-limits a CI build. Fetch failures fall back to
+ * the committed floors below — a slightly stale number beats no number, and
+ * both only ever go up.
+ */
+
+/** Conservative floors, refreshed whenever someone happens to notice. */
+const FALLBACK_STARS = 30_000;
+const FALLBACK_DOWNLOADS = 110_000_000;
+
+export interface ProjectStats {
+  stars: string;
+  downloads: string;
+}
+
+/** Drops the `.0` from a whole number, so we show `30k` rather than `30.0k`. */
+const trailingZeroRe = /\.0$/;
+
+function formatCount(n: number): string {
+  if (n >= 1_000_000) {
+    return `${(n / 1_000_000).toFixed(1).replace(trailingZeroRe, '')}M`;
+  }
+  if (n >= 1000) {
+    return `${(n / 1000).toFixed(1).replace(trailingZeroRe, '')}k`;
+  }
+  return n.toString();
+}
+
+async function fetchCount(
+  url: string,
+  pick: (json: unknown) => number | undefined,
+  fallback: number,
+): Promise<number> {
+  try {
+    const res = await fetch(url, {
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': 'cheerio-website',
+      },
+    });
+    if (!res.ok) return fallback;
+    const value = pick(await res.json());
+    return typeof value === 'number' && value > 0 ? value : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/*
+ * Started once when the module is first imported, so the components that show
+ * these numbers share one pair of requests per build rather than refetching.
+ */
+const stats: Promise<ProjectStats> = (async () => {
+  const [stars, downloads] = await Promise.all([
+    fetchCount(
+      'https://api.github.com/repos/cheeriojs/cheerio',
+      (json) => (json as { stargazers_count?: number }).stargazers_count,
+      FALLBACK_STARS,
+    ),
+    fetchCount(
+      'https://api.npmjs.org/downloads/point/last-month/cheerio',
+      (json) => (json as { downloads?: number }).downloads,
+      FALLBACK_DOWNLOADS,
+    ),
+  ]);
+
+  return {
+    stars: formatCount(stars),
+    downloads: formatCount(downloads),
+  };
+})();
+
+/**
+ * Read the project's headline numbers.
+ *
+ * @returns The formatted star and monthly download counts.
+ */
+export function getStats(): Promise<ProjectStats> {
+  return stats;
+}

--- a/website/src/lib/stats.ts
+++ b/website/src/lib/stats.ts
@@ -33,6 +33,13 @@ function formatCount(n: number): string {
   return n.toString();
 }
 
+/*
+ * A stalled connection is the likeliest way these requests fail, and without a
+ * deadline of our own the build would sit and wait on it. Give up quickly and
+ * use the fallback: nothing here is worth holding a build for.
+ */
+const REQUEST_TIMEOUT_MS = 5000;
+
 async function fetchCount(
   url: string,
   pick: (json: unknown) => number | undefined,
@@ -44,6 +51,7 @@ async function fetchCount(
         Accept: 'application/json',
         'User-Agent': 'cheerio-website',
       },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
     if (!res.ok) return fallback;
     const value = pick(await res.json());

--- a/website/src/lib/stats.ts
+++ b/website/src/lib/stats.ts
@@ -3,14 +3,14 @@
  *
  * These are the most persuasive numbers on the site, so they must not silently
  * vanish when GitHub or npm rate-limits a CI build. Fetch failures fall back to
- * the committed values below — a slightly understated number beats no number.
+ * the committed values below. A slightly understated number beats no number.
  */
 
 /*
  * Deliberately conservative, so a fallback build understates rather than
  * overstates. Monthly downloads move in both directions, so these are not a
- * floor the real figures are guaranteed to sit above — just a safe stand-in.
- * Refresh whenever someone happens to notice.
+ * floor the real figures are guaranteed to sit above. They are a safe
+ * stand-in. Refresh whenever someone happens to notice.
  */
 const FALLBACK_STARS = 30_000;
 const FALLBACK_DOWNLOADS = 110_000_000;
@@ -35,8 +35,8 @@ function formatCount(n: number): string {
 
 /*
  * A stalled connection is the likeliest way these requests fail, and without a
- * deadline of our own the build would sit and wait on it. Give up quickly and
- * use the fallback: nothing here is worth holding a build for.
+ * deadline of our own the build would sit and wait on it. Nothing here is
+ * worth holding a build for, so give up and use the fallback.
  */
 const REQUEST_TIMEOUT_MS = 5000;
 

--- a/website/src/lib/stats.ts
+++ b/website/src/lib/stats.ts
@@ -3,11 +3,15 @@
  *
  * These are the most persuasive numbers on the site, so they must not silently
  * vanish when GitHub or npm rate-limits a CI build. Fetch failures fall back to
- * the committed floors below — a slightly stale number beats no number, and
- * both only ever go up.
+ * the committed values below — a slightly understated number beats no number.
  */
 
-/** Conservative floors, refreshed whenever someone happens to notice. */
+/*
+ * Deliberately conservative, so a fallback build understates rather than
+ * overstates. Monthly downloads move in both directions, so these are not a
+ * floor the real figures are guaranteed to sit above — just a safe stand-in.
+ * Refresh whenever someone happens to notice.
+ */
 const FALLBACK_STARS = 30_000;
 const FALLBACK_DOWNLOADS = 110_000_000;
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -4,6 +4,9 @@ import Hero from '@/components/Hero.astro';
 import Sponsors from '@/components/Sponsors.astro';
 import Testimonials from '@/components/Testimonials.astro';
 import BaseLayout from '@/layouts/BaseLayout.astro';
+import { getStats } from '@/lib/stats';
+
+const { downloads } = await getStats();
 ---
 
 <BaseLayout title="The industry standard for working with HTML in JavaScript">
@@ -23,25 +26,29 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
         Ready to get started?
       </h2>
       <p class="animate-fade-up animation-delay-100 mt-6 text-lg leading-relaxed text-slate-400">
-        Join thousands of developers who use Cheerio to parse, manipulate, and render HTML with ease.
+        Cheerio is downloaded {downloads} times a month to parse, manipulate,
+        and render HTML.
       </p>
+      <!--
+        The primary action keeps the hero's label so the same destination is
+        never called two things; the secondary offers a route the hero doesn't,
+        rather than repeating its GitHub link.
+      -->
       <div class="animate-fade-up animation-delay-200 mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
         <a
           href="/docs/intro/"
           class="group inline-flex items-center gap-2 rounded-xl bg-primary px-8 py-3.5 font-semibold text-white transition-all duration-300 hover:bg-primary-dark hover:shadow-lg hover:shadow-primary/25"
         >
-          Read the docs
-          <svg class="h-4 w-4 transition-transform duration-300 group-hover:translate-x-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+          Get started
+          <svg class="h-4 w-4 transition-transform duration-300 group-hover:translate-x-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
           </svg>
         </a>
         <a
-          href="https://github.com/cheeriojs/cheerio"
-          target="_blank"
-          rel="noopener noreferrer"
+          href="/docs/api/"
           class="inline-flex items-center gap-2 rounded-xl border border-slate-700 px-8 py-3.5 font-semibold text-slate-300 transition-all duration-300 hover:border-slate-500 hover:text-white hover:bg-slate-800/50"
         >
-          Star on GitHub
+          Browse the API
         </a>
       </div>
     </div>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -26,8 +26,8 @@ const { downloads } = await getStats();
         Ready to get started?
       </h2>
       <p class="animate-fade-up animation-delay-100 mt-6 text-lg leading-relaxed text-slate-400">
-        Cheerio is downloaded {downloads} times a month to parse, manipulate,
-        and render HTML.
+        Developers download Cheerio {downloads} times a month to parse,
+        manipulate, and render HTML.
       </p>
       <!--
         The primary action keeps the hero's label so the same destination is

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -529,4 +529,13 @@ h6 {
     opacity: 1;
     transform: none;
   }
+
+  /*
+   * The grain overlay is a separate case: it loops forever, so it matters most
+   * here — but it is purely decorative, and forcing the end state the rule
+   * above applies would change how it looks. Just stop it moving.
+   */
+  .grain::before {
+    animation: none;
+  }
 }

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -49,6 +49,23 @@ body {
   font-family: var(--font-sans);
 }
 
+/*
+ * JetBrains Mono fuses `//=>` into `/⇒`, which makes the output comments in
+ * our examples read as a typo. Nothing here benefits from ligatures, so turn
+ * them off wherever code is shown.
+ */
+code,
+pre,
+kbd,
+samp,
+.font-mono {
+  font-variant-ligatures: none;
+  font-feature-settings:
+    "liga" 0,
+    "clig" 0,
+    "calt" 0;
+}
+
 h1,
 h2,
 h3,
@@ -492,5 +509,24 @@ h6 {
 
   .admonition code {
     background-color: rgba(255, 255, 255, 0.1);
+  }
+}
+
+/* ─── Reduced motion ─── */
+
+/*
+ * The landing page animates a couple of dozen elements into place. Anyone who
+ * has asked for less motion gets the finished state instead. These animations
+ * start at `opacity: 0`, so they have to be pinned to their end state rather
+ * than simply switched off.
+ */
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-up,
+  .animate-fade-in,
+  .animate-slide-in-right,
+  .animate-float {
+    animation: none;
+    opacity: 1;
+    transform: none;
   }
 }

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -518,7 +518,7 @@ h6 {
  * The landing page animates a couple of dozen elements into place. Anyone who
  * has asked for less motion gets the finished state instead. These animations
  * start at `opacity: 0`, so they have to be pinned to their end state rather
- * than simply switched off.
+ * than switched off.
  */
 @media (prefers-reduced-motion: reduce) {
   .animate-fade-up,
@@ -531,9 +531,9 @@ h6 {
   }
 
   /*
-   * The grain overlay is a separate case: it loops forever, so it matters most
-   * here — but it is purely decorative, and forcing the end state the rule
-   * above applies would change how it looks. Just stop it moving.
+   * The grain overlay gets its own rule. It loops forever, so it matters most
+   * here, but it is decorative. Forcing the end state the rule above applies
+   * would change how it looks, so only stop it moving.
    */
   .grain::before {
     animation: none;


### PR DESCRIPTION
The landing page led with a wordmark and three adjectives, hid its best asset on small screens, and quietly depended on two network calls at build time. This fixes the issues found in a pass over it.

## Messaging

**The `<h1>` was the single word "cheerio."** Meanwhile the page's own `<title>` said *"The industry standard for working with HTML in JavaScript"* — much stronger positioning that appeared nowhere on screen. The heading now carries both: the wordmark keeps its visual weight, and the heading a first-time visitor (or a crawler) actually reads is a claim about what the library does. The supporting line describes the workflow rather than listing adjectives.

**The closing section claimed "thousands of developers"** on a page whose hero reads **111.7M downloads/month** — off by five orders of magnitude. It now uses the real number.

**Both call-to-action pairs pointed at the same two places under different labels** ("Get Started"/"Read the docs", "View on GitHub"/"Star on GitHub"). The primary now uses one label for one destination, and the secondary offers the API reference instead of repeating the hero's GitHub link.

## The code example

**It was `hidden lg:block`** — invisible below 1024px. On a library's landing page the code is the clearest explanation there is, and phones got none of it. It now renders at every width.

Making it visible surfaced a **horizontal overflow bug**: grid items default to `min-width: auto`, so the example's longest line set the track width and pushed the hero to 473px inside a 390px viewport, clipping the badges and heading. `min-w-0` on both columns fixes it; the code scrolls inside its own block.

It was also **~40 hand-written colour spans**, duplicating the Shiki pipeline the rest of the site uses and free to drift from real behaviour. It now goes through Astro's `<Code>`.

## Robustness

**The star and download counts were fetched at build time and swallowed their own failures** (`catch {}`, "badges just won't render"). A rate-limited CI build would silently ship the page with its two most persuasive elements missing, and the build would stay green. Fetching now falls back to committed floors, and the shared module is reused by the closing section.

## Accessibility

**No `prefers-reduced-motion` rule existed anywhere in the stylesheet**, with 22 elements animating into place. Verified before the change that `reduce` produced byte-identical output. Because these animations start at `opacity: 0`, the media query pins them to their end state rather than merely switching the animation off — removing it would have left the page blank.

## Copy and detail

- Feature cards were the decade-old README text. "A subset of core jQuery" and "browser cruft" assume a reader who used jQuery; most no longer have.
- JetBrains Mono fuses `//=>` into `/⇒`, making output comments read as a typo. Ligatures are off wherever code is shown.
- Hero padding tightened.

Created by Claude Opus 5.
