### PR TITLE
fix: make removeAttr case-insensitive for HTML documents

### DIFF
--- a/src/api/attributes.spec.ts
+++ b/src/api/attributes.spec.ts
@@ -790,6 +790,21 @@ describe('$(...)', () => {
       expect($fruits.attr('id')).toBeUndefined();
     });
 
+    it('(key) : should remove case-preserved SVG attributes', () => {
+      const $svg = load('<svg viewBox="0 0 10 10"></svg>');
+      expect($svg('svg').attr('viewBox')).toBe('0 0 10 10');
+      $svg('svg').removeAttr('viewBox');
+      expect($svg('svg').attr('viewBox')).toBeUndefined();
+    });
+
+    it('(KEY) : should remove attributes created with mixed case via attr()', () => {
+      const $el = $('.apple');
+      $el.attr('DATA-X', 'value');
+      $el.removeAttr('DATA-X');
+      expect($el.attr('DATA-X')).toBeUndefined();
+      expect($el.attr('data-x')).toBeUndefined();
+    });
+
     it('(KEY) : should stay case-sensitive in XML documents', () => {
       const $xml = load('<food ID="fruits" id="other"/>', { xml: true });
       const $food = $xml('food');

--- a/src/api/attributes.spec.ts
+++ b/src/api/attributes.spec.ts
@@ -790,19 +790,31 @@ describe('$(...)', () => {
       expect($fruits.attr('id')).toBeUndefined();
     });
 
-    it('(key) : should remove case-preserved SVG attributes', () => {
+    it('(key) : should keep SVG attribute names case-sensitive', () => {
       const $svg = load('<svg viewBox="0 0 10 10"></svg>');
+      expect($svg('svg').attr('viewBox')).toBe('0 0 10 10');
+      // SVG attribute names are case-sensitive, so a lowercase lookup
+      // must not remove the case-preserved attribute.
+      $svg('svg').removeAttr('viewbox');
       expect($svg('svg').attr('viewBox')).toBe('0 0 10 10');
       $svg('svg').removeAttr('viewBox');
       expect($svg('svg').attr('viewBox')).toBeUndefined();
     });
 
-    it('(KEY) : should remove attributes created with mixed case via attr()', () => {
+    it('(key) : should remove attributes created with mixed case via attr()', () => {
       const $el = $('.apple');
       $el.attr('DATA-X', 'value');
-      $el.removeAttr('DATA-X');
+      // Cross-case removal: stored uppercase, removed lowercase.
+      $el.removeAttr('data-x');
       expect($el.attr('DATA-X')).toBeUndefined();
       expect($el.attr('data-x')).toBeUndefined();
+    });
+
+    it('(KEY) : should fold only ASCII characters', () => {
+      const $el = $('.apple');
+      $el.attr('data-K', 'kelvin');
+      $el.removeAttr('data-k');
+      expect($el.attr('data-K')).toBe('kelvin');
     });
 
     it('(KEY) : should stay case-sensitive in XML documents', () => {

--- a/src/api/attributes.spec.ts
+++ b/src/api/attributes.spec.ts
@@ -783,6 +783,21 @@ describe('$(...)', () => {
       expect(obj).toBeInstanceOf($);
     });
 
+    it('(KEY) : should remove regardless of case in HTML documents', () => {
+      const $fruits = $('#fruits');
+      expect($fruits.attr('id')).not.toBeUndefined();
+      $fruits.removeAttr('ID');
+      expect($fruits.attr('id')).toBeUndefined();
+    });
+
+    it('(KEY) : should stay case-sensitive in XML documents', () => {
+      const $xml = load('<food ID="fruits" id="other"/>', { xml: true });
+      const $food = $xml('food');
+      $food.removeAttr('ID');
+      expect($food.attr('ID')).toBeUndefined();
+      expect($food.attr('id')).toBe('other');
+    });
+
     it('(key) : should skip text nodes', () => {
       const $text = load(mixedText);
       const $body = $text($text('body')[0].children);

--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -879,22 +879,26 @@ export function removeAttr<T extends AnyNode>(
 
   for (const attrName of attrNames) {
     domEach(this, (elem) => {
-      if (!isTag(elem)) return;
-      if (xmlMode) {
+      if (!(isTag(elem) && elem.attribs)) return;
+      /*
+       * Attribute names are ASCII case-insensitive on HTML-namespace
+       * elements only. XML documents and foreign content (SVG/MathML,
+       * where parse5 preserves adjusted case such as `viewBox`) are
+       * case-sensitive, so they keep exact matching.
+       */
+      if (xmlMode || (elem.namespace && elem.namespace !== HTML_NAMESPACE)) {
         removeAttribute(elem, attrName);
         return;
       }
       /*
-       * HTML attribute names are ASCII case-insensitive, but the stored
-       * names are not uniformly lowercase: parse5 preserves the adjusted
-       * case of foreign-content attributes such as `viewBox` on SVG, and
-       * `attr()` stores caller-provided names verbatim. Remove by
+       * The stored names are not uniformly lowercase either: `attr()`
+       * stores caller-provided names verbatim. Remove by ASCII
        * case-insensitive comparison against the stored keys instead of
        * assuming a lowercase store.
        */
-      const lowerName = attrName.toLowerCase();
+      const lowerName = asciiLowerCase(attrName);
       for (const key of Object.keys(elem.attribs)) {
-        if (key.toLowerCase() === lowerName) {
+        if (asciiLowerCase(key) === lowerName) {
           removeAttribute(elem, key);
         }
       }
@@ -902,6 +906,22 @@ export function removeAttr<T extends AnyNode>(
   }
 
   return this;
+}
+
+const HTML_NAMESPACE = 'http://www.w3.org/1999/xhtml';
+
+/**
+ * Lowercase only ASCII `A`-`Z`, matching HTML's ASCII case-insensitive
+ * attribute name comparison. `String.prototype.toLowerCase` performs Unicode
+ * case folding, which would conflate distinct non-ASCII attribute names.
+ *
+ * @private
+ * @category Attributes
+ * @param value - The attribute name.
+ * @returns The name with ASCII uppercase letters lowercased.
+ */
+function asciiLowerCase(value: string): string {
+  return value.replace(/[A-Z]/g, (char) => char.toLowerCase());
 }
 
 /**

--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -875,18 +875,29 @@ export function removeAttr<T extends AnyNode>(
   name: string,
 ): Cheerio<T> {
   const attrNames = splitNames(name);
+  const { xmlMode } = this.options;
 
   for (const attrName of attrNames) {
-    /*
-     * HTML attribute names are ASCII case-insensitive, and htmlparser2
-     * lowercases them at parse time, so lowercase the lookup to match.
-     * XML attribute names are case-sensitive and are left untouched.
-     */
-    const normalizedName = this.options.xmlMode
-      ? attrName
-      : attrName.toLowerCase();
     domEach(this, (elem) => {
-      if (isTag(elem)) removeAttribute(elem, normalizedName);
+      if (!isTag(elem)) return;
+      if (xmlMode) {
+        removeAttribute(elem, attrName);
+        return;
+      }
+      /*
+       * HTML attribute names are ASCII case-insensitive, but the stored
+       * names are not uniformly lowercase: parse5 preserves the adjusted
+       * case of foreign-content attributes such as `viewBox` on SVG, and
+       * `attr()` stores caller-provided names verbatim. Remove by
+       * case-insensitive comparison against the stored keys instead of
+       * assuming a lowercase store.
+       */
+      const lowerName = attrName.toLowerCase();
+      for (const key of Object.keys(elem.attribs)) {
+        if (key.toLowerCase() === lowerName) {
+          removeAttribute(elem, key);
+        }
+      }
     });
   }
 

--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -877,8 +877,16 @@ export function removeAttr<T extends AnyNode>(
   const attrNames = splitNames(name);
 
   for (const attrName of attrNames) {
+    /*
+     * HTML attribute names are ASCII case-insensitive, and htmlparser2
+     * lowercases them at parse time, so lowercase the lookup to match.
+     * XML attribute names are case-sensitive and are left untouched.
+     */
+    const normalizedName = this.options.xmlMode
+      ? attrName
+      : attrName.toLowerCase();
     domEach(this, (elem) => {
-      if (isTag(elem)) removeAttribute(elem, attrName);
+      if (isTag(elem)) removeAttribute(elem, normalizedName);
     });
   }
 

--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -885,6 +885,11 @@ export function removeAttr<T extends AnyNode>(
        * elements only. XML documents and foreign content (SVG/MathML,
        * where parse5 preserves adjusted case such as `viewBox`) are
        * case-sensitive, so they keep exact matching.
+       *
+       * `namespace` is only populated by parse5. The htmlparser2-backed
+       * entry points (including `cheerio/slim`) lowercase every parsed
+       * attribute name, foreign content included, so there is no
+       * preserved case to protect and folding stays consistent there.
        */
       if (xmlMode || (elem.namespace && elem.namespace !== HTML_NAMESPACE)) {
         removeAttribute(elem, attrName);


### PR DESCRIPTION
Fixes #5257.

htmlparser2 lowercases attribute names at parse time for HTML documents (`lowerCaseAttributeNames` defaults to `htmlMode`), so `elem.attribs` only ever holds lowercase keys, and `removeAttr('CLASS')` looked up a key that cannot exist:

```js
const $ = cheerio.load('<div class="test"></div>');
$('div').removeAttr('CLASS');
$('div').attr('class'); // was "test", the removal silently no-opped
```

HTML attribute names are ASCII case-insensitive, so `removeAttr` now lowercases the name outside `xmlMode`, matching what the parser stored. XML documents keep case-sensitive behavior, locked by a test where `ID` and `id` coexist and only the exact-case one is removed.

Verification: 129 attribute tests pass (2 added); reverting the source change alone fails the new HTML-case test; eslint clean; full unit suite 795 passing.

Scope note: `attr('CLASS')` and `prop()` share the same case-sensitivity for reads and writes. Left out deliberately since the getter/setter semantics are a wider surface; happy to follow up if you want them aligned too.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/cheeriojs/cheerio/pull/5448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

