### PR TITLE
fix: split the class attribute on ASCII whitespace only

### DIFF
--- a/src/api/attributes.spec.ts
+++ b/src/api/attributes.spec.ts
@@ -842,6 +842,45 @@ describe('$(...)', () => {
     });
   });
 
+  describe('class separators', () => {
+    /*
+     * The class attribute is split on ASCII whitespace only. Verified against
+     * `element.classList` in Chrome.
+     */
+    const asciiWhitespace = ['\t', '\n', '\f', '\r', ' '];
+    const notWhitespace = [
+      '\v',
+      '\u{A0}',
+      '\u{1680}',
+      '\u{2000}',
+      '\u{2028}',
+      '\u{2029}',
+      '\u{202F}',
+      '\u{205F}',
+      '\u{3000}',
+      '\u{FEFF}',
+    ];
+
+    it('should split on ASCII whitespace', () => {
+      for (const ch of asciiWhitespace) {
+        expect(load(`<p class="a${ch}b"></p>`)('p').hasClass('b')).toBe(true);
+      }
+    });
+
+    it('should not split on other whitespace', () => {
+      for (const ch of notWhitespace) {
+        expect(load(`<p class="a${ch}b"></p>`)('p').hasClass('b')).toBe(false);
+      }
+    });
+
+    it('should treat a non-breaking space as part of the class name', () => {
+      const $p = load('<p class="a\u{A0}b"></p>')('p');
+
+      expect($p.hasClass('a\u{A0}b')).toBe(true);
+      expect($p.hasClass('a')).toBe(false);
+    });
+  });
+
   describe('.addClass', () => {
     let $: CheerioAPI;
 

--- a/src/api/attributes.spec.ts
+++ b/src/api/attributes.spec.ts
@@ -873,6 +873,43 @@ describe('$(...)', () => {
       }
     });
 
+    it('should keep non-ASCII whitespace out of the mutator split too', () => {
+      // splitNames drives addClass, removeClass and toggleClass, so a token
+      // containing a non-breaking space must travel through them whole.
+      const $add = load('<p></p>')('p');
+      $add.addClass('a\u00A0b');
+
+      expect($add.attr('class')).toBe('a\u00A0b');
+      expect($add.hasClass('a\u00A0b')).toBe(true);
+
+      const $remove = load('<p class="a\u00A0b other"></p>')('p');
+      $remove.removeClass('a\u00A0b');
+
+      expect($remove.attr('class')).toBe('other');
+
+      const $toggle = load('<p class="a\u00A0b"></p>')('p');
+      $toggle.toggleClass('a\u00A0b');
+
+      expect($toggle.attr('class')).toBe('');
+    });
+
+    it('should not trim non-ASCII whitespace from a class token edge', () => {
+      /*
+       * toggleClass splits its argument with rspace but the element's classes
+       * with splitNames. With a Unicode-aware trim in splitNames the two
+       * disagreed on a token with a leading non-breaking space: the element
+       * side saw 'a', the argument side saw the full token, and the toggle
+       * added a duplicate instead of removing the class.
+       */
+      const $p = load('<p class="\u00A0a"></p>')('p');
+
+      expect($p.hasClass('\u00A0a')).toBe(true);
+
+      $p.toggleClass('\u00A0a');
+
+      expect($p.attr('class')).toBe('');
+    });
+
     it('should treat a non-breaking space as part of the class name', () => {
       const $p = load('<p class="a\u{A0}b"></p>')('p');
 

--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -11,7 +11,13 @@ import type { Cheerio } from '../cheerio.js';
 import { text } from '../static.js';
 import { camelCase, cssCase, domEach } from '../utils.js';
 
-const rspace = /\s+/;
+/*
+ * The class attribute is split on ASCII whitespace, per the HTML spec.
+ * `\s` is wider than that: it also matches a vertical tab, a non-breaking
+ * space and the Unicode space separators, none of which a browser treats as
+ * a boundary.
+ */
+const rspace = /[\t\n\f\r ]+/;
 const dataAttrPrefix = 'data-';
 
 // Attributes that are booleans

--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -854,7 +854,11 @@ function removeAttribute(elem: Element, name: string) {
  * @returns - Split names.
  */
 function splitNames(names?: string): string[] {
-  return names ? names.trim().split(rspace) : [];
+  if (!names) return [];
+  // ASCII-only trim: String.prototype.trim also strips a non-breaking space
+  // and the Unicode space separators, which are part of a class name here.
+  const trimmed = names.replace(/^[\t\n\f\r ]+|[\t\n\f\r ]+$/g, '');
+  return trimmed ? trimmed.split(rspace) : [];
 }
 
 /**


### PR DESCRIPTION
### What

`rspace` is `/\s+/`, which is wider than the HTML spec's definition of a class boundary. `\s` also matches a vertical tab, a non-breaking space and the Unicode space separators, so cheerio sees two classes where a browser sees one:

```js
// U+00A0 between the two letters
cheerio.load('<p class="a b"></p>')('p').hasClass('a');  //=> true
```

A browser reports a single class literally named `a b`, so that is a false positive. The same `rspace` drives `splitNames`, so `addClass`, `removeClass` and `toggleClass` split on those characters too.

### The reference

I checked every candidate against `element.classList` in Chrome rather than reading the spec alone. Exactly five characters separate classes:

| separator | tab `U+0009` · line feed `U+000A` · form feed `U+000C` · carriage return `U+000D` · space `U+0020` |
| --- | --- |
| **not a separator** | `U+000B` vertical tab · `U+00A0` nbsp · `U+1680` · `U+2000` · `U+2028` · `U+2029` · `U+202F` · `U+205F` · `U+3000` · `U+FEFF` |

`\s` matches all fifteen, so ten of them were treated as boundaries incorrectly. After the change all fifteen agree with the browser.

### The change

One line, plus a comment explaining why the narrower set is correct:

```diff
-const rspace = /\s+/;
+const rspace = /[\t\n\f\r ]+/;
```

### Verification

Full suite is 796 passing. I confirmed the two new negative tests fail with only `src/api/attributes.ts` reverted, while the ASCII-whitespace test passes either way, so the new tests isolate the change rather than just restating existing behaviour. `biome check`, `eslint` and `tsc --noEmit` are clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/cheeriojs/cheerio/pull/5471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

