### PR TITLE
fix: remove every occurrence of a duplicated class in toggleClass

### DIFF
--- a/src/api/attributes.spec.ts
+++ b/src/api/attributes.spec.ts
@@ -1180,5 +1180,24 @@ describe('$(...)', () => {
         ).toStrictEqual(testAgainst);
       }
     });
+
+    it('(class) : should remove every occurrence of a duplicated class', () => {
+      // `removeClass` already does this, so `toggleClass` should agree with it.
+      const $p = load('<p class="a a b"></p>')('p');
+
+      $p.toggleClass('a');
+
+      expect($p.attr('class')).toBe('b');
+    });
+
+    it('(class) : should agree with removeClass on the same input', () => {
+      const toggled = load('<p class="x x y x"></p>')('p');
+      const removed = load('<p class="x x y x"></p>')('p');
+
+      toggled.toggleClass('x');
+      removed.removeClass('x');
+
+      expect(toggled.attr('class')).toBe(removed.attr('class'));
+    });
   });
 });

--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -1142,8 +1142,18 @@ export function toggleClass<T extends AnyNode, R extends ArrayLike<T>>(
       if (state >= 0 && index === -1) {
         elementClasses.push(classNames[j]);
       } else if (state <= 0 && index !== -1) {
-        // Otherwise remove but only if the item exists
-        elementClasses.splice(index, 1);
+        /*
+         * Otherwise remove, but only if the item exists. Every occurrence goes,
+         * not just the first, so a duplicated class does not survive the
+         * toggle. This matches `removeClass` and what a browser does. It is
+         * done in place rather than by re-running this iteration, because that
+         * would re-enter the branch above and add the class straight back.
+         */
+        for (let k = elementClasses.length - 1; k >= 0; k--) {
+          if (elementClasses[k] === classNames[j]) {
+            elementClasses.splice(k, 1);
+          }
+        }
       }
     }
 


### PR DESCRIPTION
### What

`toggleClass` removes a class with `indexOf` plus a single `splice`, so a class listed more than once survives the toggle:

```js
cheerio.load('<p class="a a b"></p>')('p').toggleClass('a').attr('class');
//=> 'a b'   expected 'b'
```

`removeClass` already handles this, and says so in a comment:

```js
/*
 * We have to do another pass to ensure that there are not duplicate
 * classes listed
 */
j--;
```

So on the same input the two functions disagree:

| input | `removeClass('x')` | `toggleClass('x')` |
| --- | --- | --- |
| `class="x x y x"` | `y` | `x y x` |

Chrome's `classList.toggle` gives `b` for the first example, matching `removeClass`.

### The change

The removal now clears every occurrence.

I first tried mirroring `removeClass`'s `j--` re-pass, and it **broke two existing tests** (`should toggle multiple classes from the element` and `should toggle classes returned from the function`). That trick works there because `removeClass` only ever removes, whereas here re-running the iteration re-enters the add branch above and puts the class straight back. So this uses an in-place loop instead, which leaves the toggle decision untouched.

### Verification

Full suite is 795 passing. I confirmed both new tests fail with only `src/api/attributes.ts` reverted, and that the existing `toggleClass` tests pass either way. `biome check`, `eslint` and `tsc --noEmit` are clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/cheeriojs/cheerio/pull/5472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

