### PR TITLE
build(deps): update parse5 packages together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     versioning-strategy: increase
     cooldown:
       default-days: 7
+    groups:
+      parse5:
+        patterns:
+          - 'parse5'
+          - 'parse5-*'
   - package-ecosystem: npm
     directory: '/website'
     schedule:

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
         "domutils": "^4.0.2",
         "encoding-sniffer": "^0.2.1",
         "htmlparser2": "^12.0.0",
-        "parse5": "^7.3.0",
-        "parse5-htmlparser2-tree-adapter": "^7.1.0",
-        "parse5-parser-stream": "^7.1.2",
+        "parse5": "^8.0.1",
+        "parse5-htmlparser2-tree-adapter": "^8.0.1",
+        "parse5-parser-stream": "^8.0.0",
         "undici": "^8.10.0",
         "whatwg-mimetype": "^5.0.0"
       },
@@ -1641,19 +1641,6 @@
         "@types/tough-cookie": "*",
         "parse5": "^8.0.0",
         "undici-types": "^8.9.0"
-      }
-    },
-    "node_modules/@types/jsdom/node_modules/parse5": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
-      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^8.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/@types/json-schema": {
@@ -4092,19 +4079,6 @@
         }
       }
     },
-    "node_modules/jsdom/node_modules/parse5": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
-      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^8.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
     "node_modules/jsdom/node_modules/whatwg-url": {
       "version": "17.1.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
@@ -5329,67 +5303,40 @@
       "license": "MIT"
     },
     "node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
       "license": "MIT",
       "dependencies": {
-        "entities": "^6.0.0"
+        "entities": "^8.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
-      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-8.0.1.tgz",
+      "integrity": "sha512-aqkH+xQxX+QGZtP5GIMmqqp16Y0v9muEf2VVeypv35kFsD5bqP1UeBanSshdfjMY+RTh2vN4mmK6nEOVRMEvHg==",
       "license": "MIT",
       "dependencies": {
-        "domhandler": "^5.0.3",
-        "parse5": "^7.0.0"
+        "domhandler": "^6.0.1",
+        "parse5": "^8.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
     "node_modules/parse5-parser-stream": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
-      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-8.0.0.tgz",
+      "integrity": "sha512-b+std4I3eeGJcO5OlBYdwBsw1FNaF+qEzzq2XGfRm1dZdqUBUirsVscPCW9X4oJU0q/0C8NqMpgokLywkgxT0A==",
       "license": "MIT",
       "dependencies": {
-        "parse5": "^7.0.0"
+        "parse5": "^8.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/path-exists": {

--- a/package.json
+++ b/package.json
@@ -116,9 +116,9 @@
     "domutils": "^4.0.2",
     "encoding-sniffer": "^0.2.1",
     "htmlparser2": "^12.0.0",
-    "parse5": "^7.3.0",
-    "parse5-htmlparser2-tree-adapter": "^7.1.0",
-    "parse5-parser-stream": "^7.1.2",
+    "parse5": "^8.0.1",
+    "parse5-htmlparser2-tree-adapter": "^8.0.1",
+    "parse5-parser-stream": "^8.0.0",
     "undici": "^8.10.0",
     "whatwg-mimetype": "^5.0.0"
   },


### PR DESCRIPTION
Updates the parse5 family together:

- `parse5` 7.3.0 -> 8.0.1
- `parse5-htmlparser2-tree-adapter` 7.1.0 -> 8.0.1
- `parse5-parser-stream` 7.1.2 -> 8.0.0

Adds a Dependabot group for `parse5` and `parse5-*` so future updates stay compatible. It also explicitly excludes generated `dist/` declarations from the source typecheck, since parse5 8 is ESM-only.

Validation:

- `npm run build`
- `npm run test:vi` (799 tests)
- `npm run lint`
- website `npm run build`
- website `npm run check`
- built CommonJS entry loads with `require()`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/cheeriojs/cheerio/pull/5474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

