### PR TITLE
fix(traversing): reset matchUntil index per starting element

### DIFF
--- a/src/api/traversing.spec.ts
+++ b/src/api/traversing.spec.ts
@@ -385,6 +385,13 @@ describe('$(...)', () => {
       const elems = $drinks.eq(0).nextUntil($until);
       expect(elems).toHaveLength(2);
     });
+
+    it('(function) : should reset the index for each starting element', () => {
+      const elems = $('.apple, .carrot', food).nextUntil((i) => i === 1);
+      expect(elems).toHaveLength(2);
+      expect(elems[0].attribs).toHaveProperty('class', 'orange');
+      expect(elems[1].attribs).toHaveProperty('class', 'sweetcorn');
+    });
   });
 
   describe('.prev', () => {
@@ -566,6 +573,13 @@ describe('$(...)', () => {
       const $until = $([$drinks[0], $drinks[1]]);
       const elems = $drinks.eq(4).prevUntil($until);
       expect(elems).toHaveLength(2);
+    });
+
+    it('(function) : should reset the index for each starting element', () => {
+      const elems = $('.pear, .sweetcorn', food).prevUntil((i) => i === 1);
+      expect(elems).toHaveLength(2);
+      expect(elems[0].attribs).toHaveProperty('class', 'orange');
+      expect(elems[1].attribs).toHaveProperty('class', 'carrot');
     });
   });
 
@@ -758,6 +772,13 @@ describe('$(...)', () => {
       const result = $('.carrot').parentsUntil(body);
       expect(result).toHaveLength(2);
       expect(result.eq(0).is('ul#vegetables')).toBe(true);
+    });
+
+    it('(function) : should reset the index for each starting element', () => {
+      const result = $('.apple, .carrot').parentsUntil((i) => i === 1);
+      expect(result).toHaveLength(2);
+      expect(result[0].attribs).toHaveProperty('id', 'vegetables');
+      expect(result[1].attribs).toHaveProperty('id', 'fruits');
     });
   });
 

--- a/src/api/traversing.ts
+++ b/src/api/traversing.ts
@@ -182,9 +182,10 @@ function _matchUntil(
       const matched: Element[] = [];
 
       domEach(elems, (elem) => {
-        for (let next; (next = nextElem(elem)); elem = next) {
-          // FIXME: `matched` might contain duplicates here and the index is too large.
-          if (matches?.(next, matched.length)) break;
+        let i = 0;
+        for (let next; (next = nextElem(elem)); elem = next, i++) {
+          // FIXME: `matched` might still contain duplicates across starting elements.
+          if (matches?.(next, i)) break;
           matched.push(next);
         }
       });


### PR DESCRIPTION
## Summary

Resets the internal `matchUntil` index per starting element during traversal so each root starts from a clean state.

## Why

Without resetting this state, multi-root traversal can carry stale indices and return inconsistent selections.
