### PR TITLE
fix(attributes): return option values, not text, from val() on a multiple select

### DIFF
--- a/src/api/attributes.spec.ts
+++ b/src/api/attributes.spec.ts
@@ -712,6 +712,18 @@ describe('$(...)', () => {
       const val = $('select#multi-valueless').val();
       expect(val).toStrictEqual(['2', '3']);
     });
+    it('(): on multiple select should prefer value attributes over text content', () => {
+      const $multi = load(
+        '<select multiple><option value="a" selected>Alpha</option><option value="b" selected>Beta</option><option value="c">Gamma</option></select>',
+      )('select');
+      expect($multi.val()).toStrictEqual(['a', 'b']);
+    });
+    it('(): on multiple select should fall back to text for valueless options', () => {
+      const $multi = load(
+        '<select multiple><option value="a" selected>Alpha</option><option selected>Beta</option></select>',
+      )('select');
+      expect($multi.val()).toStrictEqual(['a', 'Beta']);
+    });
     it('(): with no selector matches should return nothing', () => {
       const val = $('.nasty').val();
       expect(val).toBeUndefined();

--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -812,7 +812,9 @@ export function val<T extends AnyNode>(
       const option = this.find('option:selected');
 
       return this.attr('multiple')
-        ? option.toArray().map((el) => text(el.children))
+        ? option
+            .toArray()
+            .map((el) => getAttr(el, 'value', this.options.xmlMode) ?? '')
         : option.attr('value');
     }
     case 'button':


### PR DESCRIPTION
The multiple-select getter branch of `val()` maps selected options through `text(el.children)`, but jQuery's `.val()` contract is to return each selected option's value attribute, falling back to text only when the attribute is absent. Executed comparison against real jQuery 4 in jsdom:

```
<select multiple><option value="a" selected>Alpha</option><option value="b" selected>Beta</option></select>
cheerio: ["Alpha", "Beta"]    jQuery: ["a", "b"]

mixed (one option valueless):
cheerio: ["Text1", "Text2"]   jQuery: ["v1", "Text2"]
```

The divergence also propagates into `serializeArray()`: cheerio produced `[{"name":"s","value":"A"}]` where jQuery gives `[{"name":"s","value":"a"}]`. The existing fixtures masked this because every fixture option has `value` equal to its text.

The fix maps selected options through the existing `getAttr(el, 'value', this.options.xmlMode) ?? ''`, which already implements the text fallback for valueless options, so the single-select and multiple-select paths now agree.

Tests: two added, covering value attributes and the mixed valueless case, with expectations taken from executed jQuery output. With only the source reverted they fail with `expected [ 'Alpha', 'Beta' ] to strictly equal [ 'a', 'b' ]`; restored, the attributes suite passes 129/129. `npx biome check` clean on both files.

Related open PRs #5325 (val setter escaping) and #5312 (single-select value fallback) touch adjacent code but not this branch.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/cheeriojs/cheerio/pull/5484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

