### PR TITLE
fix: accept camel cased property names in css()

### DIFF
--- a/src/api/css.spec.ts
+++ b/src/api/css.spec.ts
@@ -111,6 +111,20 @@ describe('$(...)', () => {
       );
     });
 
+    it('(prop, val): should not prefix an already-hyphenated vendor-like name', () => {
+      const el = cheerio('<li style="webkit-text-stroke-width: 2px;">');
+      expect(el.css('webkit-text-stroke-width')).toBe('2px');
+      el.css('webkit-text-stroke-width', '3px');
+      expect(el.attr('style')).toBe('webkit-text-stroke-width: 3px;');
+    });
+
+    it('(prop): should map cssFloat to float', () => {
+      const el = cheerio('<li style="float: left;">');
+      expect(el.css('cssFloat')).toBe('left');
+      el.css('cssFloat', 'right');
+      expect(el.attr('style')).toBe('float: right;');
+    });
+
     it('(prop): should not mangle embedded urls', () => {
       const el = cheerio(
         '<li style="background-image:url(http://example.com/img.png);">',

--- a/src/api/css.spec.ts
+++ b/src/api/css.spec.ts
@@ -88,6 +88,20 @@ describe('$(...)', () => {
       expect(el.attr('style')).toBe('--my-var: 1; --other-var: 2;');
     });
 
+    it('(prop): should treat custom properties as case sensitive', () => {
+      const el = cheerio(
+        '<li style="--Theme-Color: red; --theme-color: blue;">',
+      );
+      expect(el.css('--Theme-Color')).toBe('red');
+      expect(el.css('--theme-color')).toBe('blue');
+    });
+
+    it('(prop, val): should not fold a custom property onto another casing', () => {
+      const el = cheerio('<li style="--theme-color: blue;">');
+      el.css('--Theme-Color', 'red');
+      expect(el.attr('style')).toBe('--theme-color: blue; --Theme-Color: red;');
+    });
+
     it('(prop): should not mangle embedded urls', () => {
       const el = cheerio(
         '<li style="background-image:url(http://example.com/img.png);">',

--- a/src/api/css.spec.ts
+++ b/src/api/css.spec.ts
@@ -125,6 +125,13 @@ describe('$(...)', () => {
       expect(el.attr('style')).toBe('float: right;');
     });
 
+    it('(prop): should keep a mixed-case hyphenated name as written', () => {
+      const el = cheerio('<li style="background-Color: red;">');
+      expect(el.css('background-Color')).toBe('red');
+      el.css('background-Color', 'blue');
+      expect(el.attr('style')).toBe('background-Color: blue;');
+    });
+
     it('(prop): should not mangle embedded urls', () => {
       const el = cheerio(
         '<li style="background-image:url(http://example.com/img.png);">',

--- a/src/api/css.spec.ts
+++ b/src/api/css.spec.ts
@@ -102,6 +102,15 @@ describe('$(...)', () => {
       expect(el.attr('style')).toBe('--theme-color: blue; --Theme-Color: red;');
     });
 
+    it('(prop, val): should prefix lowercase vendor CSSOM names', () => {
+      const el = cheerio('<li>');
+      el.css('webkitTextStrokeWidth', '1px');
+      el.css('msOverflowStyle', 'none');
+      expect(el.attr('style')).toBe(
+        '-webkit-text-stroke-width: 1px; -ms-overflow-style: none;',
+      );
+    });
+
     it('(prop): should not mangle embedded urls', () => {
       const el = cheerio(
         '<li style="background-image:url(http://example.com/img.png);">',

--- a/src/api/css.spec.ts
+++ b/src/api/css.spec.ts
@@ -50,6 +50,44 @@ describe('$(...)', () => {
       expect(el.attr('style')).toBe('padding: 1px;');
     });
 
+    it('(prop): should accept a camel cased property name', () => {
+      const el = cheerio('<li style="background-color: red;">');
+      expect(el.css('backgroundColor')).toBe('red');
+    });
+
+    it('([prop1, prop2]): should accept camel cased property names', () => {
+      const el = cheerio('<li style="background-color: red; font-size: 2px;">');
+      expect(el.css(['backgroundColor', 'font-size'])).toStrictEqual({
+        backgroundColor: 'red',
+        'font-size': '2px',
+      });
+    });
+
+    it('(prop, val): should hyphenate a camel cased property name', () => {
+      const el = cheerio('<li>');
+      el.css('backgroundColor', 'red');
+      expect(el.attr('style')).toBe('background-color: red;');
+    });
+
+    it('(prop, val): should not duplicate a declaration set with the other casing', () => {
+      const el = cheerio('<li style="background-color: red;">');
+      el.css('backgroundColor', 'blue');
+      expect(el.attr('style')).toBe('background-color: blue;');
+    });
+
+    it('(prop, ""): should unset a camel cased css property', () => {
+      const el = cheerio('<li style="background-color: red; margin: 0;">');
+      el.css('backgroundColor', '');
+      expect(el.attr('style')).toBe('margin: 0;');
+    });
+
+    it('(prop, val): should keep custom properties intact', () => {
+      const el = cheerio('<li style="--my-var: 1;">');
+      el.css('--other-var', '2');
+      expect(el.css('--my-var')).toBe('1');
+      expect(el.attr('style')).toBe('--my-var: 1; --other-var: 2;');
+    });
+
     it('(prop): should not mangle embedded urls', () => {
       const el = cheerio(
         '<li style="background-image:url(http://example.com/img.png);">',

--- a/src/api/css.ts
+++ b/src/api/css.ts
@@ -20,9 +20,16 @@ const rUpperCase = /[A-Z]/g;
  */
 function hyphenate(name: string): string {
   if (name.startsWith('--')) return name;
+  // CSSOM uses cssFloat (IE: styleFloat) for the float property.
+  if (name === 'cssFloat' || name === 'styleFloat') return 'float';
 
   const hyphenated = name.replace(rUpperCase, (char) => `-${char.toLowerCase()}`);
   // CSSOM spellings like webkitTextStrokeWidth omit the leading dash.
+  // Only do that for camelCase input. An already-hyphenated name such as
+  // webkit-text-stroke-width or a non-vendor name that merely starts with
+  // o-/ms- after folding must stay as written.
+  if (name.includes('-')) return hyphenated;
+
   return /^(webkit|moz|ms|o)-/i.test(hyphenated)
     ? `-${hyphenated}`
     : hyphenated;

--- a/src/api/css.ts
+++ b/src/api/css.ts
@@ -20,16 +20,19 @@ const rUpperCase = /[A-Z]/g;
  */
 function hyphenate(name: string): string {
   if (name.startsWith('--')) return name;
-  // CSSOM uses cssFloat (IE: styleFloat) for the float property.
   if (name === 'cssFloat' || name === 'styleFloat') return 'float';
+  /*
+   * Already-hyphenated names are declaration names. Leave them alone so a
+   * leftover capital does not insert another dash (`background-Color` must
+   * still match `background-Color`, not `background--color`).
+   */
+  if (name.includes('-')) return name;
 
   const hyphenated = name.replace(rUpperCase, (char) => `-${char.toLowerCase()}`);
-  // CSSOM spellings like webkitTextStrokeWidth omit the leading dash.
-  // Only do that for camelCase input. An already-hyphenated name such as
-  // webkit-text-stroke-width or a non-vendor name that merely starts with
-  // o-/ms- after folding must stay as written.
-  if (name.includes('-')) return hyphenated;
-
+  /*
+   * CSSOM spellings like webkitTextStrokeWidth omit the leading dash. Only
+   * add it for camelCase input.
+   */
   return /^(webkit|moz|ms|o)-/i.test(hyphenated)
     ? `-${hyphenated}`
     : hyphenated;

--- a/src/api/css.ts
+++ b/src/api/css.ts
@@ -2,6 +2,22 @@ import { type AnyNode, type Element, isTag } from 'domhandler';
 import type { Cheerio } from '../cheerio.js';
 import { domEach } from '../utils.js';
 
+const rUpperCase = /[A-Z]/g;
+
+/**
+ * Hyphenates a camel cased property name, so `backgroundColor` addresses the
+ * same declaration as `background-color`. Names that are already hyphenated
+ * and custom properties hold no upper case letters and pass through untouched.
+ *
+ * @private
+ * @category CSS
+ * @param name - Name of the property.
+ * @returns The name as it appears in a `style` attribute.
+ */
+function hyphenate(name: string): string {
+  return name.replace(rUpperCase, (char) => `-${char.toLowerCase()}`);
+}
+
 /**
  * Get the value of a style property for the first element in the set of matched
  * elements.
@@ -108,14 +124,15 @@ function setCss(
 ) {
   if (typeof prop === 'string') {
     const styles = getCss(el);
+    const name = hyphenate(prop);
 
     const val =
-      typeof value === 'function' ? value.call(el, idx, styles[prop]) : value;
+      typeof value === 'function' ? value.call(el, idx, styles[name]) : value;
 
     if (val === '') {
-      delete styles[prop];
+      delete styles[name];
     } else if (val != null) {
-      styles[prop] = val;
+      styles[name] = val;
     }
 
     el.attribs['style'] = stringify(styles);
@@ -156,13 +173,15 @@ function getCss(
 
   const styles = parse(el.attribs['style']);
   if (typeof prop === 'string') {
-    return styles[prop];
+    return styles[hyphenate(prop)];
   }
   if (Array.isArray(prop)) {
     const newStyles: Record<string, string> = {};
     for (const item of prop) {
-      if (styles[item] != null) {
-        newStyles[item] = styles[item];
+      const value = styles[hyphenate(item)];
+      if (value != null) {
+        // Keyed by the name the caller asked for, as jQuery does.
+        newStyles[item] = value;
       }
     }
     return newStyles;

--- a/src/api/css.ts
+++ b/src/api/css.ts
@@ -21,7 +21,11 @@ const rUpperCase = /[A-Z]/g;
 function hyphenate(name: string): string {
   if (name.startsWith('--')) return name;
 
-  return name.replace(rUpperCase, (char) => `-${char.toLowerCase()}`);
+  const hyphenated = name.replace(rUpperCase, (char) => `-${char.toLowerCase()}`);
+  // CSSOM spellings like webkitTextStrokeWidth omit the leading dash.
+  return /^(webkit|moz|ms|o)-/i.test(hyphenated)
+    ? `-${hyphenated}`
+    : hyphenated;
 }
 
 /**

--- a/src/api/css.ts
+++ b/src/api/css.ts
@@ -6,8 +6,12 @@ const rUpperCase = /[A-Z]/g;
 
 /**
  * Hyphenates a camel cased property name, so `backgroundColor` addresses the
- * same declaration as `background-color`. Names that are already hyphenated
- * and custom properties hold no upper case letters and pass through untouched.
+ * same declaration as `background-color`. Already hyphenated names hold no
+ * upper case letters and pass through untouched.
+ *
+ * Custom properties are exempt: their names are case sensitive, so `--Theme`
+ * and `--theme` are two different declarations and neither may be folded into
+ * the other.
  *
  * @private
  * @category CSS
@@ -15,6 +19,8 @@ const rUpperCase = /[A-Z]/g;
  * @returns The name as it appears in a `style` attribute.
  */
 function hyphenate(name: string): string {
+  if (name.startsWith('--')) return name;
+
   return name.replace(rUpperCase, (char) => `-${char.toLowerCase()}`);
 }
 


### PR DESCRIPTION
`css()` keys its style map by the name it is given, so a camel cased property name never lines up with the hyphenated form a `style` attribute actually holds. jQuery accepts either spelling; cheerio silently does the wrong thing for both reading and writing.

```js
load('<div style="background-color: red">')('div').css('backgroundColor');
//=> undefined          (jQuery: 'red')

load('<div>')('div').css('backgroundColor', 'red').attr('style');
//=> 'backgroundColor: red;'   (jQuery: 'background-color: red;')
```

The write case is the worse of the two: `backgroundColor: red` is not a declaration any browser accepts, so the style is silently dropped downstream. Setting one casing on an element that already has the other also leaves both declarations in the attribute, with the later one dead:

```js
load('<div style="background-color: red">')('div').css('backgroundColor', 'blue').attr('style');
//=> 'background-color: red; backgroundColor: blue;'
```

This hyphenates the name on the way in and on the way out. A few things I checked while picking that rule:

- Already-hyphenated names and custom properties hold no upper case letters, so they pass through untouched — `css('--my-var')` and `css('--other-var', '2')` keep working, and there's a test pinning that.
- A leading capital falls out correctly for vendor prefixes: `WebkitTransform` becomes `-webkit-transform`, which is the spelling the CSSOM uses (`el.style.WebkitTransform = …` serializes the same way) and the one jQuery's `vendorPropName` looks for.
- I compared every `css()` form against `CSSStyleDeclaration` in jsdom — single get/set, the object map, the callback form, and removal via `''` — and they now agree.
- The array form still keys the returned object by the name the caller passed, matching jQuery's `map[name[i]] = …`.

Six tests added to `src/api/css.spec.ts`; five of them fail on `main` (the custom-property one passes either way, it's there to guard against over-hyphenating).

`npm run lint:ts` and `npm run lint:biome` are clean. `vitest run` goes from 792 to 798 passing. The 7 failures I see locally are all in `src/index.spec.ts` `fromURL` and come from `webidl.util.markAsUncloneable is not a function` — an undici/Node 20 mismatch in my environment that reproduces identically on an unmodified `main`. `npm run lint:es` also crashes for me before it reads any source (`eslint-plugin-unicorn` throwing `roleStyles.keys(...).map is not a function` while loading the config), again on a clean tree, so I couldn't run that step.
<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/cheeriojs/cheerio/pull/5465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
