### PR TITLE
fix: split style declarations at top-level semicolons only

### DIFF
--- a/src/api/css.spec.ts
+++ b/src/api/css.spec.ts
@@ -178,6 +178,24 @@ describe('$(...)', () => {
         });
       });
 
+      it('should not treat a function whose name ends in url as url()', () => {
+        const el = cheerio('<div></div>');
+        el.attr('style', '--x: myurl(/* ( */ value); color: red');
+        expect(el.css()).toStrictEqual({
+          '--x': 'myurl(/* ( */ value)',
+          color: 'red',
+        });
+      });
+
+      it('should still recognize an uppercase URL() token', () => {
+        const el = cheerio('<div></div>');
+        el.attr('style', 'background: URL(https://host/*); color: red');
+        expect(el.css()).toStrictEqual({
+          background: 'URL(https://host/*)',
+          color: 'red',
+        });
+      });
+
       it('should treat comment markers inside url() as data', () => {
         const el = cheerio('<div></div>');
         el.attr('style', 'background: url(https://host/*); color: red');

--- a/src/api/css.spec.ts
+++ b/src/api/css.spec.ts
@@ -133,6 +133,26 @@ describe('$(...)', () => {
           'url(data:image/png;base64,iVBORw0KGgo)',
         );
       });
+
+      it('should not split data URIs whose tail contains a colon (#5410)', () => {
+        const background =
+          'url("data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\'/>")';
+        const el = cheerio('<div></div>');
+        el.attr('style', `background:${background}`);
+        expect(el.css()).toStrictEqual({ background });
+
+        el.css('color', 'red');
+        expect(el.css()).toStrictEqual({ background, color: 'red' });
+        expect(el.attr('style')).toStrictEqual(
+          `background: ${background}; color: red;`,
+        );
+      });
+
+      it('should not split on semicolons inside quoted strings', () => {
+        const el = cheerio('<div></div>');
+        el.attr('style', "content: 'a;b'; color: red");
+        expect(el.css()).toStrictEqual({ content: "'a;b'", color: 'red' });
+      });
     });
   });
 });

--- a/src/api/css.spec.ts
+++ b/src/api/css.spec.ts
@@ -153,6 +153,24 @@ describe('$(...)', () => {
         el.attr('style', "content: 'a;b'; color: red");
         expect(el.css()).toStrictEqual({ content: "'a;b'", color: 'red' });
       });
+
+      it('should not track parentheses inside comments', () => {
+        const el = cheerio('<div></div>');
+        el.attr('style', 'color: red/*(*/; background: blue');
+        expect(el.css()).toStrictEqual({
+          color: 'red/*(*/',
+          background: 'blue',
+        });
+      });
+
+      it('should treat escaped characters as data', () => {
+        const el = cheerio('<div></div>');
+        el.attr('style', 'font-family: foo\\(bar; color: red');
+        expect(el.css()).toStrictEqual({
+          'font-family': 'foo\\(bar',
+          color: 'red',
+        });
+      });
     });
   });
 });

--- a/src/api/css.spec.ts
+++ b/src/api/css.spec.ts
@@ -148,6 +148,36 @@ describe('$(...)', () => {
         );
       });
 
+      it('should recognize comments inside non-url functions', () => {
+        const el = cheerio('<div></div>');
+        el.attr('style', 'width: calc(1px + /* ( */ 2px); color: red');
+        expect(el.css()).toStrictEqual({
+          width: 'calc(1px + /* ( */ 2px)',
+          color: 'red',
+        });
+      });
+
+      it('should not enter quote mode from an apostrophe in a comment', () => {
+        const el = cheerio('<div></div>');
+        el.attr('style', "width: calc(100% /* it's 100 */); color: red");
+        expect(el.css()).toStrictEqual({
+          width: "calc(100% /* it's 100 */)",
+          color: 'red',
+        });
+      });
+
+      it('should not split inside braces or brackets', () => {
+        const el = cheerio('<div></div>');
+        el.attr(
+          'style',
+          '--theme: { color: red; background: blue }; margin: 0',
+        );
+        expect(el.css()).toStrictEqual({
+          '--theme': '{ color: red; background: blue }',
+          margin: '0',
+        });
+      });
+
       it('should treat comment markers inside url() as data', () => {
         const el = cheerio('<div></div>');
         el.attr('style', 'background: url(https://host/*); color: red');

--- a/src/api/css.spec.ts
+++ b/src/api/css.spec.ts
@@ -148,6 +148,15 @@ describe('$(...)', () => {
         );
       });
 
+      it('should treat comment markers inside url() as data', () => {
+        const el = cheerio('<div></div>');
+        el.attr('style', 'background: url(https://host/*); color: red');
+        expect(el.css()).toStrictEqual({
+          background: 'url(https://host/*)',
+          color: 'red',
+        });
+      });
+
       it('should not split on semicolons inside quoted strings', () => {
         const el = cheerio('<div></div>');
         el.attr('style', "content: 'a;b'; color: red");

--- a/src/api/css.ts
+++ b/src/api/css.ts
@@ -233,17 +233,41 @@ function splitDeclarations(styles: string): string[] {
   const declarations: string[] = [];
   let start = 0;
   let quote: string | undefined;
+  let inComment = false;
   let depth = 0;
 
   for (let i = 0; i < styles.length; i++) {
     const ch = styles.charCodeAt(i);
 
+    if (inComment) {
+      if (
+        ch === 42 /* Asterisk */ &&
+        styles.charCodeAt(i + 1) === 47 /* Slash */
+      ) {
+        inComment = false;
+        i++;
+      }
+      continue;
+    }
     if (quote !== undefined) {
       if (ch === 92 /* Backslash */) {
         i++;
       } else if (styles[i] === quote) {
         quote = undefined;
       }
+      continue;
+    }
+    if (ch === 92 /* Backslash */) {
+      // An escaped character is data, not structure.
+      i++;
+      continue;
+    }
+    if (
+      ch === 47 /* Slash */ &&
+      styles.charCodeAt(i + 1) === 42 /* Asterisk */
+    ) {
+      inComment = true;
+      i++;
       continue;
     }
     if (ch === 34 /* Double quote */ || ch === 39 /* Single quote */) {

--- a/src/api/css.ts
+++ b/src/api/css.ts
@@ -264,8 +264,15 @@ function splitDeclarations(styles: string): string[] {
     }
     if (
       ch === 47 /* Slash */ &&
+      depth === 0 &&
       styles.charCodeAt(i + 1) === 42 /* Asterisk */
     ) {
+      /*
+       * Comment recognition is limited to top level: CSS never recognizes
+       * comments inside url() tokens, where the marker is data, and
+       * semicolons inside parentheses are already ignored via the depth
+       * counter.
+       */
       inComment = true;
       i++;
       continue;

--- a/src/api/css.ts
+++ b/src/api/css.ts
@@ -221,8 +221,9 @@ function parse(styles: string): Record<string, string> {
 
 /**
  * Split a style attribute into declarations at top-level semicolons only.
- * Semicolons inside quoted strings or inside parentheses (such as data URIs
- * in `url(...)`) do not terminate a declaration.
+ * Semicolons inside quoted strings, comments, or any block (parentheses such
+ * as data URIs in `url(...)`, braces, brackets) do not terminate a
+ * declaration.
  *
  * @private
  * @category CSS
@@ -234,6 +235,7 @@ function splitDeclarations(styles: string): string[] {
   let start = 0;
   let quote: string | undefined;
   let inComment = false;
+  let urlDepth = 0;
   let depth = 0;
 
   for (let i = 0; i < styles.length; i++) {
@@ -263,29 +265,46 @@ function splitDeclarations(styles: string): string[] {
       continue;
     }
     if (
+      urlDepth === 0 &&
       ch === 47 /* Slash */ &&
-      depth === 0 &&
       styles.charCodeAt(i + 1) === 42 /* Asterisk */
     ) {
       /*
-       * Comment recognition is limited to top level: CSS never recognizes
-       * comments inside url() tokens, where the marker is data, and
-       * semicolons inside parentheses are already ignored via the depth
-       * counter.
+       * Comments are recognized everywhere except inside an unquoted
+       * `url()` token, where CSS treats the characters as part of the URL.
        */
       inComment = true;
       i++;
       continue;
     }
-    if (ch === 34 /* Double quote */ || ch === 39 /* Single quote */) {
+    if (
+      urlDepth === 0 &&
+      (ch === 34 /* Double quote */ || ch === 39) /* Single quote */
+    ) {
       quote = styles[i];
       continue;
     }
     if (ch === 40 /* Opening parenthesis */) {
       depth++;
+      // `url(` starts a URL token unless the value is a quoted string,
+      // which the quote branch above handles as an ordinary string.
+      if (urlDepth === 0 && isUrlToken(styles, i)) {
+        urlDepth = depth;
+      }
       continue;
     }
     if (ch === 41 /* Closing parenthesis */) {
+      if (depth > 0) {
+        if (urlDepth === depth) urlDepth = 0;
+        depth--;
+      }
+      continue;
+    }
+    if (ch === 123 /* Opening brace */ || ch === 91 /* Opening bracket */) {
+      depth++;
+      continue;
+    }
+    if (ch === 125 /* Closing brace */ || ch === 93 /* Closing bracket */) {
       if (depth > 0) depth--;
       continue;
     }
@@ -298,4 +317,26 @@ function splitDeclarations(styles: string): string[] {
   declarations.push(styles.slice(start));
 
   return declarations;
+}
+
+const WHITESPACE_RE = /\s/;
+
+/**
+ * Whether the opening parenthesis at `index` begins an unquoted `url()` token.
+ *
+ * @private
+ * @category CSS
+ * @param styles - The style attribute value.
+ * @param index - Index of the opening parenthesis.
+ * @returns Whether this parenthesis opens a URL token.
+ */
+function isUrlToken(styles: string, index: number): boolean {
+  if (index < 3 || styles.slice(index - 3, index).toLowerCase() !== 'url') {
+    return false;
+  }
+  // A quoted url("...") is a normal string, handled by the quote branch.
+  let next = index + 1;
+  while (next < styles.length && WHITESPACE_RE.test(styles[next])) next++;
+  const nextCh = styles.charCodeAt(next);
+  return nextCh !== 34 /* Double quote */ && nextCh !== 39 /* Single quote */;
 }

--- a/src/api/css.ts
+++ b/src/api/css.ts
@@ -202,7 +202,7 @@ function parse(styles: string): Record<string, string> {
 
   let key: string | undefined;
 
-  for (const str of styles.split(';')) {
+  for (const str of splitDeclarations(styles)) {
     const n = str.indexOf(':');
     // If there is no :, or if it is the first/last character, add to the previous item's value
     if (n < 1 || n === str.length - 1) {
@@ -217,4 +217,54 @@ function parse(styles: string): Record<string, string> {
   }
 
   return obj;
+}
+
+/**
+ * Split a style attribute into declarations at top-level semicolons only.
+ * Semicolons inside quoted strings or inside parentheses (such as data URIs
+ * in `url(...)`) do not terminate a declaration.
+ *
+ * @private
+ * @category CSS
+ * @param styles - The style attribute value.
+ * @returns The individual declarations.
+ */
+function splitDeclarations(styles: string): string[] {
+  const declarations: string[] = [];
+  let start = 0;
+  let quote: string | undefined;
+  let depth = 0;
+
+  for (let i = 0; i < styles.length; i++) {
+    const ch = styles.charCodeAt(i);
+
+    if (quote !== undefined) {
+      if (ch === 92 /* Backslash */) {
+        i++;
+      } else if (styles[i] === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+    if (ch === 34 /* Double quote */ || ch === 39 /* Single quote */) {
+      quote = styles[i];
+      continue;
+    }
+    if (ch === 40 /* Opening parenthesis */) {
+      depth++;
+      continue;
+    }
+    if (ch === 41 /* Closing parenthesis */) {
+      if (depth > 0) depth--;
+      continue;
+    }
+    if (ch === 59 /* Semicolon */ && depth === 0) {
+      declarations.push(styles.slice(start, i));
+      start = i + 1;
+    }
+  }
+
+  declarations.push(styles.slice(start));
+
+  return declarations;
 }

--- a/src/api/css.ts
+++ b/src/api/css.ts
@@ -320,6 +320,22 @@ function splitDeclarations(styles: string): string[] {
 }
 
 const WHITESPACE_RE = /\s/;
+const ASCII_IDENTIFIER_RE = /[\w-]/;
+
+/**
+ * Whether `char` can appear in a CSS identifier: letters, digits, hyphen,
+ * underscore, an escape, or any non-ASCII character.
+ *
+ * @private
+ * @category CSS
+ * @param char - The character to test.
+ * @returns Whether the character is part of an identifier.
+ */
+function isIdentifierChar(char: string): boolean {
+  return (
+    ASCII_IDENTIFIER_RE.test(char) || char === '\\' || char.charCodeAt(0) >= 128
+  );
+}
 
 /**
  * Whether the opening parenthesis at `index` begins an unquoted `url()` token.
@@ -332,6 +348,14 @@ const WHITESPACE_RE = /\s/;
  */
 function isUrlToken(styles: string, index: number): boolean {
   if (index < 3 || styles.slice(index - 3, index).toLowerCase() !== 'url') {
+    return false;
+  }
+  /*
+   * The three characters before `(` must be the whole function name, not the
+   * tail of a longer one: `myurl(` and `noturl(` are ordinary functions whose
+   * contents follow the normal comment rules.
+   */
+  if (index > 3 && isIdentifierChar(styles[index - 4])) {
     return false;
   }
   // A quoted url("...") is a normal string, handled by the quote branch.


### PR DESCRIPTION
Fixes #5410.

`parse()` split the style attribute on every `;`, then healed fragments that contain no colon by appending them to the previous value. That healed `url(data:image/png;base64,...)`, but a data URI whose post-semicolon tail contains a colon, such as an SVG data URI with a namespace URL, was read as a fresh declaration:

```js
$div.css()
// { background: 'url("data:image/svg+xml', 'utf8,<svg xmlns=\'http': '//www.w3.org/2000/svg\'/>")' }
```

and any `.css('color', 'red')` write-back then serialized the corrupted map into the `style` attribute.

The fix splits declarations only at top-level semicolons: quotes (with backslash escapes) and parentheses are tracked, so `;` inside `url(...)` or inside a quoted string never terminates a declaration. The existing heal-append for genuinely malformed fragments (#1134) is untouched and its test still passes.

Two tests added: the issue's SVG data URI round-trips through `.css()` and survives an unrelated property write, and semicolons inside quoted strings (`content: 'a;b'`) stay in the value.

Verification: 18 css tests pass (2 added); reverting `css.ts` alone fails the new data-URI test; full unit suite 795 passing; eslint and prettier clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/cheeriojs/cheerio/pull/5449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

