### PR TITLE
fix(manipulation): copy the content when replacing several elements

### DIFF
--- a/src/api/manipulation.spec.ts
+++ b/src/api/manipulation.spec.ts
@@ -1624,6 +1624,25 @@ describe('$(...)', () => {
       expect($fruits.children()[2]).toBe($plum[0]);
     });
 
+    it('(elem) : should consume the replacement when the last element was removed', () => {
+      const $children = $fruits.children();
+      const $plum = $('<li class="plum">Plum</li>');
+
+      $children.last().remove();
+      $children.replaceWith($plum);
+
+      /*
+       * jQuery replaces the remaining elements with copies and still consumes
+       * the original: it is detached from its old position even though its
+       * target no longer has a parent to insert it under.
+       */
+      expect($fruits.children()).toHaveLength(2);
+      expect($('.plum')).toHaveLength(2);
+      expect($fruits.children()[0]).not.toBe($plum[0]);
+      expect($fruits.children()[1]).not.toBe($plum[0]);
+      expect($plum[0].parent).toBe(null);
+    });
+
     it('(elem) : should NOP if removed', () => {
       const $pear = $('.pear');
       const $plum = $('<li class="plum">Plum</li>');

--- a/src/api/manipulation.spec.ts
+++ b/src/api/manipulation.spec.ts
@@ -1574,6 +1574,56 @@ describe('$(...)', () => {
       expect($fruits.children()[1]).toBe($('.apple')[0]);
     });
 
+    it('(elem) : should replace every selected element with a copy', () => {
+      const $plum = $('<li class="plum">Plum</li>');
+
+      $fruits.children().replaceWith($plum);
+
+      const children = $fruits.children();
+      expect(children).toHaveLength(3);
+      expect($('.plum')).toHaveLength(3);
+      // Only the last element receives the original node
+      expect(children[0]).not.toBe($plum[0]);
+      expect(children[1]).not.toBe($plum[0]);
+      expect(children[2]).toBe($plum[0]);
+    });
+
+    it('(elem) : should copy the descendants of the replacement', () => {
+      const $plum = $('<li class="plum">Plum <b>!</b></li>');
+
+      $fruits.children().replaceWith($plum);
+
+      expect($.html($fruits)).toBe(
+        `<ul id="fruits">${'<li class="plum">Plum <b>!</b></li>'.repeat(3)}</ul>`,
+      );
+      // The copies are distinct nodes, not shared references
+      expect($('.plum b')).toHaveLength(3);
+      expect($('.plum b')[0]).not.toBe($('.plum b')[1]);
+    });
+
+    it('(Array) : should replace every selected element with a copy of the array', () => {
+      const more = $(
+        '<li class="plum">Plum</li><li class="grape">Grape</li>',
+      ).get();
+
+      $fruits.children().replaceWith(more);
+
+      expect($fruits.children()).toHaveLength(6);
+      expect($('.plum')).toHaveLength(3);
+      expect($('.grape')).toHaveLength(3);
+      expect($fruits.children()[4]).toBe(more[0]);
+      expect($fruits.children()[5]).toBe(more[1]);
+    });
+
+    it('(fn) : should replace every selected element with a copy of the returned node', () => {
+      const $plum = $('<li class="plum">Plum</li>');
+
+      $fruits.children().replaceWith(() => $plum);
+
+      expect($('.plum')).toHaveLength(3);
+      expect($fruits.children()[2]).toBe($plum[0]);
+    });
+
     it('(elem) : should NOP if removed', () => {
       const $pear = $('.pear');
       const $plum = $('<li class="plum">Plum</li>');

--- a/src/api/manipulation.ts
+++ b/src/api/manipulation.ts
@@ -897,12 +897,6 @@ export function replaceWith<T extends AnyNode>(
   const lastIdx = this.length - 1;
 
   return domEach(this, (el, i) => {
-    const { parent } = el;
-    if (!parent) {
-      return;
-    }
-
-    const siblings: AnyNode[] = parent.children;
     const cont =
       typeof content === 'function' ? content.call(el, i, el) : content;
     /*
@@ -911,11 +905,20 @@ export function replaceWith<T extends AnyNode>(
      */
     const dom = this._makeDomArray(cont, i < lastIdx);
 
+    const { parent } = el;
+    const siblings: AnyNode[] | undefined = parent?.children;
+
     /*
      * In the case that `dom` contains nodes that already exist in other
-     * structures, ensure those nodes are properly removed.
+     * structures, ensure those nodes are properly removed. jQuery does this
+     * even when the element was removed from the document: the replacement
+     * is consumed, although there is nowhere to insert it.
      */
     updateDOM(dom, null);
+
+    if (!(parent && siblings)) {
+      return;
+    }
 
     const index = siblings.indexOf(el);
 

--- a/src/api/manipulation.ts
+++ b/src/api/manipulation.ts
@@ -883,6 +883,9 @@ export function remove<T extends AnyNode>(
  * //   </ul>
  * ```
  *
+ * If more than one element is selected, every element but the last one is
+ * replaced with a copy of `content`, as a node can only exist in one place.
+ *
  * @param content - Replacement for matched elements.
  * @returns The instance itself.
  * @see {@link https://api.jquery.com/replaceWith/}
@@ -891,6 +894,8 @@ export function replaceWith<T extends AnyNode>(
   this: Cheerio<T>,
   content: AcceptedElems<AnyNode>,
 ): Cheerio<T> {
+  const lastIdx = this.length - 1;
+
   return domEach(this, (el, i) => {
     const { parent } = el;
     if (!parent) {
@@ -900,7 +905,11 @@ export function replaceWith<T extends AnyNode>(
     const siblings: AnyNode[] = parent.children;
     const cont =
       typeof content === 'function' ? content.call(el, i, el) : content;
-    const dom = this._makeDomArray(cont);
+    /*
+     * A node can only be in one place, so every element but the last one is
+     * replaced with a copy of the content, as in `_insert`.
+     */
+    const dom = this._makeDomArray(cont, i < lastIdx);
 
     /*
      * In the case that `dom` contains nodes that already exist in other

--- a/website/src/content/docs/basics/manipulation.md
+++ b/website/src/content/docs/basics/manipulation.md
@@ -209,6 +209,17 @@ selection with the given element.
 $('li').replaceWith('<li>Item</li>');
 ```
 
+When the argument is an existing element, every element in the selection but
+the last one is replaced with a copy of it, as a node can only exist in one
+place:
+
+```js
+const $item = $('<li>Item</li>');
+
+// Every `li` is replaced; the last one receives `$item` itself
+$('li').replaceWith($item);
+```
+
 Note that the `replaceWith()` method removes the element from the document and
 replaces it with the given element or HTML string. If you want to keep the
 element and modify its contents, you can use the `html()` or `text()` methods


### PR DESCRIPTION
Refs #687.

`replaceWith` reuses the same replacement nodes for every selected element. Existing node content therefore moves from target to target, leaving only the last replacement. For example, replacing two `<p>` elements with one existing `<b>` should produce two `<b>` elements; previously only one remained. String content already works because it is parsed separately for each target.

This applies Cheerio's existing insertion convention: deep-clone node content for every target except the last, which receives the originals. Documentation and tests cover Cheerio objects, raw node arrays, descendants, and callback content.

The final selection index still owns the originals even when that target has been removed. The content is consumed and the callback runs for that detached target. Self-replacement now preserves the target's insertion position and removes it exactly once, preventing an adjacent sibling from being deleted. Regression tests check node identities, order, parents, and sibling links for first/middle/last self-replacement and content containing the target with its siblings.

Callback cloning remains consistent with Cheerio's other insertion methods. This differs from jQuery's per-callback insertion behavior; the PR does not claim complete jQuery parity for overlapping target/content selections.

Validation on Node 26.7.0:

- Previous PR head 15978163 with the new self-replacement regressions: 4 failed, 203 passed. Fixed manipulation suite: 207 passed.
- Full suite:15 files, 809 tests passed; no type errors.
- TypeScript, Biome, build, and ESLint excluding website pass.
- Built ESM self-replacement smoke checks and git diff --check pass.

Full repository ESLint requires the website's separate Astro dependencies, which were not installed in this checkout; its failure is `File 'astro/tsconfigs/strict' not found`. Upstream workflows on the previous head expired while awaiting approval, so those failures do not represent executed tests. Fresh upstream CI still needs maintainer approval.

AI-assisted implementation and independent AI review; validation results above were run against the code.
