### PR TITLE
fix(typedoc): configure ESM module resolution

### DIFF
--- a/tsconfig.typedoc.json
+++ b/tsconfig.typedoc.json
@@ -1,4 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler"
+  },
   "exclude": ["*.config.ts", "*.spec.ts", "scripts/*", "website/*"]
 }


### PR DESCRIPTION
## Summary

- Configure TypeDoc’s TypeScript settings for ESM module resolution.
- Use bundler-aware module resolution for documentation builds.

## Testing

- Not run (configuration-only change).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/cheeriojs/cheerio/pull/5473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

