### PR TITLE
fix: derive data keys the way a browser derives dataset keys

### DIFF
--- a/src/api/attributes.spec.ts
+++ b/src/api/attributes.spec.ts
@@ -654,6 +654,28 @@ describe('$(...)', () => {
       }
     });
 
+    it('() : should store a derived __proto__ key as an own property', () => {
+      /*
+       * `data-__proto__` derives the literal key `__proto__`. Assigning it
+       * normally would hit the inherited setter and swap the data object's
+       * prototype instead of creating the key. A browser's `dataset` lists it
+       * as an own enumerable property with the raw value, verified in Chrome.
+       */
+      const $el = load(
+        `<div data-__proto__='{"admin":true}' data-x="1"></div>`,
+      )('div');
+      const data = $el.data();
+
+      expect(Object.keys(data)).toStrictEqual(['__proto__', 'x']);
+      expect(Object.hasOwn(data, '__proto__')).toBe(true);
+      expect(data).not.toHaveProperty('admin');
+      expect(({} as Record<string, unknown>)['admin']).toBeUndefined();
+
+      const fresh = load('<div data-__proto__="polluted"></div>')('div');
+
+      expect(fresh.data('__proto__')).toBe('polluted');
+    });
+
     it('() : every reported key should read back through .data(key)', () => {
       /*
        * The keys `.data()` hands back have to be usable with `.data(key)`, or

--- a/src/api/attributes.spec.ts
+++ b/src/api/attributes.spec.ts
@@ -631,6 +631,53 @@ describe('$(...)', () => {
       });
     });
 
+    it('() : should derive keys the way a browser derives dataset keys', () => {
+      /*
+       * Only a hyphen followed by an ASCII lower-case letter starts a new word.
+       * Verified against `element.dataset` in Chrome.
+       */
+      const expected: [string, string[]][] = [
+        ['data-plain-key', ['plainKey']],
+        ['data-foo_bar', ['foo_bar']],
+        ['data-a.b', ['a.b']],
+        ['data-foo-1', ['foo-1']],
+        ['data-foo-', ['foo-']],
+        ['data-foo--bar', ['foo-Bar']],
+      ];
+
+      for (const [attr, keys] of expected) {
+        const actual = Object.keys(
+          load(`<div ${attr}="v"></div>`)('div').data(),
+        );
+
+        expect(actual).toStrictEqual(keys);
+      }
+    });
+
+    it('() : every reported key should read back through .data(key)', () => {
+      /*
+       * The keys `.data()` hands back have to be usable with `.data(key)`, or
+       * the two halves of the API disagree.
+       */
+      const attrs = [
+        'data-plain-key',
+        'data-foo_bar',
+        'data-a.b',
+        'data-foo-1',
+        'data-foo-',
+        'data-foo--bar',
+      ];
+
+      for (const attr of attrs) {
+        const html = `<div ${attr}="v"></div>`;
+        const keys = Object.keys(load(html)('div').data());
+
+        for (const key of keys) {
+          expect(load(html)('div').data(key)).toBe('v');
+        }
+      }
+    });
+
     it('(key, value) : should skip text nodes', () => {
       const $text = load(mixedText);
       const $body = $text($text('body')[0].children);

--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -553,6 +553,29 @@ function setData(
 }
 
 /**
+ * Store a parsed data value as an own property, so a derived key such as
+ * `__proto__` from `data-__proto__` cannot reach the inherited setter and
+ * change the object's prototype. A browser's `dataset` exposes that key as an
+ * own enumerable property too.
+ *
+ * @param data - The data store to write to.
+ * @param key - The derived dataset key.
+ * @param value - The parsed value.
+ */
+function setDataValue(
+  data: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): void {
+  Object.defineProperty(data, key, {
+    value,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+}
+
+/**
  * Read _all_ HTML5 `data-*` attributes from the equivalent HTML5 `data-*`
  * attribute, and cache the value in the node's internal data store.
  *
@@ -572,7 +595,7 @@ function readAllData(el: DataElement): unknown {
     const jsName = camelCase(domName.slice(dataAttrPrefix.length));
 
     if (!Object.hasOwn(data, jsName)) {
-      data[jsName] = parseDataValue(domValue);
+      setDataValue(data, jsName, parseDataValue(domValue));
     }
   }
 
@@ -597,7 +620,7 @@ function readData(el: DataElement, name: string): unknown {
   }
 
   if (Object.hasOwn(el.attribs, domName)) {
-    data[name] = parseDataValue(el.attribs[domName]);
+    setDataValue(data, name, parseDataValue(el.attribs[domName]));
     return data[name];
   }
 

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -3,10 +3,23 @@ import * as utils from './utils.js';
 
 describe('util functions', () => {
   it('camelCase function test', () => {
-    expect(utils.camelCase('cheerio.js')).toBe('cheerioJs');
-    expect(utils.camelCase('camel-case-')).toBe('camelCase');
-    expect(utils.camelCase('__directory__')).toBe('_directory_');
-    expect(utils.camelCase('_one-two.three')).toBe('OneTwoThree');
+    /*
+     * Only a hyphen followed by an ASCII lower-case letter is a word boundary,
+     * matching how a browser derives `dataset` keys from `data-*` attributes.
+     */
+    expect(utils.camelCase('camel-case')).toBe('camelCase');
+    expect(utils.camelCase('one-two-three')).toBe('oneTwoThree');
+    expect(utils.camelCase('-foo')).toBe('Foo');
+    expect(utils.camelCase('foo--bar')).toBe('foo-Bar');
+
+    /*
+     * Everything else is left alone, including dots, underscores, a trailing
+     * hyphen and a hyphen before a digit.
+     */
+    expect(utils.camelCase('cheerio.js')).toBe('cheerio.js');
+    expect(utils.camelCase('__directory__')).toBe('__directory__');
+    expect(utils.camelCase('camel-case-')).toBe('camelCase-');
+    expect(utils.camelCase('foo-1')).toBe('foo-1');
   });
 
   it('cssCase function test', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,7 +15,10 @@ export function isCheerio<T>(
 }
 
 /**
- * Convert a string to camel case notation.
+ * Convert a `data-*` attribute name to its `dataset` key, using the rule from
+ * the HTML spec: a hyphen followed by an ASCII lower-case letter is removed and
+ * the letter upper-cased. Any other hyphen, and every other character, is left
+ * alone.
  *
  * @private
  * @category Utils
@@ -23,7 +26,7 @@ export function isCheerio<T>(
  * @returns String in camel case notation.
  */
 export function camelCase(str: string): string {
-  return str.replace(/[._-](\w|$)/g, (_, x) => (x as string).toUpperCase());
+  return str.replace(/-([a-z])/g, (_, x) => (x as string).toUpperCase());
 }
 
 /**


### PR DESCRIPTION
### What

`.data()` reports keys that `.data(key)` cannot read back:

```js
const $el = cheerio.load('<div data-foo_bar="x"></div>')('div');
$el.data();          //=> { fooBar: 'x' }
$el.data('fooBar');  //=> undefined
```

`.data()` derives keys with `camelCase`, and `.data(key)` maps back with `cssCase`. `camelCase` treats `.`, `_` and a trailing separator as word boundaries, but `cssCase` only inserts a hyphen before a capital, so the mapping is not invertible: `fooBar` could have come from `foo-bar`, `foo_bar` or `foo.bar`.

### The reference

The HTML spec only treats **a hyphen followed by an ASCII lower-case letter** as a boundary, and jQuery does the same (`/-([a-z])/g`). I checked the current behaviour against `element.dataset` in Chrome rather than reasoning from the spec alone:

| attribute | `element.dataset` | cheerio before |
| --- | --- | --- |
| `data-foo_bar` | `foo_bar` | `fooBar` |
| `data-a.b` | `a.b` | `aB` |
| `data-foo-1` | `foo-1` | `foo1` |
| `data-foo-` | `foo-` | `foo` |
| `data-a-b-` | `aB-` | `aB` |
| `data-plain-key` | `plainKey` | `plainKey` |
| `data-foo--bar` | `foo-Bar` | `foo-Bar` |
| `data--foo` | `Foo` | `Foo` |
| `data-9x-y` | `9xY` | `9xY` |

Five of nine diverged. After the change all nine match, and every key `.data()` returns reads back through `.data(key)`.

### Scope

`camelCase` and `cssCase` are both `@private` and used only by the `data-*` path (`attributes.ts` lines 572 and 592), so nothing else changes.

The existing `camelCase` assertions in `src/utils.spec.ts` encoded the behaviour being fixed, so they are updated. I have kept them as explicit cases rather than deleting them, and added the browser-derived values.

### Verification

Full suite is 795 passing. I confirmed the three new tests fail with only `src/utils.ts` reverted, and that the other 129 tests in `attributes.spec.ts` pass either way, so they isolate the change. `biome check`, `eslint` and `tsc --noEmit` are clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/cheeriojs/cheerio/pull/5470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

