### PR TITLE
fix(forms): exclude controls inside a disabled fieldset from serialization

### DIFF
--- a/src/api/forms.spec.ts
+++ b/src/api/forms.spec.ts
@@ -39,6 +39,34 @@ describe('$(...)', () => {
       expect($('form#disabled').serializeArray()).toStrictEqual([]);
     });
 
+    it('() : should not get form controls inside a disabled fieldset', () => {
+      const $form = cheerio.load(
+        '<form><fieldset disabled><input name="a" value="1"></fieldset><input name="b" value="2"></form>',
+      )('form');
+      expect($form.serializeArray()).toStrictEqual([{ name: 'b', value: '2' }]);
+    });
+
+    it("() : should get form controls inside a disabled fieldset's first legend", () => {
+      const $form = cheerio.load(
+        '<form><fieldset disabled><legend><input name="l" value="1"></legend><input name="a" value="2"></fieldset></form>',
+      )('form');
+      expect($form.serializeArray()).toStrictEqual([{ name: 'l', value: '1' }]);
+    });
+
+    it('() : should not get form controls inside later legends of a disabled fieldset', () => {
+      const $form = cheerio.load(
+        '<form><fieldset disabled><legend></legend><legend><input name="l2" value="1"></legend></fieldset></form>',
+      )('form');
+      expect($form.serializeArray()).toStrictEqual([]);
+    });
+
+    it('() : should not get form controls inside a fieldset nested in a disabled fieldset', () => {
+      const $form = cheerio.load(
+        '<form><fieldset disabled><fieldset><legend><input name="n" value="1"></legend></fieldset></fieldset></form>',
+      )('form');
+      expect($form.serializeArray()).toStrictEqual([]);
+    });
+
     it('() : should not get form controls with the wrong type', () => {
       expect($('form#submit').serializeArray()).toStrictEqual([
         {

--- a/src/api/forms.ts
+++ b/src/api/forms.ts
@@ -10,6 +10,38 @@ const r20 = /%20/g;
 const rCRLF = /\r?\n/g;
 
 /**
+ * Checks whether an element is disabled through an ancestor
+ * `<fieldset disabled>`. Browsers don't submit form controls inside a disabled
+ * fieldset, unless the control is placed inside the fieldset's first `<legend>`
+ * child.
+ *
+ * @private
+ * @param elem - Element to check.
+ * @returns Whether the element is disabled via a fieldset.
+ */
+function isDisabledViaFieldset(elem: AnyNode): boolean {
+  for (
+    let child: AnyNode = elem, { parent } = elem;
+    parent;
+    child = parent, { parent } = parent
+  ) {
+    if (
+      isTag(parent) &&
+      parent.name === 'fieldset' &&
+      Object.hasOwn(parent.attribs, 'disabled')
+    ) {
+      const legend = parent.children.find(
+        (sibling) => isTag(sibling) && sibling.name === 'legend',
+      );
+
+      if (child !== legend) return true;
+    }
+  }
+
+  return false;
+}
+
+/**
  * Encode a set of form elements as a string for submission.
  *
  * @category Forms
@@ -84,6 +116,8 @@ export function serializeArray<T extends AnyNode>(
       const $elem = this._make(elem);
       const name = $elem.attr('name');
       if (!name) return [];
+      // Skip controls that browsers disable through a `<fieldset disabled>`
+      if (isDisabledViaFieldset(elem)) return [];
       // If there is no value set (e.g. `undefined`, `null`), then default value to empty
       const value = $elem.val() ?? '';
 


### PR DESCRIPTION
Browsers never submit a control that is disabled via an ancestor `<fieldset disabled>`, with the HTML spec's exemption for controls inside that fieldset's first `<legend>` element child. jQuery matches this because it filters on the `disabled` DOM property, which reflects ancestor fieldset state. Cheerio's `serializeArray()` included such controls. Executed comparison against real jQuery 4 in jsdom:

```
fieldset-disabled input   | cheerio: "a=1&b=2" | jQuery: "b=2"
first legend exception    | cheerio: "l=1&a=2" | jQuery: "l=1"
second legend not exempt  | cheerio: "l2=1"    | jQuery: ""
nested disabled fieldset  | cheerio: "n=1"     | jQuery: ""
```

The fix adds an `isDisabledViaFieldset()` helper that walks ancestors and treats a control as disabled when any ancestor is `fieldset[disabled]`, unless the walk reached that fieldset through its first legend element child. It is checked inside the existing map callback, so the diff is a pure insertion.

The deeper cause is that css-select's `:enabled` does not implement fieldset semantics, but the serialization contract is cheerio's own and jQuery likewise handles this at the serialize layer, so the fix is local to `forms.ts`.

Tests: four added covering the base case, the first-legend exemption, a second legend, and nesting, with expectations taken from executed jQuery output. With only the source reverted all four fail (e.g. `expected [ { name: 'a', value: '1' }, …(1) ] to strictly equal [ { name: 'b', value: '2' } ]`); restored, the forms suite passes 20/20. `npx biome check` clean on both files.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/cheeriojs/cheerio/pull/5486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

