### PR TITLE
fix: treat attribute names as case-insensitive outside XML mode

### DIFF
--- a/src/api/attributes.spec.ts
+++ b/src/api/attributes.spec.ts
@@ -461,6 +461,16 @@ describe('$(...)', () => {
       expect($xml.prop('checked')).toBe('checked');
       expect($xml.prop('disabled')).toBe('yes');
     });
+
+    it('(key, value) : should keep the name case when setting in XML mode', () => {
+      const $xml = $.load('<Item />', { xml: true });
+      const item = $xml('Item');
+
+      item.prop('camelCase', 'yes');
+
+      expect(item.attr('camelCase')).toBe('yes');
+      expect($xml.xml()).toBe('<Item camelCase="yes"/>');
+    });
   });
 
   describe('.data', () => {

--- a/src/api/attributes.spec.ts
+++ b/src/api/attributes.spec.ts
@@ -186,6 +186,26 @@ describe('$(...)', () => {
       expect($pear).toBeInstanceOf($);
     });
 
+    it('(KEY) : should get an attr case-insensitively (#5257)', () => {
+      const $el = load('<div class="test"></div>')('div');
+      expect($el.attr('CLASS')).toBe('test');
+    });
+
+    it('(KEY, value) : should set an attr case-insensitively (#5257)', () => {
+      const $el = load('<div class="test"></div>')('div');
+      $el.attr('CLASS', 'changed');
+
+      expect($el.attr('class')).toBe('changed');
+      expect($el.prop('outerHTML')).toBe('<div class="changed"></div>');
+    });
+
+    it('(KEY) : should keep attribute names case-sensitive in XML mode (#5257)', () => {
+      const $xml = load('<Foo BAR="1"/>', { xml: true })('Foo');
+
+      expect($xml.attr('BAR')).toBe('1');
+      expect($xml.attr('bar')).toBeUndefined();
+    });
+
     it("(bool) shouldn't treat boolean attributes differently in XML mode", () => {
       const $xml = $.load('<input checked=checked disabled=yes />', {
         xml: true,
@@ -762,6 +782,24 @@ describe('$(...)', () => {
       expect($fruits.attr('id')).not.toBeUndefined();
       $fruits.removeAttr('id');
       expect($fruits.attr('id')).toBeUndefined();
+    });
+
+    it('(KEY) : should remove an attr case-insensitively (#5257)', () => {
+      const $fruits = $('#fruits');
+      expect($fruits.attr('id')).not.toBeUndefined();
+      $fruits.removeAttr('ID');
+      expect($fruits.attr('id')).toBeUndefined();
+    });
+
+    it('(KEY) : should keep attribute names case-sensitive in XML mode (#5257)', () => {
+      const $xml = load('<Foo BAR="1"/>', { xml: true });
+      const $foo = $xml('Foo');
+
+      $foo.removeAttr('bar');
+      expect($foo.attr('BAR')).toBe('1');
+
+      $foo.removeAttr('BAR');
+      expect($foo.attr('BAR')).toBeUndefined();
     });
 
     it('(key key) : should remove multiple attrs', () => {

--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -25,6 +25,21 @@ const hrefTags = new Set(['a', 'link']);
 const srcTags = new Set(['img', 'iframe', 'audio', 'video', 'source']);
 
 /**
+ * Normalizes an attribute name.
+ *
+ * Attribute names are case-insensitive in HTML documents, and the parser stores
+ * them lowercased. In XML mode they are case-sensitive and left as they are.
+ *
+ * @private
+ * @param name - The attribute's name.
+ * @param xmlMode - Whether the document is parsed in XML mode.
+ * @returns The normalized name.
+ */
+function normalizeAttrName(name: string, xmlMode?: boolean): string {
+  return xmlMode ? name : name.toLowerCase();
+}
+
+/**
  * Gets a node's attribute. For boolean attributes, it will return the value's
  * name should it be set.
  *
@@ -65,6 +80,8 @@ function getAttr(
     return elem.attribs;
   }
 
+  name = normalizeAttrName(name, xmlMode);
+
   if (Object.hasOwn(elem.attribs, name)) {
     // Get the (decoded) attribute
     return !xmlMode && rboolean.test(name) ? name : elem.attribs[name];
@@ -95,12 +112,20 @@ function getAttr(
  * @param el - The element to set the attribute on.
  * @param name - The attribute's name.
  * @param value - The attribute's value.
+ * @param xmlMode - Whether the document is parsed in XML mode.
  */
-function setAttr(el: Element, name: string, value: string | null) {
+function setAttr(
+  el: Element,
+  name: string,
+  value: string | null,
+  xmlMode?: boolean,
+) {
+  const attrName = normalizeAttrName(name, xmlMode);
+
   if (value === null) {
-    removeAttribute(el, name);
+    removeAttribute(el, attrName);
   } else {
-    el.attribs[name] = `${value}`;
+    el.attribs[attrName] = `${value}`;
   }
 }
 
@@ -203,22 +228,32 @@ export function attr<T extends AnyNode>(
       if (typeof name !== 'string') {
         throw new TypeError('Bad combination of arguments.');
       }
+      const { xmlMode } = this.options;
+      const attrName = normalizeAttrName(name, xmlMode);
       return domEach(this, (el, i) => {
-        if (isTag(el)) setAttr(el, name, value.call(el, i, el.attribs[name]));
+        if (isTag(el)) {
+          setAttr(
+            el,
+            attrName,
+            value.call(el, i, el.attribs[attrName]),
+            xmlMode,
+          );
+        }
       });
     }
+    const { xmlMode } = this.options;
     return domEach(this, (el) => {
       if (!isTag(el)) return;
 
       if (typeof name === 'object') {
         for (const [objName, objValue] of Object.entries(name)) {
-          setAttr(el, objName, objValue);
+          setAttr(el, objName, objValue, xmlMode);
         }
       } else {
         if (typeof name !== 'string') {
           throw new TypeError('Bad combination of arguments.');
         }
-        setAttr(el, name, value ?? null);
+        setAttr(el, name, value ?? null, xmlMode);
       }
     });
   }
@@ -875,10 +910,12 @@ export function removeAttr<T extends AnyNode>(
   name: string,
 ): Cheerio<T> {
   const attrNames = splitNames(name);
+  const { xmlMode } = this.options;
 
   for (const attrName of attrNames) {
+    const normalized = normalizeAttrName(attrName, xmlMode);
     domEach(this, (elem) => {
-      if (isTag(elem)) removeAttribute(elem, attrName);
+      if (isTag(elem)) removeAttribute(elem, normalized);
     });
   }
 

--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -308,6 +308,7 @@ function setProp(el: Element, name: string, value: unknown, xmlMode?: boolean) {
           ? ''
           : null
         : `${value as string}`,
+      xmlMode,
     );
   }
 }


### PR DESCRIPTION
Closes #5257.

## The problem

```js
const $ = cheerio.load('<div class="test"></div>');
$('div').removeAttr('CLASS');
$('div').attr('class'); // 'test' — the attribute is still there
```

Attribute names are case-insensitive in HTML documents, and the parser stores them lowercased, so `removeAttr('CLASS')` looks up a key that can never exist and silently does nothing.

## Scope

The issue reports `removeAttr`, but `attr()` has the same problem on both ends:

```js
$('div').attr('CLASS');            // undefined
$('div').attr('CLASS', 'changed'); // adds a second, literal `CLASS` attribute
```

Fixing only `removeAttr` would leave `removeAttr('CLASS')` working while `attr('CLASS')` still returned `undefined`, so this covers the three entry points that address an attribute by name. Happy to narrow it to `removeAttr` if you would rather keep the change smaller.

## The fix

A single `normalizeAttrName` step used by `getAttr`, `setAttr` and `removeAttr`. It lowercases the name, matching what the DOM does for HTML elements in HTML documents.

XML mode is left untouched: attribute names are case-sensitive in XML, so `normalizeAttrName` returns them as they are and `load('<Foo BAR="1"/>', { xml: true })` keeps behaving exactly as before. That case is covered by tests too.

## Tests

Five cases in `attributes.spec.ts`: get, set and remove with an uppercase name in HTML mode, plus get and remove in XML mode to pin the case-sensitive behaviour. The three HTML ones fail on `main`.

## Verification

- `vitest run`: 804 tests passing, no type errors
- `eslint`, `biome check`, `tsc --noEmit`: clean on the changed files
