### PR TITLE
fix(manipulation): clone Cheerio content in the html() setter for all targets but the last

### DIFF
--- a/src/api/manipulation.spec.ts
+++ b/src/api/manipulation.spec.ts
@@ -1760,6 +1760,19 @@ describe('$(...)', () => {
       expect(tested).toBe(3);
     });
 
+    it('(Cheerio object) : should copy the content for each element in selection', () => {
+      const $fruits = $('li');
+      const $durian = $('<div class="durian">Durian</div>');
+      $fruits.html($durian);
+      expect($('.durian')).toHaveLength(3);
+      $fruits.each(function () {
+        expect($(this).children()).toHaveLength(1);
+        expect($(this).html()).toBe('<div class="durian">Durian</div>');
+      });
+      // The last target receives the original node
+      expect($fruits.last().children()[0]).toBe($durian[0]);
+    });
+
     it('(html) : should skip text nodes', () => {
       const $text = load(mixedText);
       const $body = $text($text('body')[0].children);

--- a/src/api/manipulation.ts
+++ b/src/api/manipulation.ts
@@ -992,14 +992,20 @@ export function html<T extends AnyNode>(
     return this._render(el.children);
   }
 
-  return domEach(this, (el) => {
+  const lastIdx = this.length - 1;
+
+  return domEach(this, (el, i) => {
     if (!hasChildren(el)) return;
     for (const child of el.children) {
       child.next = child.prev = child.parent = null;
     }
 
+    /*
+     * Nodes passed in a Cheerio instance are moved, so clone them for all
+     * targets but the last to give each target its own copy.
+     */
     const content = isCheerio(str)
-      ? str.toArray()
+      ? this._makeDomArray(str, i < lastIdx)
       : this._parse(`${str}`, this.options, false, el).children;
 
     updateDOM(content, el);


### PR DESCRIPTION
Passing a Cheerio object to the `html()` setter on a multi-element selection moves the content into each target in turn, so every target but the last ends up empty. The string path re-parses per element and is unaffected. Executed comparison against real jQuery 4 in jsdom:

```js
$('div').html($('<span>x</span>'));  // two divs
// cheerio: ["", "<span>x</span>"]
// jQuery:  ["<span>x</span>", "<span>x</span>"]
```

jQuery clones the content for every target but the last, and this file's own `_insert` (append/prepend), `before`/`after` and `_wrap` helpers already follow exactly that convention through `_makeDomArray`'s clone flag. The `html()` setter now does the same: `this._makeDomArray(str, i < lastIdx)`.

Test added asserting three targets all receive the content and that the last target keeps the original node (preserving the existing move-the-original semantics for the final target, as elsewhere in the file). With only the source reverted it fails with `expected LoadedCheerio{ …(5) } to have a length of 3 but got 1`; restored, the manipulation suite passes 198/198. `npx biome check` clean on both files.

Related: open PR #5431 fixes the identical bug class in `replaceWith` only; this branch does not touch that code.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/cheeriojs/cheerio/pull/5485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

